### PR TITLE
feat: comment entity 구현, 1:N entity mappedBy 수정, findById, create 구현

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/Board.java
+++ b/src/main/java/net/causw/adapter/persistence/Board.java
@@ -7,7 +7,6 @@ import org.hibernate.annotations.ColumnDefault;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import java.util.Set;
@@ -36,8 +35,7 @@ public class Board extends BaseEntity {
     @ColumnDefault("false")
     private Boolean isDeleted;
 
-    @OneToMany(cascade = CascadeType.ALL)
-    @JoinColumn(name = "post_id")
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
     private Set<Post> postSet;
 
     private Board(

--- a/src/main/java/net/causw/adapter/persistence/Comment.java
+++ b/src/main/java/net/causw/adapter/persistence/Comment.java
@@ -2,6 +2,7 @@ package net.causw.adapter.persistence;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import net.causw.application.dto.CommentFullDto;
 import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.CascadeType;
@@ -101,6 +102,28 @@ public class Comment extends BaseEntity {
                 writer,
                 post,
                 parentComment
+        );
+    }
+
+    public static Comment from(CommentFullDto commentFullDto) {
+        return new Comment(
+                commentFullDto.getId(),
+                commentFullDto.getContent(),
+                commentFullDto.getIsDeleted(),
+                User.from(commentFullDto.getWriter()),
+                Post.from(commentFullDto.getPost()),
+                null
+        );
+    }
+
+    public static Comment from(CommentFullDto commentFullDto, CommentFullDto parentCommentFullDto) {
+        return new Comment(
+                commentFullDto.getId(),
+                commentFullDto.getContent(),
+                commentFullDto.getIsDeleted(),
+                User.from(commentFullDto.getWriter()),
+                Post.from(commentFullDto.getPost()),
+                Comment.from(parentCommentFullDto)
         );
     }
 }

--- a/src/main/java/net/causw/adapter/persistence/Comment.java
+++ b/src/main/java/net/causw/adapter/persistence/Comment.java
@@ -33,7 +33,7 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
-    @ManyToOne()
+    @ManyToOne
     @JoinColumn(name = "parent_comment_id", nullable = true)
     private Comment parentComment;
 

--- a/src/main/java/net/causw/adapter/persistence/Comment.java
+++ b/src/main/java/net/causw/adapter/persistence/Comment.java
@@ -1,0 +1,60 @@
+package net.causw.adapter.persistence;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import java.util.List;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@Table(name = "TB_COMMENT")
+public class Comment extends BaseEntity {
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "is_deleted")
+    @ColumnDefault("false")
+    private Boolean isDeleted;
+
+    @ManyToOne(targetEntity = User.class)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User writer;
+
+    @ManyToOne(targetEntity = Post.class)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne()
+    @JoinColumn(name = "parent_comment_id", nullable = true)
+    private Comment parentComment;
+
+    @OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL)
+    private List<Comment> childCommentList;
+
+    private Comment(
+            String content,
+            Boolean isDeleted
+    ) {
+        this.content = content;
+        this.isDeleted = isDeleted;
+    }
+
+    public static Comment of(
+            String content,
+            Boolean isDeleted
+    ) {
+        return new Comment(
+                content,
+                isDeleted
+        );
+    }
+}

--- a/src/main/java/net/causw/adapter/persistence/Comment.java
+++ b/src/main/java/net/causw/adapter/persistence/Comment.java
@@ -42,19 +42,65 @@ public class Comment extends BaseEntity {
 
     private Comment(
             String content,
-            Boolean isDeleted
+            Boolean isDeleted,
+            User writer,
+            Post post,
+            Comment parentComment
     ) {
         this.content = content;
         this.isDeleted = isDeleted;
+        this.writer = writer;
+        this.post = post;
+        this.parentComment = parentComment;
+    }
+
+    private Comment(
+            String id,
+            String content,
+            Boolean isDeleted,
+            User writer,
+            Post post,
+            Comment parentComment
+    ) {
+        super(id);
+        this.content = content;
+        this.isDeleted = isDeleted;
+        this.writer = writer;
+        this.post = post;
+        this.parentComment = parentComment;
     }
 
     public static Comment of(
             String content,
-            Boolean isDeleted
+            Boolean isDeleted,
+            User writer,
+            Post post,
+            Comment parentComment
     ) {
         return new Comment(
                 content,
-                isDeleted
+                isDeleted,
+                writer,
+                post,
+                parentComment
+        );
+    }
+
+    public static Comment of(
+            String id,
+            String content,
+            Boolean isDeleted,
+            User writer,
+            Post post,
+            Comment parentComment
+    ) {
+        return new Comment(
+                id,
+                content,
+                isDeleted,
+                writer,
+                post,
+                parentComment
         );
     }
 }

--- a/src/main/java/net/causw/adapter/persistence/CommentRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/CommentRepository.java
@@ -1,0 +1,8 @@
+package net.causw.adapter.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, String> {
+}

--- a/src/main/java/net/causw/adapter/persistence/Post.java
+++ b/src/main/java/net/causw/adapter/persistence/Post.java
@@ -4,11 +4,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import java.util.List;
 
 @Getter
 @Entity
@@ -28,6 +31,9 @@ public class Post extends BaseEntity {
     @ManyToOne(targetEntity = Board.class)
     @JoinColumn(name = "board_id", nullable = false)
     private Board board;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private List<Comment> commentList;
 
     private Post(String title, String content, Boolean isDeleted) {
         this.title = title;

--- a/src/main/java/net/causw/adapter/persistence/Post.java
+++ b/src/main/java/net/causw/adapter/persistence/Post.java
@@ -2,6 +2,7 @@ package net.causw.adapter.persistence;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import net.causw.application.dto.PostDetailDto;
 import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.CascadeType;
@@ -41,7 +42,23 @@ public class Post extends BaseEntity {
         this.isDeleted = isDeleted;
     }
 
+    private Post(String id, String title, String content, Boolean isDeleted) {
+        super(id);
+        this.title = title;
+        this.content = content;
+        this.isDeleted = isDeleted;
+    }
+
     public static Post of(String title, String content, Boolean isDeleted) {
         return new Post(title, content, isDeleted);
+    }
+
+    public static Post from(PostDetailDto postDetailDto) {
+        return new Post(
+                postDetailDto.getId(),
+                postDetailDto.getTitle(),
+                postDetailDto.getContent(),
+                postDetailDto.getIsDeleted()
+        );
     }
 }

--- a/src/main/java/net/causw/adapter/persistence/User.java
+++ b/src/main/java/net/causw/adapter/persistence/User.java
@@ -3,6 +3,7 @@ package net.causw.adapter.persistence;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import net.causw.application.dto.UserFullDto;
 import net.causw.domain.model.Role;
 import net.causw.domain.model.UserState;
 
@@ -10,10 +11,10 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.Table;
-import javax.persistence.OneToOne;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
 import java.util.List;
 
 @Getter
@@ -137,6 +138,19 @@ public class User extends BaseEntity {
                 admissionYear,
                 role,
                 state
+        );
+    }
+
+    public static User from(UserFullDto userFullDto) {
+        return new User(
+                userFullDto.getId(),
+                userFullDto.getEmail(),
+                userFullDto.getName(),
+                userFullDto.getPassword(),
+                userFullDto.getStudentId(),
+                userFullDto.getAdmissionYear(),
+                userFullDto.getRole(),
+                userFullDto.getState()
         );
     }
 }

--- a/src/main/java/net/causw/adapter/persistence/port/CommentPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/CommentPortImpl.java
@@ -3,9 +3,9 @@ package net.causw.adapter.persistence.port;
 import net.causw.adapter.persistence.CommentRepository;
 import net.causw.application.dto.CommentDetailDto;
 import net.causw.application.spi.CommentPort;
-import net.causw.domain.exceptions.BadRequestException;
-import net.causw.domain.exceptions.ErrorCode;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
 
 @Component
 public class CommentPortImpl implements CommentPort {
@@ -16,12 +16,7 @@ public class CommentPortImpl implements CommentPort {
     }
 
     @Override
-    public CommentDetailDto findById(String id) {
-        return CommentDetailDto.from(this.commentRepository.findById(id).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        "Invalid comment id"
-                )
-        ));
+    public Optional<CommentDetailDto> findById(String id) {
+        return this.commentRepository.findById(id).map(CommentDetailDto::from);
     }
 }

--- a/src/main/java/net/causw/adapter/persistence/port/CommentPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/CommentPortImpl.java
@@ -1,0 +1,27 @@
+package net.causw.adapter.persistence.port;
+
+import net.causw.adapter.persistence.CommentRepository;
+import net.causw.application.dto.CommentDetailDto;
+import net.causw.application.spi.CommentPort;
+import net.causw.domain.exceptions.BadRequestException;
+import net.causw.domain.exceptions.ErrorCode;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CommentPortImpl implements CommentPort {
+    private final CommentRepository commentRepository;
+
+    public CommentPortImpl(CommentRepository commentRepository) {
+        this.commentRepository = commentRepository;
+    }
+
+    @Override
+    public CommentDetailDto findById(String id) {
+        return CommentDetailDto.from(this.commentRepository.findById(id).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        "Invalid comment id"
+                )
+        ));
+    }
+}

--- a/src/main/java/net/causw/adapter/persistence/port/CommentPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/CommentPortImpl.java
@@ -1,7 +1,14 @@
 package net.causw.adapter.persistence.port;
 
+import net.causw.adapter.persistence.Comment;
 import net.causw.adapter.persistence.CommentRepository;
-import net.causw.application.dto.CommentDetailDto;
+import net.causw.adapter.persistence.Post;
+import net.causw.adapter.persistence.User;
+import net.causw.application.dto.CommentCreateRequestDto;
+import net.causw.application.dto.CommentFullDto;
+import net.causw.application.dto.CommentResponseDto;
+import net.causw.application.dto.PostDetailDto;
+import net.causw.application.dto.UserFullDto;
 import net.causw.application.spi.CommentPort;
 import org.springframework.stereotype.Component;
 
@@ -16,7 +23,42 @@ public class CommentPortImpl implements CommentPort {
     }
 
     @Override
-    public Optional<CommentDetailDto> findById(String id) {
-        return this.commentRepository.findById(id).map(CommentDetailDto::from);
+    public Optional<CommentFullDto> findById(String id) {
+        return this.commentRepository.findById(id).map(CommentFullDto::from);
+    }
+
+    @Override
+    public CommentResponseDto create(
+            CommentCreateRequestDto commentCreateDto,
+            UserFullDto writer,
+            PostDetailDto post
+    ) {
+        return CommentResponseDto.from(
+                this.commentRepository.save(Comment.of(
+                        commentCreateDto.getContent(),
+                        false,
+                        User.from(writer),
+                        Post.from(post),
+                        null
+                ))
+        );
+    }
+
+    @Override
+    public CommentResponseDto create(
+            CommentCreateRequestDto commentCreateDto,
+            UserFullDto writer,
+            PostDetailDto post,
+            CommentFullDto parentCommentDto
+    ) {
+        return CommentResponseDto.from(
+                this.commentRepository.save(Comment.of(
+                    commentCreateDto.getContent(),
+                    false,
+                    User.from(writer),
+                    Post.from(post),
+                    Comment.from(parentCommentDto)
+                ))
+        );
     }
 }

--- a/src/main/java/net/causw/adapter/web/CommentController.java
+++ b/src/main/java/net/causw/adapter/web/CommentController.java
@@ -1,0 +1,26 @@
+package net.causw.adapter.web;
+
+import net.causw.application.CommentService;
+import net.causw.application.dto.CommentDetailDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/comments")
+public class CommentController {
+    private final CommentService commentService;
+
+    public CommentController(CommentService commentService) {
+        this.commentService = commentService;
+    }
+
+    @GetMapping(value = "/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    public CommentDetailDto findById(@PathVariable String id) {
+        return this.commentService.findById(id);
+    }
+}

--- a/src/main/java/net/causw/adapter/web/CommentController.java
+++ b/src/main/java/net/causw/adapter/web/CommentController.java
@@ -1,10 +1,14 @@
 package net.causw.adapter.web;
 
 import net.causw.application.CommentService;
-import net.causw.application.dto.CommentDetailDto;
+import net.causw.application.dto.CommentCreateRequestDto;
+import net.causw.application.dto.CommentFullDto;
+import net.causw.application.dto.CommentResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,7 +24,13 @@ public class CommentController {
 
     @GetMapping(value = "/{id}")
     @ResponseStatus(HttpStatus.OK)
-    public CommentDetailDto findById(@PathVariable String id) {
+    public CommentFullDto findById(@PathVariable String id) {
         return this.commentService.findById(id);
+    }
+
+    @PostMapping(value = "/")
+    @ResponseStatus(HttpStatus.OK)
+    public CommentResponseDto create(@RequestBody CommentCreateRequestDto commentCreateDto) {
+        return this.commentService.create(commentCreateDto);
     }
 }

--- a/src/main/java/net/causw/application/CommentService.java
+++ b/src/main/java/net/causw/application/CommentService.java
@@ -2,6 +2,8 @@ package net.causw.application;
 
 import net.causw.application.dto.CommentDetailDto;
 import net.causw.application.spi.CommentPort;
+import net.causw.domain.exceptions.BadRequestException;
+import net.causw.domain.exceptions.ErrorCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +17,11 @@ public class CommentService {
 
     @Transactional(readOnly = true)
     public CommentDetailDto findById(String id) {
-        return this.commentPort.findById(id);
+        return this.commentPort.findById(id).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        "Invalid comment id"
+                )
+        );
     }
 }

--- a/src/main/java/net/causw/application/CommentService.java
+++ b/src/main/java/net/causw/application/CommentService.java
@@ -1,7 +1,13 @@
 package net.causw.application;
 
-import net.causw.application.dto.CommentDetailDto;
+import net.causw.application.dto.CommentCreateRequestDto;
+import net.causw.application.dto.CommentFullDto;
+import net.causw.application.dto.CommentResponseDto;
+import net.causw.application.dto.PostDetailDto;
+import net.causw.application.dto.UserFullDto;
 import net.causw.application.spi.CommentPort;
+import net.causw.application.spi.PostPort;
+import net.causw.application.spi.UserPort;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import org.springframework.stereotype.Service;
@@ -10,18 +16,60 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class CommentService {
     private final CommentPort commentPort;
+    private final UserPort userPort;
+    private final PostPort postPort;
 
-    public CommentService(CommentPort commentPort) {
+    public CommentService(
+            CommentPort commentPort,
+            UserPort userPort,
+            PostPort postPort
+    ) {
         this.commentPort = commentPort;
+        this.userPort = userPort;
+        this.postPort = postPort;
     }
 
     @Transactional(readOnly = true)
-    public CommentDetailDto findById(String id) {
+    public CommentFullDto findById(String id) {
         return this.commentPort.findById(id).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
                         "Invalid comment id"
                 )
+        );
+    }
+
+    @Transactional
+    public CommentResponseDto create(CommentCreateRequestDto commentCreateDto) {
+        UserFullDto userDto = this.userPort.findById(commentCreateDto.getWriterId()).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        "Invalid writer id"
+                )
+        );
+
+        PostDetailDto postDto = this.postPort.findById(commentCreateDto.getPostId());
+
+        if (commentCreateDto.getParentCommentId().isEmpty()) {
+            return this.commentPort.create(
+                    commentCreateDto,
+                    userDto,
+                    postDto
+            );
+        }
+
+        CommentFullDto parentCommentDto = this.commentPort.findById(commentCreateDto.getParentCommentId()).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        "Invalid parent comment id"
+                )
+        );
+
+        return this.commentPort.create(
+                commentCreateDto,
+                userDto,
+                postDto,
+                parentCommentDto
         );
     }
 }

--- a/src/main/java/net/causw/application/CommentService.java
+++ b/src/main/java/net/causw/application/CommentService.java
@@ -1,0 +1,20 @@
+package net.causw.application;
+
+import net.causw.application.dto.CommentDetailDto;
+import net.causw.application.spi.CommentPort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CommentService {
+    private final CommentPort commentPort;
+
+    public CommentService(CommentPort commentPort) {
+        this.commentPort = commentPort;
+    }
+
+    @Transactional(readOnly = true)
+    public CommentDetailDto findById(String id) {
+        return this.commentPort.findById(id);
+    }
+}

--- a/src/main/java/net/causw/application/dto/CommentCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/CommentCreateRequestDto.java
@@ -1,0 +1,18 @@
+package net.causw.application.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentCreateRequestDto {
+    private String content;
+    private String postId; // -> post
+    private String writerId; // -> writer
+    private String parentCommentId; // -> parent comment
+}

--- a/src/main/java/net/causw/application/dto/CommentDetailDto.java
+++ b/src/main/java/net/causw/application/dto/CommentDetailDto.java
@@ -1,0 +1,43 @@
+package net.causw.application.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import net.causw.adapter.persistence.Comment;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class CommentDetailDto {
+    private String id;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private UserDetailDto writer;
+
+    private CommentDetailDto(
+            String id,
+            String content,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt,
+            UserDetailDto writer
+    ) {
+        this.id = id;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.writer = writer;
+    }
+
+    public static CommentDetailDto from(Comment comment) {
+        return new CommentDetailDto(
+                comment.getId(),
+                comment.getContent(),
+                comment.getCreatedAt(),
+                comment.getUpdatedAt(),
+                UserDetailDto.from(
+                        comment.getWriter()
+                )
+        );
+    }
+}

--- a/src/main/java/net/causw/application/dto/CommentDetailDto.java
+++ b/src/main/java/net/causw/application/dto/CommentDetailDto.java
@@ -15,6 +15,8 @@ public class CommentDetailDto {
     private String content;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private Boolean isDeleted;
+    private PostDetailDto post;
     private UserResponseDto writer;
     private List<CommentDetailDto> childCommentList;
 
@@ -23,6 +25,8 @@ public class CommentDetailDto {
             String content,
             LocalDateTime createdAt,
             LocalDateTime updatedAt,
+            Boolean isDeleted,
+            PostDetailDto post,
             UserResponseDto writer,
             List<CommentDetailDto> childCommentList
     ) {
@@ -30,6 +34,8 @@ public class CommentDetailDto {
         this.content = content;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
+        this.isDeleted = isDeleted;
+        this.post = post;
         this.writer = writer;
         this.childCommentList = childCommentList;
     }
@@ -40,6 +46,10 @@ public class CommentDetailDto {
                 comment.getContent(),
                 comment.getCreatedAt(),
                 comment.getUpdatedAt(),
+                comment.getIsDeleted(),
+                PostDetailDto.from(
+                        comment.getPost()
+                ),
                 UserResponseDto.from(
                         comment.getWriter()
                 ),

--- a/src/main/java/net/causw/application/dto/CommentDetailDto.java
+++ b/src/main/java/net/causw/application/dto/CommentDetailDto.java
@@ -5,6 +5,8 @@ import lombok.NoArgsConstructor;
 import net.causw.adapter.persistence.Comment;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor
@@ -14,19 +16,22 @@ public class CommentDetailDto {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private UserDetailDto writer;
+    private List<CommentDetailDto> childCommentList;
 
     private CommentDetailDto(
             String id,
             String content,
             LocalDateTime createdAt,
             LocalDateTime updatedAt,
-            UserDetailDto writer
+            UserDetailDto writer,
+            List<CommentDetailDto> childCommentList
     ) {
         this.id = id;
         this.content = content;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.writer = writer;
+        this.childCommentList = childCommentList;
     }
 
     public static CommentDetailDto from(Comment comment) {
@@ -37,7 +42,11 @@ public class CommentDetailDto {
                 comment.getUpdatedAt(),
                 UserDetailDto.from(
                         comment.getWriter()
-                )
+                ),
+                comment.getChildCommentList()
+                        .stream()
+                        .map(CommentDetailDto::from)
+                        .collect(Collectors.toList())
         );
     }
 }

--- a/src/main/java/net/causw/application/dto/CommentDetailDto.java
+++ b/src/main/java/net/causw/application/dto/CommentDetailDto.java
@@ -15,7 +15,7 @@ public class CommentDetailDto {
     private String content;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-    private UserDetailDto writer;
+    private UserResponseDto writer;
     private List<CommentDetailDto> childCommentList;
 
     private CommentDetailDto(
@@ -23,7 +23,7 @@ public class CommentDetailDto {
             String content,
             LocalDateTime createdAt,
             LocalDateTime updatedAt,
-            UserDetailDto writer,
+            UserResponseDto writer,
             List<CommentDetailDto> childCommentList
     ) {
         this.id = id;
@@ -40,7 +40,7 @@ public class CommentDetailDto {
                 comment.getContent(),
                 comment.getCreatedAt(),
                 comment.getUpdatedAt(),
-                UserDetailDto.from(
+                UserResponseDto.from(
                         comment.getWriter()
                 ),
                 comment.getChildCommentList()

--- a/src/main/java/net/causw/application/dto/CommentFullDto.java
+++ b/src/main/java/net/causw/application/dto/CommentFullDto.java
@@ -1,0 +1,62 @@
+package net.causw.application.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import net.causw.adapter.persistence.Comment;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+public class CommentFullDto {
+    private String id;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Boolean isDeleted;
+    private PostDetailDto post;
+    private UserFullDto writer;
+    private List<CommentFullDto> childCommentList;
+
+    private CommentFullDto(
+            String id,
+            String content,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt,
+            Boolean isDeleted,
+            PostDetailDto post,
+            UserFullDto writer,
+            List<CommentFullDto> childCommentList
+    ) {
+        this.id = id;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.isDeleted = isDeleted;
+        this.post = post;
+        this.writer = writer;
+        this.childCommentList = childCommentList;
+    }
+
+    public static CommentFullDto from(Comment comment) {
+        return new CommentFullDto(
+                comment.getId(),
+                comment.getContent(),
+                comment.getCreatedAt(),
+                comment.getUpdatedAt(),
+                comment.getIsDeleted(),
+                PostDetailDto.from(
+                        comment.getPost()
+                ),
+                UserFullDto.from(
+                        comment.getWriter()
+                ),
+                comment.getChildCommentList()
+                        .stream()
+                        .map(CommentFullDto::from)
+                        .collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/net/causw/application/dto/CommentResponseDto.java
+++ b/src/main/java/net/causw/application/dto/CommentResponseDto.java
@@ -10,25 +10,27 @@ import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor
-public class CommentDetailDto {
+public class CommentResponseDto {
     private String id;
     private String content;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private Boolean isDeleted;
     private PostDetailDto post;
-    private UserResponseDto writer;
-    private List<CommentDetailDto> childCommentList;
+    private String writerId;
+    private String writerName;
+    private List<CommentResponseDto> childCommentList;
 
-    private CommentDetailDto(
+    private CommentResponseDto(
             String id,
             String content,
             LocalDateTime createdAt,
             LocalDateTime updatedAt,
             Boolean isDeleted,
             PostDetailDto post,
-            UserResponseDto writer,
-            List<CommentDetailDto> childCommentList
+            String writerId,
+            String writerName,
+            List<CommentResponseDto> childCommentList
     ) {
         this.id = id;
         this.content = content;
@@ -36,12 +38,13 @@ public class CommentDetailDto {
         this.updatedAt = updatedAt;
         this.isDeleted = isDeleted;
         this.post = post;
-        this.writer = writer;
+        this.writerId = writerId;
+        this.writerName = writerName;
         this.childCommentList = childCommentList;
     }
 
-    public static CommentDetailDto from(Comment comment) {
-        return new CommentDetailDto(
+    public static CommentResponseDto from(Comment comment) {
+        return new CommentResponseDto(
                 comment.getId(),
                 comment.getContent(),
                 comment.getCreatedAt(),
@@ -50,12 +53,11 @@ public class CommentDetailDto {
                 PostDetailDto.from(
                         comment.getPost()
                 ),
-                UserResponseDto.from(
-                        comment.getWriter()
-                ),
+                comment.getWriter().getId(),
+                comment.getWriter().getName(),
                 comment.getChildCommentList()
                         .stream()
-                        .map(CommentDetailDto::from)
+                        .map(CommentResponseDto::from)
                         .collect(Collectors.toList())
         );
     }

--- a/src/main/java/net/causw/application/spi/CommentPort.java
+++ b/src/main/java/net/causw/application/spi/CommentPort.java
@@ -1,9 +1,26 @@
 package net.causw.application.spi;
 
-import net.causw.application.dto.CommentDetailDto;
+import net.causw.application.dto.CommentCreateRequestDto;
+import net.causw.application.dto.CommentFullDto;
+import net.causw.application.dto.CommentResponseDto;
+import net.causw.application.dto.PostDetailDto;
+import net.causw.application.dto.UserFullDto;
 
 import java.util.Optional;
 
 public interface CommentPort {
-    Optional<CommentDetailDto> findById(String id);
+    Optional<CommentFullDto> findById(String id);
+
+    CommentResponseDto create(
+            CommentCreateRequestDto commentCreateDto,
+            UserFullDto writer,
+            PostDetailDto post
+    );
+
+    CommentResponseDto create(
+            CommentCreateRequestDto commentCreateDto,
+            UserFullDto writer,
+            PostDetailDto post,
+            CommentFullDto parentComment
+    );
 }

--- a/src/main/java/net/causw/application/spi/CommentPort.java
+++ b/src/main/java/net/causw/application/spi/CommentPort.java
@@ -2,6 +2,8 @@ package net.causw.application.spi;
 
 import net.causw.application.dto.CommentDetailDto;
 
+import java.util.Optional;
+
 public interface CommentPort {
-    CommentDetailDto findById(String id);
+    Optional<CommentDetailDto> findById(String id);
 }

--- a/src/main/java/net/causw/application/spi/CommentPort.java
+++ b/src/main/java/net/causw/application/spi/CommentPort.java
@@ -1,0 +1,7 @@
+package net.causw.application.spi;
+
+import net.causw.application.dto.CommentDetailDto;
+
+public interface CommentPort {
+    CommentDetailDto findById(String id);
+}


### PR DESCRIPTION
## Description
comment entity 구현

## Changes detail
- findById api만 우선 구현
- 1:N 관계에 있어서, 테이블마다 이상한 컬럼이 생성되어 이에 대해 mappedBy로 변경

### Checklist

- [ ] Test case
- [ ] End of work
