### PR TITLE
fix: refactor board, post, comment structure

### DIFF
--- a/src/main/java/net/causw/CauswApplication.java
+++ b/src/main/java/net/causw/CauswApplication.java
@@ -2,8 +2,10 @@ package net.causw;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class CauswApplication {
     public static void main(String[] args) {
         SpringApplication.run(CauswApplication.class, args);

--- a/src/main/java/net/causw/adapter/persistence/BaseEntity.java
+++ b/src/main/java/net/causw/adapter/persistence/BaseEntity.java
@@ -5,8 +5,10 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.Column;
+import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
@@ -15,6 +17,7 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor
 @MappedSuperclass
+@EntityListeners(value = {AuditingEntityListener.class})
 public class BaseEntity {
     @Id
     @GeneratedValue(generator = "uuid")

--- a/src/main/java/net/causw/adapter/persistence/Board.java
+++ b/src/main/java/net/causw/adapter/persistence/Board.java
@@ -3,6 +3,7 @@ package net.causw.adapter.persistence;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import net.causw.domain.model.BoardDomainModel;
 import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.CascadeType;
@@ -13,6 +14,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -47,6 +49,26 @@ public class Board extends BaseEntity {
     private Set<Post> postSet;
 
     private Board(
+            String id,
+            String name,
+            String description,
+            String createRoles,
+            String modifyRoles,
+            String readRoles,
+            Boolean isDeleted,
+            Circle circle
+    ) {
+        super(id);
+        this.name = name;
+        this.description = description;
+        this.createRoles = createRoles;
+        this.modifyRoles = modifyRoles;
+        this.readRoles = readRoles;
+        this.isDeleted = isDeleted;
+        this.circle = circle;
+    }
+
+    private Board(
             String name,
             String description,
             String createRoles,
@@ -65,6 +87,28 @@ public class Board extends BaseEntity {
     }
 
     public static Board of(
+            String id,
+            String name,
+            String description,
+            String createRoles,
+            String modifyRoles,
+            String readRoles,
+            Boolean isDeleted,
+            Circle circle
+    ) {
+        return new Board(
+                id,
+                name,
+                description,
+                createRoles,
+                modifyRoles,
+                readRoles,
+                isDeleted,
+                circle
+        );
+    }
+
+    public static Board of(
             String name,
             String description,
             String createRoles,
@@ -80,6 +124,21 @@ public class Board extends BaseEntity {
                 modifyRoles,
                 readRoles,
                 isDeleted,
+                circle
+        );
+    }
+
+    public static Board from(BoardDomainModel boardDomainModel) {
+        Circle circle = boardDomainModel.getCircle().map(Circle::from).orElse(null);
+
+        return new Board(
+                boardDomainModel.getId(),
+                boardDomainModel.getName(),
+                boardDomainModel.getDescription(),
+                boardDomainModel.getCreateRoleList().stream().map(Object::toString).collect(Collectors.joining(",")),
+                boardDomainModel.getModifyRoleList().stream().map(Object::toString).collect(Collectors.joining(",")),
+                boardDomainModel.getReadRoleList().stream().map(Object::toString).collect(Collectors.joining(",")),
+                boardDomainModel.getIsDeleted(),
                 circle
         );
     }

--- a/src/main/java/net/causw/adapter/persistence/Comment.java
+++ b/src/main/java/net/causw/adapter/persistence/Comment.java
@@ -3,6 +3,7 @@ package net.causw.adapter.persistence;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.causw.domain.model.CommentDomainModel;
+import net.causw.domain.model.PostDomainModel;
 import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.CascadeType;
@@ -105,28 +106,19 @@ public class Comment extends BaseEntity {
         );
     }
 
-    public static Comment from(CommentDomainModel commentDomainModel) {
-        return new Comment(
-                commentDomainModel.getId(),
-                commentDomainModel.getContent(),
-                commentDomainModel.getIsDeleted(),
-                User.from(commentDomainModel.getWriter()),
-                Post.from(commentDomainModel.getPost()),
-                null
-        );
-    }
+    public static Comment from(CommentDomainModel commentDomainModel, PostDomainModel postDomainModel) {
+        Comment parentComment = null;
+        if (commentDomainModel.getParentComment() != null) {
+            parentComment = Comment.from(commentDomainModel.getParentComment(), postDomainModel);
+        }
 
-    public static Comment from(
-            CommentDomainModel commentDomainModel,
-            CommentDomainModel parentCommentDomainModel
-    ) {
         return new Comment(
                 commentDomainModel.getId(),
                 commentDomainModel.getContent(),
                 commentDomainModel.getIsDeleted(),
                 User.from(commentDomainModel.getWriter()),
-                Post.from(commentDomainModel.getPost()),
-                Comment.from(parentCommentDomainModel)
+                Post.from(postDomainModel),
+                parentComment
         );
     }
 }

--- a/src/main/java/net/causw/adapter/persistence/Post.java
+++ b/src/main/java/net/causw/adapter/persistence/Post.java
@@ -5,14 +5,11 @@ import lombok.NoArgsConstructor;
 import net.causw.domain.model.PostDomainModel;
 import org.hibernate.annotations.ColumnDefault;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import javax.persistence.Table;
-import java.util.List;
 
 @Getter
 @Entity
@@ -25,6 +22,10 @@ public class Post extends BaseEntity {
     @Column(columnDefinition = "TEXT", name = "content", nullable = false)
     private String content;
 
+    @ManyToOne(targetEntity = User.class)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User writer;
+
     @Column(name = "is_deleted")
     @ColumnDefault("false")
     private Boolean isDeleted;
@@ -33,24 +34,68 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "board_id", nullable = false)
     private Board board;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
-    private List<Comment> commentList;
-
-    private Post(String title, String content, Boolean isDeleted) {
+    private Post(
+            String title,
+            String content,
+            User writer,
+            Boolean isDeleted,
+            Board board
+    ) {
         this.title = title;
         this.content = content;
+        this.writer = writer;
         this.isDeleted = isDeleted;
+        this.board = board;
     }
 
-    private Post(String id, String title, String content, Boolean isDeleted) {
+    private Post(
+            String id,
+            String title,
+            String content,
+            User writer,
+            Boolean isDeleted,
+            Board board
+    ) {
         super(id);
         this.title = title;
         this.content = content;
+        this.writer = writer;
         this.isDeleted = isDeleted;
+        this.board = board;
     }
 
-    public static Post of(String title, String content, Boolean isDeleted) {
-        return new Post(title, content, isDeleted);
+    public static Post of(
+            String title,
+            String content,
+            User writer,
+            Boolean isDeleted,
+            Board board
+    ) {
+        return new Post(
+                title,
+                content,
+                writer,
+                isDeleted,
+                board
+        );
+    }
+
+    public static Post of(
+            String id,
+            String title,
+            String content,
+            User writer,
+            Boolean isDeleted,
+            Board board
+    ) {
+        return new Post(
+                id,
+                title,
+                content,
+                writer,
+                isDeleted,
+                board
+        );
     }
 
     public static Post from(PostDomainModel postDomainModel) {
@@ -58,7 +103,9 @@ public class Post extends BaseEntity {
                 postDomainModel.getId(),
                 postDomainModel.getTitle(),
                 postDomainModel.getContent(),
-                postDomainModel.getIsDeleted()
+                User.from(postDomainModel.getWriter()),
+                postDomainModel.getIsDeleted(),
+                Board.from(postDomainModel.getBoard())
         );
     }
 }

--- a/src/main/java/net/causw/adapter/web/CommentController.java
+++ b/src/main/java/net/causw/adapter/web/CommentController.java
@@ -4,6 +4,7 @@ import net.causw.application.CommentService;
 import net.causw.application.dto.CommentCreateRequestDto;
 import net.causw.application.dto.CommentResponseDto;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,9 +28,12 @@ public class CommentController {
         return this.commentService.findById(id);
     }
 
-    @PostMapping(value = "/")
+    @PostMapping
     @ResponseStatus(HttpStatus.OK)
-    public CommentResponseDto create(@RequestBody CommentCreateRequestDto commentCreateDto) {
-        return this.commentService.create(commentCreateDto);
+    public CommentResponseDto create(
+            @AuthenticationPrincipal String creatorId,
+            @RequestBody CommentCreateRequestDto commentCreateRequestDto
+    ) {
+        return this.commentService.create(creatorId, commentCreateRequestDto);
     }
 }

--- a/src/main/java/net/causw/adapter/web/PostController.java
+++ b/src/main/java/net/causw/adapter/web/PostController.java
@@ -1,7 +1,16 @@
 package net.causw.adapter.web;
 
 import net.causw.application.PostService;
+import net.causw.application.dto.PostCreateRequestDto;
+import net.causw.application.dto.PostResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -13,11 +22,15 @@ public class PostController {
         this.postService = postService;
     }
 
-    /* TODO : Refactoring & Implementation
     @GetMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.OK)
-    public PostDetailDto findById(@PathVariable String id) {
+    public PostResponseDto findById(@PathVariable String id) {
         return this.postService.findById(id);
     }
-     */
+
+    @PostMapping
+    @ResponseStatus(value = HttpStatus.CREATED)
+    public PostResponseDto create(@AuthenticationPrincipal String creatorId, @RequestBody PostCreateRequestDto postCreateRequestDto) {
+        return this.postService.create(creatorId, postCreateRequestDto);
+    }
 }

--- a/src/main/java/net/causw/application/PostService.java
+++ b/src/main/java/net/causw/application/PostService.java
@@ -1,20 +1,85 @@
 package net.causw.application;
 
+import net.causw.application.dto.PostCreateRequestDto;
 import net.causw.application.dto.PostResponseDto;
+import net.causw.application.spi.BoardPort;
 import net.causw.application.spi.PostPort;
+import net.causw.application.spi.UserPort;
+import net.causw.domain.exceptions.BadRequestException;
+import net.causw.domain.exceptions.ErrorCode;
+import net.causw.domain.model.BoardDomainModel;
+import net.causw.domain.model.PostDomainModel;
+import net.causw.domain.model.UserDomainModel;
+import net.causw.domain.validation.ConstraintValidator;
+import net.causw.domain.validation.ValidatorBucket;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.validation.Validator;
+import java.util.ArrayList;
 
 @Service
 public class PostService {
     private final PostPort postPort;
+    private final UserPort userPort;
+    private final BoardPort boardPort;
+    private final Validator validator;
 
-    public PostService(PostPort postPort) {
+    public PostService(
+            PostPort postPort,
+            UserPort userPort,
+            BoardPort boardPort,
+            Validator validator
+    ) {
         this.postPort = postPort;
+        this.userPort = userPort;
+        this.boardPort = boardPort;
+        this.validator = validator;
     }
 
     @Transactional(readOnly = true)
     public PostResponseDto findById(String id) {
-        return PostResponseDto.from(this.postPort.findById(id));
+        // TODO : GHJANG : Need implementation - put comment (with pagenation)
+        return PostResponseDto.from(this.postPort.findById(id).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        "Invalid post id"
+                )
+        ), new ArrayList<>());
+    }
+
+    @Transactional
+    public PostResponseDto create(String creatorId, PostCreateRequestDto postCreateRequestDto) {
+        ValidatorBucket validatorBucket = ValidatorBucket.of();
+
+        UserDomainModel creatorDomainModel = this.userPort.findById(creatorId).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        "Invalid request user id"
+                )
+        );
+
+        BoardDomainModel boardDomainModel = this.boardPort.findById(postCreateRequestDto.getBoardId()).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        "Invalid board id"
+                )
+        );
+
+        // TODO : GHJANG : validate create role of board for creator user
+        // TODO : GHJANG : If the board has Circle, member check is also needed
+
+        PostDomainModel postDomainModel = PostDomainModel.of(
+                postCreateRequestDto.getTitle(),
+                postCreateRequestDto.getContent(),
+                creatorDomainModel,
+                boardDomainModel
+        );
+
+        validatorBucket
+                .consistOf(ConstraintValidator.of(postDomainModel, this.validator))
+                .validate();
+
+        return PostResponseDto.from(this.postPort.create(postDomainModel));
     }
 }

--- a/src/main/java/net/causw/application/dto/BoardResponseDto.java
+++ b/src/main/java/net/causw/application/dto/BoardResponseDto.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import net.causw.adapter.persistence.Board;
 import net.causw.domain.model.BoardDomainModel;
+import net.causw.domain.model.CircleDomainModel;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -23,6 +24,7 @@ public class BoardResponseDto {
     private Boolean isDeleted;
 
     private String circleId;
+    private String circleName;
 
     private BoardResponseDto(
             String id,
@@ -32,7 +34,8 @@ public class BoardResponseDto {
             List<String> modifyRoleList,
             List<String> readRoleList,
             Boolean isDeleted,
-            String circleId
+            String circleId,
+            String circleName
     ) {
         this.id = id;
         this.name = name;
@@ -42,11 +45,16 @@ public class BoardResponseDto {
         this.readRoleList = readRoleList;
         this.isDeleted = isDeleted;
         this.circleId = circleId;
+        this.circleName = circleName;
     }
 
     public static BoardResponseDto from(Board board) {
         String circleId = null;
-        if (board.getCircle() != null) { circleId = board.getCircle().getId(); }
+        String circleName = null;
+        if (board.getCircle() != null) {
+            circleId = board.getCircle().getId();
+            circleName = board.getCircle().getName();
+        }
         return new BoardResponseDto(
                 board.getId(),
                 board.getName(),
@@ -55,11 +63,15 @@ public class BoardResponseDto {
                 new ArrayList<>(Arrays.asList(board.getModifyRoles().split(","))),
                 new ArrayList<>(Arrays.asList(board.getReadRoles().split(","))),
                 board.getIsDeleted(),
-                circleId
+                circleId,
+                circleName
         );
     }
 
     public static BoardResponseDto from(BoardDomainModel boardDomainModel) {
+        String circleId = boardDomainModel.getCircle().map(CircleDomainModel::getId).orElse(null);
+        String circleName = boardDomainModel.getCircle().map(CircleDomainModel::getName).orElse(null);
+
         return new BoardResponseDto(
                 boardDomainModel.getId(),
                 boardDomainModel.getName(),
@@ -68,7 +80,8 @@ public class BoardResponseDto {
                 boardDomainModel.getModifyRoleList(),
                 boardDomainModel.getReadRoleList(),
                 boardDomainModel.getIsDeleted(),
-                boardDomainModel.getCircleId()
+                circleId,
+                circleName
         );
     }
 }

--- a/src/main/java/net/causw/application/dto/BoardUpdateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/BoardUpdateRequestDto.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.List;
-import java.util.Optional;
 
 @Getter
 @Setter
@@ -18,6 +17,4 @@ public class BoardUpdateRequestDto {
     private List<String> createRoleList;
     private List<String> modifyRoleList;
     private List<String> readRoleList;
-
-    private String circleId;
 }

--- a/src/main/java/net/causw/application/dto/CommentCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/CommentCreateRequestDto.java
@@ -5,13 +5,18 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.Optional;
+
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class CommentCreateRequestDto {
     private String content;
-    private String postId; // -> post
-    private String writerId; // -> writer
-    private String parentCommentId; // -> parent comment
+    private String postId;
+    private String parentCommentId;
+
+    public Optional<String> getParentCommentId() {
+        return Optional.ofNullable(this.parentCommentId);
+    }
 }

--- a/src/main/java/net/causw/application/dto/CommentResponseDto.java
+++ b/src/main/java/net/causw/application/dto/CommentResponseDto.java
@@ -16,9 +16,10 @@ public class CommentResponseDto {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private Boolean isDeleted;
-    private PostResponseDto post;
+    private String postId;
     private String writerId;
     private String writerName;
+    private String parentCommentId;
     private List<CommentResponseDto> childCommentList;
 
     private CommentResponseDto(
@@ -27,9 +28,10 @@ public class CommentResponseDto {
             LocalDateTime createdAt,
             LocalDateTime updatedAt,
             Boolean isDeleted,
-            PostResponseDto post,
+            String postId,
             String writerId,
             String writerName,
+            String parentCommentId,
             List<CommentResponseDto> childCommentList
     ) {
         this.id = id;
@@ -37,24 +39,29 @@ public class CommentResponseDto {
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.isDeleted = isDeleted;
-        this.post = post;
+        this.postId = postId;
         this.writerId = writerId;
         this.writerName = writerName;
+        this.parentCommentId = parentCommentId;
         this.childCommentList = childCommentList;
     }
 
     public static CommentResponseDto from(CommentDomainModel comment) {
+        String parentCommentId = null;
+        if (comment.getParentComment() != null) {
+            parentCommentId = comment.getParentComment().getId();
+        }
+
         return new CommentResponseDto(
                 comment.getId(),
                 comment.getContent(),
                 comment.getCreatedAt(),
                 comment.getUpdatedAt(),
                 comment.getIsDeleted(),
-                PostResponseDto.from(
-                        comment.getPost()
-                ),
+                comment.getPostId(),
                 comment.getWriter().getId(),
                 comment.getWriter().getName(),
+                parentCommentId,
                 comment.getChildCommentList()
                         .stream()
                         .map(CommentResponseDto::from)

--- a/src/main/java/net/causw/application/dto/PostCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/PostCreateRequestDto.java
@@ -1,0 +1,16 @@
+package net.causw.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostCreateRequestDto {
+    private String title;
+    private String content;
+    private String boardId;
+}

--- a/src/main/java/net/causw/application/dto/PostResponseDto.java
+++ b/src/main/java/net/causw/application/dto/PostResponseDto.java
@@ -2,10 +2,11 @@ package net.causw.application.dto;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import net.causw.adapter.persistence.Post;
 import net.causw.domain.model.PostDomainModel;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -14,37 +15,59 @@ public class PostResponseDto {
     private String title;
     private String content;
     private Boolean isDeleted;
+    private BoardResponseDto board;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-    private String boardId;
+    private List<CommentResponseDto> commentList;
 
     private PostResponseDto(
             String id,
             String title,
             String content,
             Boolean isDeleted,
+            BoardResponseDto board,
             LocalDateTime createdAt,
             LocalDateTime updatedAt,
-            String boardId
+            List<CommentResponseDto> commentList
     ) {
         this.id = id;
         this.title = title;
         this.content = content;
         this.isDeleted = isDeleted;
+        this.board = board;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
-        this.boardId = boardId;
+        this.commentList = commentList;
     }
 
-    public static PostResponseDto from(PostDomainModel post) {
+    public static PostResponseDto from(
+            PostDomainModel post
+    ) {
         return new PostResponseDto(
                 post.getId(),
                 post.getTitle(),
                 post.getContent(),
                 post.getIsDeleted(),
+                BoardResponseDto.from(post.getBoard()),
                 post.getCreatedAt(),
                 post.getUpdatedAt(),
-                post.getBoardId()
+                new ArrayList<>()
+        );
+    }
+
+    public static PostResponseDto from(
+            PostDomainModel post,
+            List<CommentResponseDto> commentList
+    ) {
+        return new PostResponseDto(
+                post.getId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getIsDeleted(),
+                BoardResponseDto.from(post.getBoard()),
+                post.getCreatedAt(),
+                post.getUpdatedAt(),
+                commentList
         );
     }
 }

--- a/src/main/java/net/causw/application/spi/BoardPort.java
+++ b/src/main/java/net/causw/application/spi/BoardPort.java
@@ -1,13 +1,15 @@
 package net.causw.application.spi;
 
 import net.causw.domain.model.BoardDomainModel;
-import net.causw.domain.model.CircleDomainModel;
 
 import java.util.Optional;
 
 public interface BoardPort {
     Optional<BoardDomainModel> findById(String id);
-    BoardDomainModel create(BoardDomainModel boardDomainModel, Optional<CircleDomainModel> circleDomainModel);
+
+    BoardDomainModel create(BoardDomainModel boardDomainModel);
+
     Optional<BoardDomainModel> update(String id, BoardDomainModel boardDomainModel);
+
     Optional<BoardDomainModel> delete(String id);
 }

--- a/src/main/java/net/causw/application/spi/CommentPort.java
+++ b/src/main/java/net/causw/application/spi/CommentPort.java
@@ -2,23 +2,11 @@ package net.causw.application.spi;
 
 import net.causw.domain.model.CommentDomainModel;
 import net.causw.domain.model.PostDomainModel;
-import net.causw.domain.model.UserDomainModel;
 
 import java.util.Optional;
 
 public interface CommentPort {
     Optional<CommentDomainModel> findById(String id);
 
-    CommentDomainModel create(
-            CommentDomainModel commentDomainModel,
-            UserDomainModel writer,
-            PostDomainModel post
-    );
-
-    CommentDomainModel create(
-            CommentDomainModel commentDomainModel,
-            UserDomainModel writer,
-            PostDomainModel post,
-            CommentDomainModel parentComment
-    );
+    CommentDomainModel create(CommentDomainModel commentDomainModel, PostDomainModel postDomainModel);
 }

--- a/src/main/java/net/causw/application/spi/PostPort.java
+++ b/src/main/java/net/causw/application/spi/PostPort.java
@@ -2,6 +2,10 @@ package net.causw.application.spi;
 
 import net.causw.domain.model.PostDomainModel;
 
+import java.util.Optional;
+
 public interface PostPort {
-    PostDomainModel findById(String id);
+    Optional<PostDomainModel> findById(String id);
+
+    PostDomainModel create(PostDomainModel postDomainModel);
 }

--- a/src/main/java/net/causw/domain/model/BoardDomainModel.java
+++ b/src/main/java/net/causw/domain/model/BoardDomainModel.java
@@ -29,7 +29,7 @@ public class BoardDomainModel {
     @NotNull(message = "Board state is null")
     private Boolean isDeleted;
 
-    private String circleId;
+    private CircleDomainModel circle;
 
     private BoardDomainModel(
             String id,
@@ -39,7 +39,7 @@ public class BoardDomainModel {
             List<String> modifyRoleList,
             List<String> readRoleList,
             Boolean isDeleted,
-            String circleId
+            CircleDomainModel circle
     ) {
         this.id = id;
         this.name = name;
@@ -48,7 +48,7 @@ public class BoardDomainModel {
         this.modifyRoleList = modifyRoleList;
         this.readRoleList = readRoleList;
         this.isDeleted = isDeleted;
-        this.circleId = circleId;
+        this.circle = circle;
     }
 
     public static BoardDomainModel of(
@@ -59,7 +59,7 @@ public class BoardDomainModel {
             List<String> modifyRoleList,
             List<String> readRoleList,
             Boolean isDeleted,
-            String circleId
+            CircleDomainModel circle
     ) {
         return new BoardDomainModel(
                 id,
@@ -69,7 +69,7 @@ public class BoardDomainModel {
                 modifyRoleList,
                 readRoleList,
                 isDeleted,
-                circleId
+                circle
         );
     }
 
@@ -79,7 +79,7 @@ public class BoardDomainModel {
             List<String> createRoleList,
             List<String> modifyRoleList,
             List<String> readRoleList,
-            String circleId
+            CircleDomainModel circle
     ) {
         return new BoardDomainModel(
                 null,
@@ -89,11 +89,11 @@ public class BoardDomainModel {
                 modifyRoleList,
                 readRoleList,
                 false,
-                circleId
+                circle
         );
     }
 
-    public Optional<String> getOptionalCircleId() {
-        return Optional.ofNullable(this.circleId);
+    public Optional<CircleDomainModel> getCircle() {
+        return Optional.ofNullable(this.circle);
     }
 }

--- a/src/main/java/net/causw/domain/model/CommentDomainModel.java
+++ b/src/main/java/net/causw/domain/model/CommentDomainModel.java
@@ -3,6 +3,7 @@ package net.causw.domain.model;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -13,9 +14,9 @@ public class CommentDomainModel {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private UserDomainModel writer;
-    private PostDomainModel post;
-    private CommentDomainModel parentComment; // 생성
-    private List<CommentDomainModel> childCommentList; // 조회
+    private String postId;
+    private CommentDomainModel parentComment;           // Write
+    private List<CommentDomainModel> childCommentList;  // Read
 
     private CommentDomainModel(
             String id,
@@ -24,45 +25,8 @@ public class CommentDomainModel {
             LocalDateTime createdAt,
             LocalDateTime updatedAt,
             UserDomainModel writer,
-            PostDomainModel post,
-            CommentDomainModel parentComment
-    ) {
-        this.id = id;
-        this.content = content;
-        this.isDeleted = isDeleted;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.writer = writer;
-        this.post = post;
-        this.parentComment = parentComment;
-    }
-
-    private CommentDomainModel(
-            String id,
-            String content,
-            Boolean isDeleted,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            UserDomainModel writer,
-            PostDomainModel post
-    ) {
-        this.id = id;
-        this.content = content;
-        this.isDeleted = isDeleted;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.writer = writer;
-        this.post = post;
-    }
-
-    private CommentDomainModel(
-            String id,
-            String content,
-            Boolean isDeleted,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            UserDomainModel writer,
-            PostDomainModel post,
+            String postId,
+            CommentDomainModel parentComment,
             List<CommentDomainModel> childCommentList
     ) {
         this.id = id;
@@ -71,10 +35,32 @@ public class CommentDomainModel {
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.writer = writer;
-        this.post = post;
+        this.postId = postId;
+        this.parentComment = parentComment;
         this.childCommentList = childCommentList;
     }
 
+    // Constructor with parent comment, without id (Used for write)
+    public static CommentDomainModel of(
+            String content,
+            UserDomainModel writer,
+            String postId,
+            CommentDomainModel parentComment
+    ) {
+        return new CommentDomainModel(
+                null,
+                content,
+                false,
+                null,
+                null,
+                writer,
+                postId,
+                parentComment,
+                new ArrayList<>()
+        );
+    }
+
+    // Constructor with parent comment and id (Used for read single comment)
     public static CommentDomainModel of(
             String id,
             String content,
@@ -82,7 +68,7 @@ public class CommentDomainModel {
             LocalDateTime createdAt,
             LocalDateTime updatedAt,
             UserDomainModel writer,
-            PostDomainModel post,
+            String postId,
             CommentDomainModel parentComment
     ) {
         return new CommentDomainModel(
@@ -92,11 +78,13 @@ public class CommentDomainModel {
                 createdAt,
                 updatedAt,
                 writer,
-                post,
-                parentComment
+                postId,
+                parentComment,
+                new ArrayList<>()
         );
     }
 
+    // Constructor without related comments (Used for read leaf comment)
     public static CommentDomainModel of(
             String id,
             String content,
@@ -104,7 +92,7 @@ public class CommentDomainModel {
             LocalDateTime createdAt,
             LocalDateTime updatedAt,
             UserDomainModel writer,
-            PostDomainModel post
+            String postId
     ) {
         return new CommentDomainModel(
                 id,
@@ -113,10 +101,13 @@ public class CommentDomainModel {
                 createdAt,
                 updatedAt,
                 writer,
-                post
+                postId,
+                null,
+                new ArrayList<>()
         );
     }
 
+    // Constructor with child comments (Used for read parent comment)
     public static CommentDomainModel of(
             String id,
             String content,
@@ -124,7 +115,7 @@ public class CommentDomainModel {
             LocalDateTime createdAt,
             LocalDateTime updatedAt,
             UserDomainModel writer,
-            PostDomainModel post,
+            String postId,
             List<CommentDomainModel> childCommentList
     ) {
         return new CommentDomainModel(
@@ -134,7 +125,8 @@ public class CommentDomainModel {
                 createdAt,
                 updatedAt,
                 writer,
-                post,
+                postId,
+                null,
                 childCommentList
         );
     }

--- a/src/main/java/net/causw/domain/model/PostDomainModel.java
+++ b/src/main/java/net/causw/domain/model/PostDomainModel.java
@@ -1,97 +1,87 @@
 package net.causw.domain.model;
 
 import lombok.Getter;
+import lombok.Setter;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Getter
+@Setter
 public class PostDomainModel {
     private String id;
+
+    @NotBlank(message = "Title is blank")
     private String title;
+
+    @NotBlank(message = "Content is blank")
     private String content;
+
+    @NotNull(message = "Writer is null")
+    private UserDomainModel writer;
     private Boolean isDeleted;
+    private BoardDomainModel board;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-    private String boardId;
-    private List<CommentDomainModel> commentList;
 
     private PostDomainModel(
             String id,
             String title,
             String content,
+            UserDomainModel writer,
             Boolean isDeleted,
+            BoardDomainModel board,
             LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            String boardId
+            LocalDateTime updatedAt
     ) {
         this.id = id;
         this.title = title;
         this.content = content;
+        this.writer = writer;
         this.isDeleted = isDeleted;
+        this.board = board;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
-        this.boardId = boardId;
-    }
-
-    private PostDomainModel(
-            String id,
-            String title,
-            String content,
-            Boolean isDeleted,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            String boardId,
-            List<CommentDomainModel> commentList) {
-        this.id = id;
-        this.title = title;
-        this.content = content;
-        this.isDeleted = isDeleted;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.boardId = boardId;
-        this.commentList = commentList;
     }
 
     public static PostDomainModel of(
             String id,
             String title,
             String content,
+            UserDomainModel writer,
             Boolean isDeleted,
+            BoardDomainModel board,
             LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            String boardId
+            LocalDateTime updatedAt
     ) {
         return new PostDomainModel(
                 id,
                 title,
                 content,
+                writer,
                 isDeleted,
+                board,
                 createdAt,
-                updatedAt,
-                boardId
+                updatedAt
         );
     }
 
     public static PostDomainModel of(
-            String id,
             String title,
             String content,
-            Boolean isDeleted,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            String boardId,
-            List<CommentDomainModel> commentList
+            UserDomainModel writer,
+            BoardDomainModel board
     ) {
         return new PostDomainModel(
-                id,
+                null,
                 title,
                 content,
-                isDeleted,
-                createdAt,
-                updatedAt,
-                boardId,
-                commentList
+                writer,
+                false,
+                board,
+                null,
+                null
         );
     }
 }

--- a/src/test/groovy/net/causw/application/BoardServiceTest.groovy
+++ b/src/test/groovy/net/causw/application/BoardServiceTest.groovy
@@ -84,8 +84,8 @@ class BoardServiceTest extends Specification {
 
         this.userPort.findById("test") >> Optional.of(creatorUserDomainModel)
         this.circlePort.findById("test") >> Optional.of(circleDomainModel)
-        this.boardPort.create((BoardDomainModel) this.mockBoardDomainModel, Optional.ofNullable(null)) >> this.mockBoardDomainModel
-        this.boardPort.create((BoardDomainModel) this.mockBoardDomainModel, Optional.ofNullable(circleDomainModel)) >> this.mockBoardDomainModel
+        this.boardPort.create((BoardDomainModel) this.mockBoardDomainModel) >> this.mockBoardDomainModel
+        this.boardPort.create((BoardDomainModel) this.mockBoardDomainModel) >> this.mockBoardDomainModel
 
         when: "create board without circle"
         PowerMockito.mockStatic(BoardDomainModel.class)
@@ -109,7 +109,6 @@ class BoardServiceTest extends Specification {
         when: "create board with circle"
         mockBoardCreateRequestDto.setCircleId("test")
         creatorUserDomainModel.setRole(Role.LEADER_CIRCLE)
-        (BoardDomainModel) this.mockBoardDomainModel.setCircleId("test")
         PowerMockito.mockStatic(BoardDomainModel.class)
         PowerMockito.when(BoardDomainModel.of(
                 "test",
@@ -117,7 +116,7 @@ class BoardServiceTest extends Specification {
                 Arrays.asList("PRESIDENT", "COUNCIL"),
                 Arrays.asList("PRESIDENT", "COUNCIL"),
                 Arrays.asList("PRESIDENT", "COUNCIL"),
-                "test"
+                circleDomainModel
         )).thenReturn((BoardDomainModel) this.mockBoardDomainModel)
         boardResponseDto = this.boardService.create("test", mockBoardCreateRequestDto)
 
@@ -301,7 +300,7 @@ class BoardServiceTest extends Specification {
 
         this.userPort.findById("test") >> Optional.of(creator)
         this.circlePort.findById("test") >> Optional.of(mockCircleDomainModel)
-        this.boardPort.create((BoardDomainModel) this.mockBoardDomainModel, Optional.ofNullable(mockCircleDomainModel)) >> this.mockBoardDomainModel
+        this.boardPort.create((BoardDomainModel) this.mockBoardDomainModel) >> this.mockBoardDomainModel
 
         when: "invalid leader id"
         creator.setId("invalid_test")
@@ -319,8 +318,7 @@ class BoardServiceTest extends Specification {
                 "test_description",
                 Arrays.asList("PRESIDENT", "COUNCIL"),
                 Arrays.asList("PRESIDENT", "COUNCIL"),
-                Arrays.asList("PRESIDENT", "COUNCIL"),
-                null
+                Arrays.asList("PRESIDENT", "COUNCIL")
         )
 
         def updater = UserDomainModel.of(
@@ -382,9 +380,8 @@ class BoardServiceTest extends Specification {
         }
 
         when: "update board with circle"
-        mockBoardUpdateRequestDto.setCircleId("test")
-        this.mockBoardDomainModel.setCircleId("test")
-        mockUpdatedBoardDomainModel.setCircleId("test")
+        this.mockBoardDomainModel.setCircle(mockCircleDomainModel)
+        mockUpdatedBoardDomainModel.setCircle(mockCircleDomainModel)
         updater.setRole(Role.LEADER_CIRCLE)
         PowerMockito.mockStatic(BoardDomainModel.class)
         PowerMockito.when(BoardDomainModel.of(
@@ -395,7 +392,7 @@ class BoardServiceTest extends Specification {
                 mockBoardUpdateRequestDto.getModifyRoleList(),
                 mockBoardUpdateRequestDto.getReadRoleList(),
                 false,
-                "test"
+                mockCircleDomainModel
         )).thenReturn(mockUpdatedBoardDomainModel)
         boardResponseDto = this.boardService.update("test", "test", mockBoardUpdateRequestDto)
 
@@ -415,8 +412,7 @@ class BoardServiceTest extends Specification {
                 "test_description",
                 Arrays.asList("PRESIDENT", "COUNCIL"),
                 Arrays.asList("PRESIDENT", "COUNCIL"),
-                Arrays.asList("PRESIDENT", "COUNCIL"),
-                null
+                Arrays.asList("PRESIDENT", "COUNCIL")
         )
 
         def updater = UserDomainModel.of(
@@ -450,8 +446,7 @@ class BoardServiceTest extends Specification {
                 "test_description",
                 Arrays.asList("PRESIDENT", "COUNCIL"),
                 Arrays.asList("PRESIDENT", "COUNCIL"),
-                Arrays.asList("PRESIDENT", "COUNCIL"),
-                null
+                Arrays.asList("PRESIDENT", "COUNCIL")
         )
 
         def updater = UserDomainModel.of(
@@ -560,8 +555,7 @@ class BoardServiceTest extends Specification {
                 "test_description",
                 Arrays.asList("PRESIDENT", "COUNCIL"),
                 Arrays.asList("PRESIDENT", "COUNCIL"),
-                Arrays.asList("PRESIDENT", "COUNCIL"),
-                null
+                Arrays.asList("PRESIDENT", "COUNCIL")
         )
 
         def updater = UserDomainModel.of(
@@ -595,8 +589,7 @@ class BoardServiceTest extends Specification {
                 "test_description",
                 Arrays.asList("PRESIDENT", "COUNCIL"),
                 Arrays.asList("PRESIDENT", "COUNCIL"),
-                Arrays.asList("PRESIDENT", "COUNCIL"),
-                "test"
+                Arrays.asList("PRESIDENT", "COUNCIL")
         )
 
         def updater = UserDomainModel.of(
@@ -611,7 +604,7 @@ class BoardServiceTest extends Specification {
                 UserState.WAIT
         )
 
-        def mockCircleFullDto = CircleDomainModel.of(
+        def mockCircleDomainModel = CircleDomainModel.of(
                 "test",
                 "test",
                 null,
@@ -620,9 +613,9 @@ class BoardServiceTest extends Specification {
                 updater
         )
 
-        this.mockBoardDomainModel.setCircleId("test")
+        this.mockBoardDomainModel.setCircle(mockCircleDomainModel)
         this.userPort.findById("test") >> Optional.of(updater)
-        this.circlePort.findById("test") >> Optional.of(mockCircleFullDto)
+        this.circlePort.findById("test") >> Optional.of(mockCircleDomainModel)
         this.boardPort.findById("test") >> Optional.of(this.mockBoardDomainModel)
 
         when: "invalid leader id"
@@ -658,14 +651,14 @@ class BoardServiceTest extends Specification {
         )
 
         def mockDeletedBoardDomainModel = BoardDomainModel.of(
-                (String)this.mockBoardDomainModel.getId(),
-                (String)this.mockBoardDomainModel.getName(),
-                (String)this.mockBoardDomainModel.getDescription(),
-                (List<String>)this.mockBoardDomainModel.getCreateRoleList(),
-                (List<String>)this.mockBoardDomainModel.getModifyRoleList(),
-                (List<String>)this.mockBoardDomainModel.getReadRoleList(),
+                (String) this.mockBoardDomainModel.getId(),
+                (String) this.mockBoardDomainModel.getName(),
+                (String) this.mockBoardDomainModel.getDescription(),
+                (List<String>) this.mockBoardDomainModel.getCreateRoleList(),
+                (List<String>) this.mockBoardDomainModel.getModifyRoleList(),
+                (List<String>) this.mockBoardDomainModel.getReadRoleList(),
                 true,
-                (String)this.mockBoardDomainModel.getCircleId()
+                mockCircleDomainModel
         )
 
         this.userPort.findById("test") >> Optional.of(deleter)
@@ -683,8 +676,8 @@ class BoardServiceTest extends Specification {
         }
 
         when: "update board with circle"
-        this.mockBoardDomainModel.setCircleId("test")
-        mockDeletedBoardDomainModel.setCircleId("test")
+        this.mockBoardDomainModel.setCircle(mockCircleDomainModel)
+        mockDeletedBoardDomainModel.setCircle(mockCircleDomainModel)
         deleter.setRole(Role.LEADER_CIRCLE)
         boardResponseDto = this.boardService.delete("test", "test")
 
@@ -771,7 +764,7 @@ class BoardServiceTest extends Specification {
                 deleter
         )
 
-        this.mockBoardDomainModel.setCircleId("test")
+        this.mockBoardDomainModel.setCircle(mockCircleDomainModel)
         this.userPort.findById("test") >> Optional.of(deleter)
         this.circlePort.findById("test") >> Optional.of(mockCircleDomainModel)
         this.boardPort.findById("test") >> Optional.of(this.mockBoardDomainModel)

--- a/src/test/groovy/net/causw/application/CircleServiceTest.groovy
+++ b/src/test/groovy/net/causw/application/CircleServiceTest.groovy
@@ -114,7 +114,7 @@ class CircleServiceTest extends Specification {
         this.circlePort.findByName("test") >> Optional.ofNullable(null)
 
         this.userPort.updateRole("test", Role.LEADER_CIRCLE) >> Optional.of(this.leader)
-        this.circlePort.create((CircleDomainModel) this.mockCircleDomainModel, (UserDomainModel) this.leader) >> this.mockCircleDomainModel
+        this.circlePort.create((CircleDomainModel) this.mockCircleDomainModel) >> this.mockCircleDomainModel
         this.circleMemberPort.create((UserDomainModel) this.leader, (CircleDomainModel) this.mockCircleDomainModel) >> this.mockCircleMemberDomainModel
         this.circleMemberPort.updateStatus("test", CircleMemberStatus.MEMBER) >> Optional.of(this.mockCircleMemberDomainModel)
 


### PR DESCRIPTION
## Description
Board, Post, Comment의 리팩토링 수행

## Changes detail
- Comment -> Post -> Board -> Circle 순서로 이어지는 관계에서 성능을 고려하여 Domain Level에서 Comment - Post 사이의 연관 관계를 잘라냈습니다 (CommentDomainModel에서는 Post Id만 보유하도록)
- ResponseDto와 DomainModel에 대한 전반적인 수정을 진행했습니다.
- Comment, Post의 일부 API에 대한 validation은 리팩토링 PR의 규모가 너무 커지는 것 같아 TODO로 남겨두었습니다. 다음 PR에서 TC와 함께 구현하도록 하겠습니다.

### Checklist

- [ ] Test case
- [x] End of work
