### PR TITLE
fix: internal server error on get post caused by comment sort

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/port/ChildCommentPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/ChildCommentPortImpl.java
@@ -9,7 +9,6 @@ import net.causw.domain.model.PostDomainModel;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
-import java.util.Collections;
 import java.util.Optional;
 
 @Component
@@ -33,7 +32,6 @@ public class ChildCommentPortImpl extends DomainModelMapper implements ChildComm
     @Override
     public Page<ChildCommentDomainModel> findByParentComment(String parentCommentId, Integer pageNum) {
         Page<ChildComment> childComments = this.childCommentRepository.findByParentComment_IdOrderByCreatedAtDesc(parentCommentId, this.pageableFactory.create(pageNum));
-        Collections.reverse(childComments.getContent());
 
         return childComments
                 .map(this::entityToDomainModel);

--- a/src/main/java/net/causw/adapter/persistence/port/CommentPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/CommentPortImpl.java
@@ -9,7 +9,6 @@ import net.causw.domain.model.PostDomainModel;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
-import java.util.Collections;
 import java.util.Optional;
 
 @Component
@@ -33,7 +32,6 @@ public class CommentPortImpl extends DomainModelMapper implements CommentPort {
     @Override
     public Page<CommentDomainModel> findByPostId(String postId, Integer pageNum) {
         Page<Comment> comments = this.commentRepository.findByPost_IdOrderByCreatedAtDesc(postId, this.pageableFactory.create(pageNum));
-        Collections.reverse(comments.getContent());
 
         return comments
                 .map(this::entityToDomainModel);


### PR DESCRIPTION
## Related issue

## Description
Post findById 호출 시 Internal Server Error 발생 현상 수정

## Changes detail
- JPA에서 반환하는 Page의 content list는 immutable list이기 때문에 sort가 불가 -> 제거
- 다시 정렬을 하거나, Pageable을 custom하여 해결이 가능하지만, 불필요한 작업으로 고려되어 프론트와의 협의를 통해 역순으로 전달하면 프론트에서 뷰 구성 시 정렬하는 것으로 결정

### Checklist

- [ ] Test case
- [x] End of work
