### PR TITLE
feat: post find deleted & restore impl

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/PostRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/PostRepository.java
@@ -5,11 +5,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, String> {
     Page<Post> findAllByBoard_IdAndIsDeletedIsFalseOrderByCreatedAtDesc(String boardId, Pageable pageable);
+    Page<Post> findAllByBoard_IdAndIsDeletedIsTrueOrderByCreatedAtDesc(String boardId, Pageable pageable);
     Optional<Post> findTop1ByBoard_IdAndIsDeletedIsFalseOrderByCreatedAtDesc(String boardId);
 }

--- a/src/main/java/net/causw/adapter/persistence/port/PostPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/PostPortImpl.java
@@ -49,6 +49,7 @@ public class PostPortImpl extends DomainModelMapper implements PostPort {
                 srcPost -> {
                     srcPost.setTitle(postDomainModel.getTitle());
                     srcPost.setContent(postDomainModel.getContent());
+                    srcPost.setIsDeleted(postDomainModel.getIsDeleted());
 
                     return this.entityToDomainModel(this.postRepository.save(srcPost));
                 }
@@ -64,6 +65,12 @@ public class PostPortImpl extends DomainModelMapper implements PostPort {
     @Override
     public Page<PostDomainModel> findAll(String boardId, Integer pageNum, Integer pageSize) {
         return this.postRepository.findAllByBoard_IdAndIsDeletedIsFalseOrderByCreatedAtDesc(boardId, this.pageableFactory.create(pageNum, pageSize))
+                .map(this::entityToDomainModel);
+    }
+
+    @Override
+    public Page<PostDomainModel> findDeleted(String boardId, Integer pageNum) {
+        return this.postRepository.findAllByBoard_IdAndIsDeletedIsTrueOrderByCreatedAtDesc(boardId, this.pageableFactory.create(pageNum))
                 .map(this::entityToDomainModel);
     }
 

--- a/src/main/java/net/causw/adapter/web/PostController.java
+++ b/src/main/java/net/causw/adapter/web/PostController.java
@@ -1,12 +1,10 @@
 package net.causw.adapter.web;
 
 import net.causw.application.PostService;
-import net.causw.application.dto.PostAllResponseDto;
 import net.causw.application.dto.PostAllWithBoardResponseDto;
 import net.causw.application.dto.PostCreateRequestDto;
 import net.causw.application.dto.PostResponseDto;
 import net.causw.application.dto.PostUpdateRequestDto;
-import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -43,9 +41,10 @@ public class PostController {
     public PostAllWithBoardResponseDto findAll(
             @AuthenticationPrincipal String requestUserId,
             @RequestParam String boardId,
-            @RequestParam(defaultValue = "0") Integer pageNum
+            @RequestParam(defaultValue = "0") Integer pageNum,
+            @RequestParam(defaultValue = "false") Boolean isDeleted
     ) {
-        return this.postService.findAll(requestUserId, boardId, pageNum);
+        return this.postService.findAll(requestUserId, boardId, pageNum, isDeleted);
     }
 
     @GetMapping("/app/notice")
@@ -85,6 +84,18 @@ public class PostController {
                 requestUserId,
                 id,
                 postUpdateRequestDto
+        );
+    }
+
+    @PutMapping(value = "/restore/{id}")
+    @ResponseStatus(value = HttpStatus.OK)
+    public PostResponseDto restore(
+            @AuthenticationPrincipal String requestUserId,
+            @PathVariable String id
+    ) {
+        return this.postService.restore(
+                requestUserId,
+                id
         );
     }
 }

--- a/src/main/java/net/causw/application/spi/PostPort.java
+++ b/src/main/java/net/causw/application/spi/PostPort.java
@@ -18,5 +18,7 @@ public interface PostPort {
 
     Page<PostDomainModel> findAll(String boardId, Integer pageNum, Integer pageSize);
 
+    Page<PostDomainModel> findDeleted(String boardId, Integer pageNum);
+
     Optional<PostDomainModel> findLatest(String boardId);
 }

--- a/src/test/groovy/net/causw/application/PostServiceTest.groovy
+++ b/src/test/groovy/net/causw/application/PostServiceTest.groovy
@@ -188,7 +188,7 @@ class PostServiceTest extends Specification {
         this.postPort.findAll(((BoardDomainModel) this.mockBoardDomainModel).getId(), 0) >> new PageImpl<PostDomainModel>(List.of((PostDomainModel)this.mockPostDomainModel))
 
         when: "post findById without circle"
-        def postFind = this.postService.findAll("test user id", "test board id", 0)
+        def postFind = this.postService.findAll("test user id", "test board id", 0, false)
 
         then:
         postFind instanceof PostAllWithBoardResponseDto
@@ -198,7 +198,7 @@ class PostServiceTest extends Specification {
 
         when: "post findById with circle"
         ((BoardDomainModel) this.mockBoardDomainModel).setCircle((CircleDomainModel) this.mockCircleDomainModel)
-        postFind = this.postService.findAll("test user id", "test board id", 0)
+        postFind = this.postService.findAll("test user id", "test board id", 0, false)
 
         then:
         postFind instanceof PostAllWithBoardResponseDto
@@ -230,7 +230,7 @@ class PostServiceTest extends Specification {
 
         when:
         this.mockBoardDomainModel.setIsDeleted(true)
-        this.postService.findAll("test user id", "test board id", 0)
+        this.postService.findAll("test user id", "test board id", 0, false)
 
         then:
         thrown(BadRequestException)
@@ -270,7 +270,7 @@ class PostServiceTest extends Specification {
 
         when: "bad request case - leave"
         ((BoardDomainModel) this.mockBoardDomainModel).setCircle((CircleDomainModel) this.mockCircleDomainModel)
-        this.postService.findAll("test user id", "test board id", 0)
+        this.postService.findAll("test user id", "test board id", 0, false)
 
         then:
         thrown(BadRequestException)
@@ -278,7 +278,7 @@ class PostServiceTest extends Specification {
         when: "unauthorized case - drop"
         circleMemberDomainModel.setStatus(CircleMemberStatus.DROP)
         ((BoardDomainModel) this.mockBoardDomainModel).setCircle((CircleDomainModel) this.mockCircleDomainModel)
-        this.postService.findAll("test user id", "test board id", 0)
+        this.postService.findAll("test user id", "test board id", 0, false)
 
         then:
         thrown(UnauthorizedException)


### PR DESCRIPTION
## Related issue
- #214 

## Description
삭제된 게시물 리스트 불러오기 & 삭제된 게시물 복원 api 구현

## Changes detail
- findAll api에 isDeleted param 추가해서 별도로 삭제된 리스트를 부르게 구현.
- restore api 신규 추가
- 모두 president 권한으로 적용

### Checklist

- [ ] Test case
- [ ] End of work
