### PR TITLE
feat: impl basic exception model

### DIFF
--- a/src/main/java/net/causw/application/dto/ExceptionDto.java
+++ b/src/main/java/net/causw/application/dto/ExceptionDto.java
@@ -1,0 +1,19 @@
+package net.causw.application.dto;
+
+import lombok.Getter;
+import net.causw.domain.exceptions.ErrorCode;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ExceptionDto {
+    private final Integer errorCode;
+    private final String message;
+    private final LocalDateTime timeStamp;
+
+    public ExceptionDto(ErrorCode errorCode, String message) {
+        this.errorCode = errorCode.getCode();
+        this.message = message;
+        this.timeStamp = LocalDateTime.now();
+    }
+}

--- a/src/main/java/net/causw/domain/exceptions/BadRequestException.java
+++ b/src/main/java/net/causw/domain/exceptions/BadRequestException.java
@@ -1,0 +1,7 @@
+package net.causw.domain.exceptions;
+
+public class BadRequestException extends BaseRuntimeExeption {
+    public BadRequestException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/net/causw/domain/exceptions/BaseRuntimeExeption.java
+++ b/src/main/java/net/causw/domain/exceptions/BaseRuntimeExeption.java
@@ -1,0 +1,14 @@
+package net.causw.domain.exceptions;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BaseRuntimeExeption extends RuntimeException {
+    private final ErrorCode errorCode;
+    private final String message;
+
+    public BaseRuntimeExeption(ErrorCode errorCode, String message) {
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+}

--- a/src/main/java/net/causw/domain/exceptions/ErrorCode.java
+++ b/src/main/java/net/causw/domain/exceptions/ErrorCode.java
@@ -1,0 +1,23 @@
+package net.causw.domain.exceptions;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+    ROW_DOES_NOT_EXIST(4000),
+    ROW_ALREADY_EXIST(4001),
+    NULL_PARAMETER(4002),
+    INVALID_PARAMETER(4003),
+
+    INVALID_SIGNIN(4100),
+    EXPIRED_JWT(4101),
+    API_NOT_ACCESSIBLE(4102),
+
+    INTERNAL_SERVER(5000);
+
+    private int code;
+
+    ErrorCode(int code) {
+        this.code = code;
+    }
+}

--- a/src/main/java/net/causw/domain/exceptions/InternalServerException.java
+++ b/src/main/java/net/causw/domain/exceptions/InternalServerException.java
@@ -1,0 +1,7 @@
+package net.causw.domain.exceptions;
+
+public class InternalServerException extends BaseRuntimeExeption {
+    public InternalServerException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/net/causw/domain/exceptions/UnauthorizedException.java
+++ b/src/main/java/net/causw/domain/exceptions/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package net.causw.domain.exceptions;
+
+public class UnauthorizedException extends BaseRuntimeExeption {
+    public UnauthorizedException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/net/causw/infra/port/UserPortImpl.java
+++ b/src/main/java/net/causw/infra/port/UserPortImpl.java
@@ -1,5 +1,7 @@
 package net.causw.infra.port;
 
+import net.causw.domain.exceptions.BadRequestException;
+import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.model.UserDomainModel;
 import net.causw.domain.spi.UserPort;
 import net.causw.infra.UserRepository;
@@ -16,6 +18,11 @@ public class UserPortImpl implements UserPort {
     @Override
     public UserDomainModel findById(String id) {
         // TODO: Throw specific exception
-        return UserDomainModel.of(userRepository.findById(id).orElseThrow());
+        return UserDomainModel.of(this.userRepository.findById(id).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        "Invalid user id"
+                )
+        ));
     }
 }

--- a/src/main/java/net/causw/web/GlobalExceptionHandler.java
+++ b/src/main/java/net/causw/web/GlobalExceptionHandler.java
@@ -1,0 +1,47 @@
+package net.causw.web;
+
+import lombok.extern.slf4j.Slf4j;
+import net.causw.application.dto.ExceptionDto;
+import net.causw.domain.exceptions.BadRequestException;
+import net.causw.domain.exceptions.ErrorCode;
+import net.causw.domain.exceptions.UnauthorizedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.nio.file.AccessDeniedException;
+
+@Component
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(value = {BadRequestException.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ExceptionDto handleBadRequestException(BadRequestException exception) {
+        GlobalExceptionHandler.log.error("error message", exception);
+        return new ExceptionDto(exception.getErrorCode(), exception.getMessage());
+    }
+
+    @ExceptionHandler(value = {UnauthorizedException.class})
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ExceptionDto handleUnauthorizedException(UnauthorizedException exception) {
+        GlobalExceptionHandler.log.error("error message", exception);
+        return new ExceptionDto(exception.getErrorCode(), exception.getMessage());
+    }
+
+    @ExceptionHandler(value = {AccessDeniedException.class})
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ExceptionDto handleAccessDeniedException(AccessDeniedException exception) {
+        GlobalExceptionHandler.log.error("error message", exception);
+        return new ExceptionDto(ErrorCode.API_NOT_ACCESSIBLE, exception.getMessage());
+    }
+
+    @ExceptionHandler(value = {Exception.class})
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ExceptionDto unknownException(Exception exception) {
+        GlobalExceptionHandler.log.error("error message", exception);
+        return new ExceptionDto(ErrorCode.INTERNAL_SERVER, "Internal server error");
+    }
+}


### PR DESCRIPTION
## Related issue
- #20 

## Description
Back-end 앱 전체에서 사용할 기본 Exception Model입니다.

- 앱 내에서 발생한 모든 에러는 `web/GlobalExceptionHandler` 에서 처리합니다. 우선은 `400 Bad Request` 발생 시 이를 처리하는 `handleBadRequestException` 메소드를 만들었으며, 정의한 에러 외의 모든 에러를 처리하는 `unknownException` 메소드를 만들어 두었습니다. 이는 `500 Internal Server Error` 타입으로 클라이언트에게 전달됩니다.
- 에러 모델은 `domain/exceptions/` 패키지 내부에 정의했습니다. `BaseRuntimeException` abstract class에서 기본적인 틀을 다루며, 필드로는 간단하게 `errorCode` 와 `message` 를 갖습니다.
- 우선은 하위 클래스로 `BadRequestException` 과 `InternalServerException` 을 두었으며, 이용 방법은 간단하게, 로직 구현 할 때 예외 처리 시 부합하는 에러 클래스 객체를 생성해서 `throw` 하면 됩니다.
   => 예제로 `UserPortImpl` 에서 `findById` 진행 시 유저가 없는 경우, `BadRequestException` 을 던져줍니다.

- ErrorCode의 경우에는 노션에 정리해두겠습니다. 추후 구현하시면서 새로운 에러 타입이 필요한 경우, 혹은 에러 코드가 필요한 경우 만들어서 쓰시고 노션에만 잘 정리해주세요.

### Checklist

- [ ] Test case
- [x] End of work
