### PR TITLE
feat: accept & reject user of circle

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/UserCircle.java
+++ b/src/main/java/net/causw/adapter/persistence/UserCircle.java
@@ -32,6 +32,18 @@ public class UserCircle extends BaseEntity {
     private User user;
 
     private UserCircle(
+            String id,
+            UserCircleStatus status,
+            Circle circle,
+            User user
+    ) {
+        super(id);
+        this.status = status;
+        this.circle = circle;
+        this.user = user;
+    }
+
+    private UserCircle(
             UserCircleStatus status,
             Circle circle,
             User user
@@ -39,6 +51,20 @@ public class UserCircle extends BaseEntity {
         this.status = status;
         this.circle = circle;
         this.user = user;
+    }
+
+    public static UserCircle of(
+            String id,
+            UserCircleStatus status,
+            Circle circle,
+            User user
+    ) {
+        return new UserCircle(
+                id,
+                status,
+                circle,
+                user
+        );
     }
 
     public static UserCircle of(

--- a/src/main/java/net/causw/adapter/persistence/port/UserCirclePortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/UserCirclePortImpl.java
@@ -41,22 +41,10 @@ public class UserCirclePortImpl implements UserCirclePort {
     }
 
     @Override
-    public Optional<UserCircleDto> accept(String userId, String circleId) {
-        return this.setStatus(
-                userId,
-                circleId,
-                UserCircleStatus.MEMBER
-        );
-    }
-
-    private Optional<UserCircleDto> setStatus(
-            String userId,
-            String circleId,
-            UserCircleStatus status
-    ) {
-        return this.userCircleRepository.findByUser_IdAndCircle_Id(userId, circleId).map(
+    public Optional<UserCircleDto> updateStatus(String applicationId, UserCircleStatus targetStatus) {
+        return this.userCircleRepository.findById(applicationId).map(
                 userCircle -> {
-                    userCircle.setStatus(status);
+                    userCircle.setStatus(targetStatus);
 
                     return UserCircleDto.from(this.userCircleRepository.save(userCircle));
                 }

--- a/src/main/java/net/causw/adapter/web/CircleController.java
+++ b/src/main/java/net/causw/adapter/web/CircleController.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -47,5 +48,17 @@ public class CircleController {
     @ResponseStatus(value = HttpStatus.OK)
     public DuplicatedCheckDto isDuplicatedName(@PathVariable String name) {
         return this.circleService.isDuplicatedName(name);
+    }
+
+    @PutMapping(value = "/applications/{applicationId}/accept")
+    @ResponseStatus(value = HttpStatus.OK)
+    public UserCircleDto acceptUser(@AuthenticationPrincipal String requestUserId, @PathVariable String applicationId) {
+        return this.circleService.acceptUser(requestUserId, applicationId);
+    }
+
+    @PutMapping(value = "/applications/{applicationId}/reject")
+    @ResponseStatus(value = HttpStatus.OK)
+    public UserCircleDto rejectUser(@AuthenticationPrincipal String requestUserId, @PathVariable String applicationId) {
+        return this.circleService.rejectUser(requestUserId, applicationId);
     }
 }

--- a/src/main/java/net/causw/application/spi/UserCirclePort.java
+++ b/src/main/java/net/causw/application/spi/UserCirclePort.java
@@ -14,5 +14,5 @@ public interface UserCirclePort {
 
     UserCircleDto create(UserFullDto userFullDto, CircleFullDto circleFullDto);
 
-    Optional<UserCircleDto> accept(String userId, String circleId);
+    Optional<UserCircleDto> updateStatus(String applicationId, UserCircleStatus targetStatus);
 }

--- a/src/main/java/net/causw/domain/exceptions/ErrorCode.java
+++ b/src/main/java/net/causw/domain/exceptions/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     INVALID_USER_DATA_REQUEST(4003),    // User signup & update validation error
     TARGET_DELETED(4004),
     INVALID_HTTP_METHOD(4005),
+    APPLY_NOT_EXIST(4006),
 
     /**
      * 401 Unauthorized

--- a/src/main/java/net/causw/domain/model/CircleDomainModel.java
+++ b/src/main/java/net/causw/domain/model/CircleDomainModel.java
@@ -8,7 +8,7 @@ public class CircleDomainModel {
     private String name;
     private String mainImage;
     private String description;
-    private String isDeleted;
+    private Boolean isDeleted;
     private UserDomainModel manager;
 
     private CircleDomainModel(
@@ -16,7 +16,7 @@ public class CircleDomainModel {
             String name,
             String mainImage,
             String description,
-            String isDeleted,
+            Boolean isDeleted,
             UserDomainModel manager
     ) {
         this.id = id;
@@ -32,7 +32,7 @@ public class CircleDomainModel {
             String name,
             String mainImage,
             String description,
-            String isDeleted,
+            Boolean isDeleted,
             UserDomainModel manager
     ) {
         return new CircleDomainModel(

--- a/src/main/java/net/causw/domain/model/UserCircleStatus.java
+++ b/src/main/java/net/causw/domain/model/UserCircleStatus.java
@@ -4,7 +4,8 @@ public enum UserCircleStatus {
     AWAIT("await"),
     MEMBER("member"),
     LEAVE("leave"),
-    DROP("drop");
+    DROP("drop"),
+    REJECT("reject");
 
     private String value;
 

--- a/src/main/java/net/causw/domain/validation/UserCircleStateAwaitValidator.java
+++ b/src/main/java/net/causw/domain/validation/UserCircleStateAwaitValidator.java
@@ -1,0 +1,83 @@
+package net.causw.domain.validation;
+
+import net.causw.application.spi.UserCirclePort;
+import net.causw.domain.exceptions.BadRequestException;
+import net.causw.domain.exceptions.ErrorCode;
+import net.causw.domain.exceptions.UnauthorizedException;
+import net.causw.domain.model.UserCircleStatus;
+
+public class UserCircleStateAwaitValidator extends AbstractValidator {
+
+    private UserCircleStatus status;
+    private UserCirclePort userCirclePort;
+    private String userId;
+    private String circleId;
+
+    private UserCircleStateAwaitValidator(
+            UserCirclePort userCirclePort,
+            String userId,
+            String circleId
+    ) {
+        this.userCirclePort = userCirclePort;
+        this.userId = userId;
+        this.circleId = circleId;
+        this.status = null;
+    }
+
+    private UserCircleStateAwaitValidator(UserCircleStatus status) {
+        this.status = status;
+    }
+
+    public static UserCircleStateAwaitValidator of(
+            UserCirclePort userCirclePort,
+            String userId,
+            String circleId
+    ) {
+        return new UserCircleStateAwaitValidator(
+                userCirclePort,
+                userId,
+                circleId
+        );
+    }
+
+    public static UserCircleStateAwaitValidator of(UserCircleStatus status) {
+        return new UserCircleStateAwaitValidator(status);
+    }
+
+    @Override
+    public void validate() {
+        if (this.status == null) {
+            this.status = this.userCirclePort.loadUserCircleStatus(this.userId, this.circleId).orElseThrow(
+                    () -> new BadRequestException(
+                            ErrorCode.ROW_DOES_NOT_EXIST,
+                            "Invalid application information"
+                    )
+            );
+        }
+
+        if (this.status == UserCircleStatus.MEMBER) {
+            throw new BadRequestException(
+                    ErrorCode.ROW_ALREADY_EXIST,
+                    "The user is already member of the circle"
+            );
+        }
+
+        if (this.status == UserCircleStatus.LEAVE) {
+            throw new BadRequestException(
+                    ErrorCode.APPLY_NOT_EXIST,
+                    "The user did not applied to the circle"
+            );
+        }
+
+        if (this.status == UserCircleStatus.DROP) {
+            throw new UnauthorizedException(
+                    ErrorCode.BLOCKED_USER,
+                    "The user is blocked from the circle"
+            );
+        }
+
+        if (this.hasNext()) {
+            this.next.validate();
+        }
+    }
+}

--- a/src/main/java/net/causw/domain/validation/UserEqualValidator.java
+++ b/src/main/java/net/causw/domain/validation/UserEqualValidator.java
@@ -1,0 +1,34 @@
+package net.causw.domain.validation;
+
+import net.causw.domain.exceptions.ErrorCode;
+import net.causw.domain.exceptions.UnauthorizedException;
+
+public class UserEqualValidator extends AbstractValidator {
+
+    private final String srcUserId;
+
+    private final String targetUserId;
+
+    private UserEqualValidator(String srcUserId, String targetUserId) {
+        this.srcUserId = srcUserId;
+        this.targetUserId = targetUserId;
+    }
+
+    public static UserEqualValidator of(String srcUserId, String targetUserId) {
+        return new UserEqualValidator(srcUserId, targetUserId);
+    }
+
+    @Override
+    public void validate() {
+        if (!this.srcUserId.equals(this.targetUserId)) {
+            throw new UnauthorizedException(
+                    ErrorCode.API_NOT_ALLOWED,
+                    "You don't have access"
+            );
+        }
+
+        if (this.hasNext()) {
+            this.next.validate();
+        }
+    }
+}


### PR DESCRIPTION
## Related issue
- #85 

## Description
유저 소모임 신청 승인 / 거절

## Changes detail
- 기존 `UserCirclePortImpl` 의 `accept` 를 제거하고 `updateStatus()` 로 통일하였으며, 이에 대한 선택 주체를 `UserCircleService` 로 넘겼습니다: Service 레벨에서의 과한 코드 중복 방지
- 소모임장에 한정하여 `AWAIT` 상태인 신청을 `Accept` 혹은 `Reject` 상태로 변경할 수 있는 기능을 구현했습니다.
- 관리자 (ADMIN) 도 해당 API 의 권한을 갖도록 추후 업데이트가 필요합니다.

### Checklist

- [x] Test case
- [x] End of work
