### PR TITLE
fix: refactor circle & board domain model

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/port/BoardPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/BoardPortImpl.java
@@ -36,7 +36,7 @@ public class BoardPortImpl implements BoardPort {
                 boardDomainModel.getCreateRoleList().stream().map(Object::toString).collect(Collectors.joining(",")),
                 boardDomainModel.getModifyRoleList().stream().map(Object::toString).collect(Collectors.joining(",")),
                 boardDomainModel.getReadRoleList().stream().map(Object::toString).collect(Collectors.joining(",")),
-                false,
+                boardDomainModel.getIsDeleted(),
                 circle
         )));
     }

--- a/src/main/java/net/causw/adapter/persistence/port/CirclePortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/CirclePortImpl.java
@@ -35,14 +35,8 @@ public class CirclePortImpl implements CirclePort {
     }
 
     @Override
-    public CircleDomainModel create(CircleDomainModel circleDomainModel, UserDomainModel leader) {
-        return this.entityToDomainModel(this.circleRepository.save(Circle.of(
-                circleDomainModel.getName(),
-                circleDomainModel.getMainImage(),
-                circleDomainModel.getDescription(),
-                false,
-                User.from(leader)
-        )));
+    public CircleDomainModel create(CircleDomainModel circleDomainModel) {
+        return this.entityToDomainModel(this.circleRepository.save(Circle.from(circleDomainModel)));
     }
 
     @Override

--- a/src/main/java/net/causw/application/BoardService.java
+++ b/src/main/java/net/causw/application/BoardService.java
@@ -88,13 +88,11 @@ public class BoardService {
         ));
 
         BoardDomainModel boardDomainModel = BoardDomainModel.of(
-                null,
                 boardCreateRequestDto.getName(),
                 boardCreateRequestDto.getDescription(),
                 boardCreateRequestDto.getCreateRoleList(),
                 boardCreateRequestDto.getModifyRoleList(),
                 boardCreateRequestDto.getReadRoleList(),
-                false,
                 boardCreateRequestDto.getCircleId().orElse(null)
         );
 

--- a/src/main/java/net/causw/application/spi/CirclePort.java
+++ b/src/main/java/net/causw/application/spi/CirclePort.java
@@ -12,7 +12,7 @@ public interface CirclePort {
 
     Optional<CircleDomainModel> findByName(String name);
 
-    CircleDomainModel create(CircleDomainModel circleDomainModel, UserDomainModel leader);
+    CircleDomainModel create(CircleDomainModel circleDomainModel);
 
     Optional<CircleDomainModel> updateLeader(String id, UserDomainModel newLeader);
 }

--- a/src/main/java/net/causw/domain/model/BoardDomainModel.java
+++ b/src/main/java/net/causw/domain/model/BoardDomainModel.java
@@ -25,6 +25,7 @@ public class BoardDomainModel {
     @NotNull(message = "Read role is null")
     private List<String> readRoleList;
 
+    @NotNull(message = "Board state is null")
     private Boolean isDeleted;
 
     private String circleId;
@@ -67,6 +68,26 @@ public class BoardDomainModel {
                 modifyRoleList,
                 readRoleList,
                 isDeleted,
+                circleId
+        );
+    }
+
+    public static BoardDomainModel of(
+            String name,
+            String description,
+            List<String> createRoleList,
+            List<String> modifyRoleList,
+            List<String> readRoleList,
+            String circleId
+    ) {
+        return new BoardDomainModel(
+                null,
+                name,
+                description,
+                createRoleList,
+                modifyRoleList,
+                readRoleList,
+                false,
                 circleId
         );
     }

--- a/src/main/java/net/causw/domain/model/CircleDomainModel.java
+++ b/src/main/java/net/causw/domain/model/CircleDomainModel.java
@@ -3,14 +3,23 @@ package net.causw.domain.model;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
 @Getter
 @Setter
 public class CircleDomainModel {
     private String id;
-    private String name;
     private String mainImage;
     private String description;
+
+    @NotBlank(message = "Name is blank")
+    private String name;
+
+    @NotNull(message = "Circle state is null")
     private Boolean isDeleted;
+
+    @NotNull(message = "Circle leader is null")
     private UserDomainModel leader;
 
     private CircleDomainModel(
@@ -43,6 +52,22 @@ public class CircleDomainModel {
                 mainImage,
                 description,
                 isDeleted,
+                leader
+        );
+    }
+
+    public static CircleDomainModel of(
+            String name,
+            String mainImage,
+            String description,
+            UserDomainModel leader
+    ) {
+        return new CircleDomainModel(
+                null,
+                name,
+                mainImage,
+                description,
+                false,
                 leader
         );
     }

--- a/src/test/groovy/net/causw/application/BoardServiceTest.groovy
+++ b/src/test/groovy/net/causw/application/BoardServiceTest.groovy
@@ -3,17 +3,12 @@ package net.causw.application
 import net.causw.application.dto.BoardCreateRequestDto
 import net.causw.application.dto.BoardResponseDto
 import net.causw.application.dto.BoardUpdateRequestDto
-
 import net.causw.application.spi.BoardPort
 import net.causw.application.spi.CirclePort
 import net.causw.application.spi.UserPort
 import net.causw.domain.exceptions.BadRequestException
 import net.causw.domain.exceptions.UnauthorizedException
-import net.causw.domain.model.BoardDomainModel
-import net.causw.domain.model.CircleDomainModel
-import net.causw.domain.model.Role
-import net.causw.domain.model.UserDomainModel
-import net.causw.domain.model.UserState
+import net.causw.domain.model.*
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.powermock.api.mockito.PowerMockito
@@ -89,21 +84,19 @@ class BoardServiceTest extends Specification {
 
         this.userPort.findById("test") >> Optional.of(creatorUserDomainModel)
         this.circlePort.findById("test") >> Optional.of(circleDomainModel)
-        this.boardPort.create((BoardDomainModel)this.mockBoardDomainModel, Optional.ofNullable(null)) >> this.mockBoardDomainModel
-        this.boardPort.create((BoardDomainModel)this.mockBoardDomainModel, Optional.ofNullable(circleDomainModel)) >> this.mockBoardDomainModel
+        this.boardPort.create((BoardDomainModel) this.mockBoardDomainModel, Optional.ofNullable(null)) >> this.mockBoardDomainModel
+        this.boardPort.create((BoardDomainModel) this.mockBoardDomainModel, Optional.ofNullable(circleDomainModel)) >> this.mockBoardDomainModel
 
         when: "create board without circle"
         PowerMockito.mockStatic(BoardDomainModel.class)
         PowerMockito.when(BoardDomainModel.of(
-                null,
                 "test",
                 "test_description",
                 Arrays.asList("PRESIDENT", "COUNCIL"),
                 Arrays.asList("PRESIDENT", "COUNCIL"),
                 Arrays.asList("PRESIDENT", "COUNCIL"),
-                false,
                 null
-        )).thenReturn((BoardDomainModel)this.mockBoardDomainModel)
+        )).thenReturn((BoardDomainModel) this.mockBoardDomainModel)
         def boardResponseDto = this.boardService.create("test", mockBoardCreateRequestDto)
 
         then:
@@ -116,18 +109,16 @@ class BoardServiceTest extends Specification {
         when: "create board with circle"
         mockBoardCreateRequestDto.setCircleId("test")
         creatorUserDomainModel.setRole(Role.LEADER_CIRCLE)
-        (BoardDomainModel)this.mockBoardDomainModel.setCircleId("test")
+        (BoardDomainModel) this.mockBoardDomainModel.setCircleId("test")
         PowerMockito.mockStatic(BoardDomainModel.class)
         PowerMockito.when(BoardDomainModel.of(
-                null,
                 "test",
                 "test_description",
                 Arrays.asList("PRESIDENT", "COUNCIL"),
                 Arrays.asList("PRESIDENT", "COUNCIL"),
                 Arrays.asList("PRESIDENT", "COUNCIL"),
-                false,
                 "test"
-        )).thenReturn((BoardDomainModel)this.mockBoardDomainModel)
+        )).thenReturn((BoardDomainModel) this.mockBoardDomainModel)
         boardResponseDto = this.boardService.create("test", mockBoardCreateRequestDto)
 
         then:
@@ -163,22 +154,20 @@ class BoardServiceTest extends Specification {
         )
 
         this.userPort.findById("test") >> Optional.of(mockCreatorDomainModel)
-        this.boardPort.create((BoardDomainModel)this.mockBoardDomainModel, null) >> this.mockBoardDomainModel
+        this.boardPort.create((BoardDomainModel) this.mockBoardDomainModel, null) >> this.mockBoardDomainModel
 
         when: "name is blank"
         mockBoardCreateRequestDto.setName("")
         this.mockBoardDomainModel.setName("")
         PowerMockito.mockStatic(BoardDomainModel.class)
         PowerMockito.when(BoardDomainModel.of(
-                null,
                 "",
                 "test_description",
                 Arrays.asList("PRESIDENT", "COUNCIL"),
                 Arrays.asList("PRESIDENT", "COUNCIL"),
                 Arrays.asList("PRESIDENT", "COUNCIL"),
-                false,
                 null
-        )).thenReturn((BoardDomainModel)this.mockBoardDomainModel)
+        )).thenReturn((BoardDomainModel) this.mockBoardDomainModel)
         this.boardService.create("test", mockBoardCreateRequestDto)
 
         then:
@@ -191,15 +180,13 @@ class BoardServiceTest extends Specification {
         this.mockBoardDomainModel.setCreateRoleList(null)
         PowerMockito.mockStatic(BoardDomainModel.class)
         PowerMockito.when(BoardDomainModel.of(
-                null,
                 "test",
                 "test_description",
                 null,
                 Arrays.asList("PRESIDENT", "COUNCIL"),
                 Arrays.asList("PRESIDENT", "COUNCIL"),
-                false,
                 null
-        )).thenReturn((BoardDomainModel)this.mockBoardDomainModel)
+        )).thenReturn((BoardDomainModel) this.mockBoardDomainModel)
         this.boardService.create("test", mockBoardCreateRequestDto)
 
         then:
@@ -212,15 +199,13 @@ class BoardServiceTest extends Specification {
         this.mockBoardDomainModel.setModifyRoleList(null)
         PowerMockito.mockStatic(BoardDomainModel.class)
         PowerMockito.when(BoardDomainModel.of(
-                null,
                 "test",
                 "test_description",
                 Arrays.asList("PRESIDENT", "COUNCIL"),
                 null,
                 Arrays.asList("PRESIDENT", "COUNCIL"),
-                false,
                 null
-        )).thenReturn((BoardDomainModel)this.mockBoardDomainModel)
+        )).thenReturn((BoardDomainModel) this.mockBoardDomainModel)
         this.boardService.create("test", mockBoardCreateRequestDto)
 
         then:
@@ -233,15 +218,13 @@ class BoardServiceTest extends Specification {
         this.mockBoardDomainModel.setReadRoleList(null)
         PowerMockito.mockStatic(BoardDomainModel.class)
         PowerMockito.when(BoardDomainModel.of(
-                null,
                 "test",
                 "test_description",
                 Arrays.asList("PRESIDENT", "COUNCIL"),
                 Arrays.asList("PRESIDENT", "COUNCIL"),
                 null,
-                false,
                 null
-        )).thenReturn((BoardDomainModel)this.mockBoardDomainModel)
+        )).thenReturn((BoardDomainModel) this.mockBoardDomainModel)
         this.boardService.create("test", mockBoardCreateRequestDto)
 
         then:
@@ -273,7 +256,7 @@ class BoardServiceTest extends Specification {
         )
 
         this.userPort.findById("test") >> Optional.of(mockCreatorDomainModel)
-        this.boardPort.create((BoardDomainModel)this.mockBoardDomainModel, null) >> this.mockBoardDomainModel
+        this.boardPort.create((BoardDomainModel) this.mockBoardDomainModel, null) >> this.mockBoardDomainModel
 
         when: "invalid creator role"
         mockCreatorDomainModel.setRole(Role.NONE)
@@ -318,7 +301,7 @@ class BoardServiceTest extends Specification {
 
         this.userPort.findById("test") >> Optional.of(creator)
         this.circlePort.findById("test") >> Optional.of(mockCircleDomainModel)
-        this.boardPort.create((BoardDomainModel)this.mockBoardDomainModel, Optional.ofNullable(mockCircleDomainModel)) >> this.mockBoardDomainModel
+        this.boardPort.create((BoardDomainModel) this.mockBoardDomainModel, Optional.ofNullable(mockCircleDomainModel)) >> this.mockBoardDomainModel
 
         when: "invalid leader id"
         creator.setId("invalid_test")
@@ -499,7 +482,7 @@ class BoardServiceTest extends Specification {
                 mockBoardUpdateRequestDto.getReadRoleList(),
                 false,
                 null
-        )).thenReturn((BoardDomainModel)this.mockBoardDomainModel)
+        )).thenReturn((BoardDomainModel) this.mockBoardDomainModel)
         this.boardService.update("test", "test", mockBoardUpdateRequestDto)
 
         then:
@@ -520,7 +503,7 @@ class BoardServiceTest extends Specification {
                 mockBoardUpdateRequestDto.getReadRoleList(),
                 false,
                 null
-        )).thenReturn((BoardDomainModel)this.mockBoardDomainModel)
+        )).thenReturn((BoardDomainModel) this.mockBoardDomainModel)
         this.boardService.update("test", "test", mockBoardUpdateRequestDto)
 
         then:
@@ -541,7 +524,7 @@ class BoardServiceTest extends Specification {
                 mockBoardUpdateRequestDto.getReadRoleList(),
                 false,
                 null
-        )).thenReturn((BoardDomainModel)this.mockBoardDomainModel)
+        )).thenReturn((BoardDomainModel) this.mockBoardDomainModel)
         this.boardService.update("test", "test", mockBoardUpdateRequestDto)
 
         then:
@@ -562,7 +545,7 @@ class BoardServiceTest extends Specification {
                 mockBoardUpdateRequestDto.getReadRoleList(),
                 false,
                 null
-        )).thenReturn((BoardDomainModel)this.mockBoardDomainModel)
+        )).thenReturn((BoardDomainModel) this.mockBoardDomainModel)
         this.boardService.update("test", "test", mockBoardUpdateRequestDto)
 
         then:


### PR DESCRIPTION
## Description
Circle, Board 의 Domain model의 리팩토링

## Changes detail
- Default 값 지정을 Domain model 내부에서 지정하는 형태로 변경
- Circle domain model의 Constraint validator 추가

### Checklist

- [x] Test case
- [x] End of work
