### PR TITLE
Fix/board return createlist

### DIFF
--- a/src/main/java/net/causw/adapter/web/BoardController.java
+++ b/src/main/java/net/causw/adapter/web/BoardController.java
@@ -30,8 +30,8 @@ public class BoardController {
 
     @GetMapping
     @ResponseStatus(value = HttpStatus.OK)
-    public List<BoardResponseDto> findAll() {
-        return this.boardService.findAll();
+    public List<BoardResponseDto> findAll(@AuthenticationPrincipal String userId) {
+        return this.boardService.findAll(userId);
     }
 
     @GetMapping(params = "circleId")
@@ -45,23 +45,29 @@ public class BoardController {
 
     @PostMapping
     @ResponseStatus(value = HttpStatus.CREATED)
-    public BoardResponseDto create(@AuthenticationPrincipal String creatorId,
-                                   @RequestBody BoardCreateRequestDto boardCreateRequestDto) {
+    public BoardResponseDto create(
+            @AuthenticationPrincipal String creatorId,
+            @RequestBody BoardCreateRequestDto boardCreateRequestDto
+    ) {
         return this.boardService.create(creatorId, boardCreateRequestDto);
     }
 
     @PutMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.OK)
-    public BoardResponseDto update(@AuthenticationPrincipal String updaterId,
-                                   @PathVariable String id,
-                                   @RequestBody BoardUpdateRequestDto boardUpdateRequestDto) {
+    public BoardResponseDto update(
+            @AuthenticationPrincipal String updaterId,
+            @PathVariable String id,
+            @RequestBody BoardUpdateRequestDto boardUpdateRequestDto
+    ) {
         return this.boardService.update(updaterId, id, boardUpdateRequestDto);
     }
 
     @DeleteMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.OK)
-    public BoardResponseDto delete(@AuthenticationPrincipal String deleterId,
-                                   @PathVariable String id) {
+    public BoardResponseDto delete(
+            @AuthenticationPrincipal String deleterId,
+            @PathVariable String id
+    ) {
         return this.boardService.delete(deleterId, id);
     }
 }

--- a/src/main/java/net/causw/application/PostService.java
+++ b/src/main/java/net/causw/application/PostService.java
@@ -66,6 +66,13 @@ public class PostService {
                 )
         );
 
+        UserDomainModel userDomainModel = this.userPort.findById(userId).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        "Invalid user id"
+                )
+        );
+
         validatorBucket
                 .consistOf(TargetIsDeletedValidator.of(postDomainModel.getIsDeleted()));
 
@@ -93,6 +100,7 @@ public class PostService {
         // TODO : GHJANG : PostResponseDto에 댓글 갯수 포함 필요
         return PostResponseDto.from(
                 postDomainModel,
+                userDomainModel,
                 this.commentPort.findByPostId(id)
                         .stream()
                         .map(CommentResponseDto::from)
@@ -173,7 +181,7 @@ public class PostService {
                         creatorDomainModel.getRole(),
                         boardDomainModel.getCreateRoleList()
                                 .stream()
-                                .map(Role::valueOf)
+                                .map(Role::of)
                                 .collect(Collectors.toList())
                 ));
 
@@ -199,6 +207,6 @@ public class PostService {
                 .consistOf(ConstraintValidator.of(postDomainModel, this.validator))
                 .validate();
 
-        return PostResponseDto.from(this.postPort.create(postDomainModel));
+        return PostResponseDto.from(this.postPort.create(postDomainModel), creatorDomainModel);
     }
 }

--- a/src/main/java/net/causw/application/dto/BoardResponseDto.java
+++ b/src/main/java/net/causw/application/dto/BoardResponseDto.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import net.causw.domain.model.BoardDomainModel;
 import net.causw.domain.model.CircleDomainModel;
+import net.causw.domain.model.Role;
 
 import java.util.List;
 
@@ -17,6 +18,7 @@ public class BoardResponseDto {
     private String description;
     private List<String> createRoleList;
     private String category;
+    private boolean writable;
     private Boolean isDeleted;
 
     private String circleId;
@@ -28,6 +30,7 @@ public class BoardResponseDto {
             String description,
             List<String> createRoleList,
             String category,
+            boolean writable,
             Boolean isDeleted,
             String circleId,
             String circleName
@@ -37,12 +40,13 @@ public class BoardResponseDto {
         this.description = description;
         this.createRoleList = createRoleList;
         this.category = category;
+        this.writable = writable;
         this.isDeleted = isDeleted;
         this.circleId = circleId;
         this.circleName = circleName;
     }
 
-    public static BoardResponseDto from(BoardDomainModel boardDomainModel) {
+    public static BoardResponseDto from(BoardDomainModel boardDomainModel, Role userRole) {
         String circleId = boardDomainModel.getCircle().map(CircleDomainModel::getId).orElse(null);
         String circleName = boardDomainModel.getCircle().map(CircleDomainModel::getName).orElse(null);
 
@@ -52,6 +56,7 @@ public class BoardResponseDto {
                 boardDomainModel.getDescription(),
                 boardDomainModel.getCreateRoleList(),
                 boardDomainModel.getCategory(),
+                boardDomainModel.getCreateRoleList().contains(userRole.getValue()),
                 boardDomainModel.getIsDeleted(),
                 circleId,
                 circleName

--- a/src/main/java/net/causw/application/dto/PostResponseDto.java
+++ b/src/main/java/net/causw/application/dto/PostResponseDto.java
@@ -3,6 +3,7 @@ package net.causw.application.dto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.causw.domain.model.PostDomainModel;
+import net.causw.domain.model.UserDomainModel;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -41,14 +42,15 @@ public class PostResponseDto {
     }
 
     public static PostResponseDto from(
-            PostDomainModel post
+            PostDomainModel post,
+            UserDomainModel user
     ) {
         return new PostResponseDto(
                 post.getId(),
                 post.getTitle(),
                 post.getContent(),
                 post.getIsDeleted(),
-                BoardResponseDto.from(post.getBoard()),
+                BoardResponseDto.from(post.getBoard(), user.getRole()),
                 post.getCreatedAt(),
                 post.getUpdatedAt(),
                 new ArrayList<>()
@@ -57,6 +59,7 @@ public class PostResponseDto {
 
     public static PostResponseDto from(
             PostDomainModel post,
+            UserDomainModel user,
             List<CommentResponseDto> commentList
     ) {
         return new PostResponseDto(
@@ -64,7 +67,7 @@ public class PostResponseDto {
                 post.getTitle(),
                 post.getContent(),
                 post.getIsDeleted(),
-                BoardResponseDto.from(post.getBoard()),
+                BoardResponseDto.from(post.getBoard(), user.getRole()),
                 post.getCreatedAt(),
                 post.getUpdatedAt(),
                 commentList

--- a/src/main/java/net/causw/domain/exceptions/ErrorCode.java
+++ b/src/main/java/net/causw/domain/exceptions/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     AWAITING_STATUS(4008),
     INVALID_STUDENT_ID(4009),
     TIME_NOT_PASSED(4010),
+    INVALID_REQUEST_ROLE(4011),
 
     /**
      * 401 Unauthorized

--- a/src/main/java/net/causw/domain/model/BoardDomainModel.java
+++ b/src/main/java/net/causw/domain/model/BoardDomainModel.java
@@ -5,8 +5,10 @@ import lombok.Setter;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -73,6 +75,25 @@ public class BoardDomainModel {
             String category,
             CircleDomainModel circle
     ) {
+        if (createRoleList != null) {
+            if (createRoleList.isEmpty()) {
+                createRoleList.addAll(
+                        Arrays.stream(Role.values())
+                                .map(Role::getValue)
+                                .collect(Collectors.toList())
+                );
+                createRoleList.remove(Role.NONE.getValue());
+            } else {
+                createRoleList = createRoleList
+                        .stream()
+                        .map(Role::of)
+                        .map(Role::getValue)
+                        .collect(Collectors.toList());
+
+                createRoleList.add(Role.ADMIN.getValue());
+            }
+        }
+
         return new BoardDomainModel(
                 null,
                 name,

--- a/src/main/java/net/causw/domain/model/Role.java
+++ b/src/main/java/net/causw/domain/model/Role.java
@@ -1,6 +1,10 @@
 package net.causw.domain.model;
 
 import lombok.Getter;
+import net.causw.domain.exceptions.BadRequestException;
+import net.causw.domain.exceptions.ErrorCode;
+
+import java.util.Arrays;
 
 @Getter
 public enum Role {
@@ -21,5 +25,17 @@ public enum Role {
 
     Role(String value) {
         this.value = value;
+    }
+
+    public static Role of(String value) {
+        return Arrays.stream(values())
+                .filter(v -> value.equalsIgnoreCase(v.value))
+                .findFirst()
+                .orElseThrow(
+                        () -> new BadRequestException(
+                                ErrorCode.INVALID_REQUEST_ROLE,
+                                String.format("'%s' is invalid : not supported", value)
+                        )
+                );
     }
 }

--- a/src/test/groovy/net/causw/application/CommentServiceTest.groovy
+++ b/src/test/groovy/net/causw/application/CommentServiceTest.groovy
@@ -52,6 +52,7 @@ class CommentServiceTest extends Specification {
                 "test board id",
                 "test board description",
                 Arrays.asList("PRESIDENT"),
+                "test category",
                 false,
                 null
         )

--- a/src/test/groovy/net/causw/application/UserServiceTest.groovy
+++ b/src/test/groovy/net/causw/application/UserServiceTest.groovy
@@ -1,23 +1,13 @@
 package net.causw.application
 
-import net.causw.application.dto.CircleResponseDto
-import net.causw.application.dto.UserCreateRequestDto
-import net.causw.application.dto.UserPasswordUpdateRequestDto
-import net.causw.application.dto.UserResponseDto
-import net.causw.application.dto.UserUpdateRequestDto
-import net.causw.application.dto.UserUpdateRoleRequestDto
+import net.causw.application.dto.*
 import net.causw.application.spi.CircleMemberPort
 import net.causw.application.spi.CirclePort
 import net.causw.application.spi.UserPort
 import net.causw.config.JwtTokenProvider
 import net.causw.domain.exceptions.BadRequestException
 import net.causw.domain.exceptions.UnauthorizedException
-import net.causw.domain.model.CircleDomainModel
-import net.causw.domain.model.CircleMemberDomainModel
-import net.causw.domain.model.CircleMemberStatus
-import net.causw.domain.model.Role
-import net.causw.domain.model.UserDomainModel
-import net.causw.domain.model.UserState
+import net.causw.domain.model.*
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.powermock.api.mockito.PowerMockito
@@ -190,7 +180,9 @@ class UserServiceTest extends Specification {
                 CircleMemberStatus.MEMBER,
                 mockCircleDomainModel,
                 "test1",
-                "test"
+                "test",
+                null,
+                null
         )
 
         def userUpdateRoleRequestDto = new UserUpdateRoleRequestDto(Role.COUNCIL)
@@ -406,12 +398,12 @@ class UserServiceTest extends Specification {
                 id,
                 userUpdateRequestDto.getEmail(),
                 userUpdateRequestDto.getName(),
-                (String)this.mockUserDomainModel.getPassword(),
+                (String) this.mockUserDomainModel.getPassword(),
                 userUpdateRequestDto.getStudentId(),
                 userUpdateRequestDto.getAdmissionYear(),
-                (Role)this.mockUserDomainModel.getRole(),
-                (String)this.mockUserDomainModel.getProfileImage(),
-                (UserState)this.mockUserDomainModel.getState()
+                (Role) this.mockUserDomainModel.getRole(),
+                (String) this.mockUserDomainModel.getProfileImage(),
+                (UserState) this.mockUserDomainModel.getState()
         )
 
         PowerMockito.mockStatic(UserDomainModel.class)
@@ -419,12 +411,12 @@ class UserServiceTest extends Specification {
                 id,
                 userUpdateRequestDto.getEmail(),
                 userUpdateRequestDto.getName(),
-                (String)this.mockUserDomainModel.getPassword(),
+                (String) this.mockUserDomainModel.getPassword(),
                 userUpdateRequestDto.getStudentId(),
                 userUpdateRequestDto.getAdmissionYear(),
-                (Role)this.mockUserDomainModel.getRole(),
-                (String)this.mockUserDomainModel.getProfileImage(),
-                (UserState)this.mockUserDomainModel.getState()
+                (Role) this.mockUserDomainModel.getRole(),
+                (String) this.mockUserDomainModel.getProfileImage(),
+                (UserState) this.mockUserDomainModel.getState()
         )).thenReturn(mockUpdatedUserDomainModel)
 
         this.userPort.findById(id) >> Optional.of(this.mockUserDomainModel)
@@ -458,12 +450,12 @@ class UserServiceTest extends Specification {
                 id,
                 userUpdateRequestDto.getEmail(),
                 userUpdateRequestDto.getName(),
-                (String)this.mockUserDomainModel.getPassword(),
+                (String) this.mockUserDomainModel.getPassword(),
                 userUpdateRequestDto.getStudentId(),
                 userUpdateRequestDto.getAdmissionYear(),
-                (Role)this.mockUserDomainModel.getRole(),
-                (String)this.mockUserDomainModel.getProfileImage(),
-                (UserState)this.mockUserDomainModel.getState()
+                (Role) this.mockUserDomainModel.getRole(),
+                (String) this.mockUserDomainModel.getProfileImage(),
+                (UserState) this.mockUserDomainModel.getState()
         )
 
         this.userPort.findById(id) >> Optional.of(this.mockUserDomainModel)
@@ -506,9 +498,9 @@ class UserServiceTest extends Specification {
                 "20210000",
                 2021,
                 null,
-        )).thenReturn((UserDomainModel)this.mockUserDomainModel)
+        )).thenReturn((UserDomainModel) this.mockUserDomainModel)
 
-        this.userPort.create((UserDomainModel)this.mockUserDomainModel) >> this.mockUserDomainModel
+        this.userPort.create((UserDomainModel) this.mockUserDomainModel) >> this.mockUserDomainModel
         this.userPort.findByEmail("test@cau.ac.kr") >> Optional.ofNullable(null)
 
         when:
@@ -516,7 +508,7 @@ class UserServiceTest extends Specification {
 
         then:
         userResponseDto instanceof UserResponseDto
-        with (userResponseDto) {
+        with(userResponseDto) {
             getEmail() == this.mockUserDomainModel.getEmail()
             getName() == this.mockUserDomainModel.getName()
             getStudentId() == this.mockUserDomainModel.getStudentId()
@@ -762,12 +754,12 @@ class UserServiceTest extends Specification {
         )
 
         def mockUpdatedUserDomainModel = UserDomainModel.of(
-                (String)this.mockUserDomainModel.getId(),
-                (String)this.mockUserDomainModel.getEmail(),
-                (String)this.mockUserDomainModel.getName(),
+                (String) this.mockUserDomainModel.getId(),
+                (String) this.mockUserDomainModel.getEmail(),
+                (String) this.mockUserDomainModel.getName(),
                 "test12345!",
-                (String)this.mockUserDomainModel.getStudentId(),
-                (Integer)this.mockUserDomainModel.getAdmissionYear(),
+                (String) this.mockUserDomainModel.getStudentId(),
+                (Integer) this.mockUserDomainModel.getAdmissionYear(),
                 Role.PRESIDENT,
                 null,
                 UserState.WAIT
@@ -849,12 +841,12 @@ class UserServiceTest extends Specification {
         this.mockUserDomainModel.setState(UserState.ACTIVE)
 
         def mockUpdatedUserDomainModel = UserDomainModel.of(
-                (String)this.mockUserDomainModel.getId(),
-                (String)this.mockUserDomainModel.getEmail(),
-                (String)this.mockUserDomainModel.getName(),
+                (String) this.mockUserDomainModel.getId(),
+                (String) this.mockUserDomainModel.getEmail(),
+                (String) this.mockUserDomainModel.getName(),
                 "test12345!",
-                (String)this.mockUserDomainModel.getStudentId(),
-                (Integer)this.mockUserDomainModel.getAdmissionYear(),
+                (String) this.mockUserDomainModel.getStudentId(),
+                (Integer) this.mockUserDomainModel.getAdmissionYear(),
                 Role.NONE,
                 null,
                 UserState.INACTIVE
@@ -886,7 +878,9 @@ class UserServiceTest extends Specification {
                 CircleMemberStatus.MEMBER,
                 circle,
                 "test",
-                "test"
+                "test",
+                null,
+                null
         )
 
         this.userPort.findById("test") >> Optional.of(this.mockUserDomainModel)
@@ -912,12 +906,12 @@ class UserServiceTest extends Specification {
         this.mockUserDomainModel.setState(UserState.ACTIVE)
 
         def mockUpdatedUserDomainModel = UserDomainModel.of(
-                (String)this.mockUserDomainModel.getId(),
-                (String)this.mockUserDomainModel.getEmail(),
-                (String)this.mockUserDomainModel.getName(),
+                (String) this.mockUserDomainModel.getId(),
+                (String) this.mockUserDomainModel.getEmail(),
+                (String) this.mockUserDomainModel.getName(),
                 "test12345!",
-                (String)this.mockUserDomainModel.getStudentId(),
-                (Integer)this.mockUserDomainModel.getAdmissionYear(),
+                (String) this.mockUserDomainModel.getStudentId(),
+                (Integer) this.mockUserDomainModel.getAdmissionYear(),
                 Role.PRESIDENT,
                 null,
                 UserState.INACTIVE
@@ -970,7 +964,9 @@ class UserServiceTest extends Specification {
                 CircleMemberStatus.MEMBER,
                 circle,
                 "test",
-                "test"
+                "test",
+                null,
+                null
         )
 
         this.userPort.findById("test") >> Optional.of(this.mockUserDomainModel)
@@ -1023,7 +1019,7 @@ class UserServiceTest extends Specification {
         )
 
         this.userPort.findById("test1") >> Optional.of(mockApiCallUser)
-        this.userPort.findByName("test") >> List.of((UserDomainModel)this.mockUserDomainModel, mockApiCallUser)
+        this.userPort.findByName("test") >> List.of((UserDomainModel) this.mockUserDomainModel, mockApiCallUser)
 
         when:
         this.userService.findByName("test1", "test")
@@ -1068,7 +1064,7 @@ class UserServiceTest extends Specification {
         )
 
         this.userPort.findById("test1") >> Optional.of(mockApiCallUser)
-        this.userPort.findByRole(Role.PRESIDENT) >> List.of((UserDomainModel)this.mockUserDomainModel, mockApiCallUser)
+        this.userPort.findByRole(Role.PRESIDENT) >> List.of((UserDomainModel) this.mockUserDomainModel, mockApiCallUser)
 
         when:
         this.userService.findByRole("test1", Role.PRESIDENT)


### PR DESCRIPTION
## Related issue
- #143 
- #146 
- #147

## Description
CreateRoleList을 기반으로 요청 사용자가 글을 작성할 수 있는지 여부를 체크하는 로직을 추가했습니다.

## Changes detail
- 현재는 create에 대한 API와 같은 ResponseDto를 쓰고 있기 때문에 우선은 필드를 추가하고 overriding을 통해 구현을 해두었습니다. 추후에 리팩토링이 필요해 보입니다.
- findById의 경우 #144 에서 삭제될 API이기 때문에, 우선 아무 값이나 넣어두었습니다.
- TC는 역시 추후 구현하겠습니다.

### Checklist

- [ ] Test case
- [x] End of work
