### PR TITLE
feat: Implement to delete board

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/port/BoardPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/BoardPortImpl.java
@@ -56,6 +56,17 @@ public class BoardPortImpl implements BoardPort {
         );
     }
 
+    @Override
+    public Optional<BoardDomainModel> delete(String id) {
+        return this.boardRepository.findById(id).map(
+                srcBoard -> {
+                    srcBoard.setIsDeleted(true);
+
+                    return this.entityToDomainModel(this.boardRepository.save(srcBoard));
+                }
+        );
+    }
+
     private BoardDomainModel entityToDomainModel(Board board) {
         return BoardDomainModel.of(
                 board.getId(),

--- a/src/main/java/net/causw/adapter/web/BoardController.java
+++ b/src/main/java/net/causw/adapter/web/BoardController.java
@@ -6,6 +6,7 @@ import net.causw.application.dto.BoardResponseDto;
 import net.causw.application.dto.BoardUpdateRequestDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -43,5 +44,12 @@ public class BoardController {
                                    @PathVariable String id,
                                    @RequestBody BoardUpdateRequestDto boardUpdateRequestDto) {
         return this.boardService.update(updaterId, id, boardUpdateRequestDto);
+    }
+
+    @DeleteMapping(value = "/{id}")
+    @ResponseStatus(value = HttpStatus.OK)
+    public BoardResponseDto delete(@AuthenticationPrincipal String deleterId,
+                                   @PathVariable String id) {
+        return this.boardService.delete(deleterId, id);
     }
 }

--- a/src/main/java/net/causw/application/dto/BoardUpdateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/BoardUpdateRequestDto.java
@@ -20,8 +20,4 @@ public class BoardUpdateRequestDto {
     private List<String> readRoleList;
 
     private String circleId;
-
-    public Optional<String> getCircleId() {
-        return Optional.ofNullable(this.circleId);
-    }
 }

--- a/src/main/java/net/causw/application/spi/BoardPort.java
+++ b/src/main/java/net/causw/application/spi/BoardPort.java
@@ -9,4 +9,5 @@ public interface BoardPort {
     Optional<BoardDomainModel> findById(String id);
     BoardDomainModel create(BoardDomainModel boardDomainModel, Optional<CircleDomainModel> circleDomainModel);
     Optional<BoardDomainModel> update(String id, BoardDomainModel boardDomainModel);
+    Optional<BoardDomainModel> delete(String id);
 }

--- a/src/main/java/net/causw/domain/model/BoardDomainModel.java
+++ b/src/main/java/net/causw/domain/model/BoardDomainModel.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Optional;
 
 @Getter
 @Setter
@@ -90,5 +91,9 @@ public class BoardDomainModel {
                 false,
                 circleId
         );
+    }
+
+    public Optional<String> getOptionalCircleId() {
+        return Optional.ofNullable(this.circleId);
     }
 }


### PR DESCRIPTION
## Related issue
- #69 

## Description
Implement to delete board

## Changes detail
- 보드 삭제 구현
- 보드 업데이트 시 소모임 id 확인 방법을 BoardUpadateRequestDto에서 조회한 BoardDomainModel로 수정

### Checklist

- [x] Test case
- [x] End of work
