### PR TITLE
[feat] docker file to run database in local test

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  causw_database:
+    image: postgres:9.3
+    container_name: causw_db
+    ports:
+      - '5432:5432'
+    environment:
+      POSTGRES_USER: 'causwlocaluser'
+      POSTGRES_PASSWORD: 'causwlocalpw'
+      POSTGRES_DB: 'causw'


### PR DESCRIPTION
## Related issue
- None

## Description
로컬 테스트 진행 시 사용할 수 있는 Docker-compose 파일입니다. 앱 또한 docker로 구동하는 것을 고려하여 docker-compose로 구성했습니다.
이 PR이 머지되는 경우, Pull 받으신 후 터미널에서 다음 명령어를 이용할 수 있습니다.
```
docker-compose -f docker-compose.yaml up -d   // 실행
docker-compose -f docker-compose.yaml down   // 종료 및 이미지 삭제
```

그 외에도 `docker ps` 와 같은 명령어들이 있으니 검색해보면서 공부해보시면 좋습니다.

우선은 `application.yaml` 파일에서 지정한, 로컬용 id / pw를 입력해 두었는데, 추후 만약 서버에서 이 파일로 db를 구동하게 되면 환경변수로 입력하도록 할 예정입니다. (그럴 경우 이 파일도 바뀌어야 합니다)



## Changes detail

- Add docker-compose file

### Checklist

- [ ] Test case
- [x] End of work
