### PR TITLE
fix: refactor content in CommentResponseDto for deleted case

### DIFF
--- a/src/main/java/net/causw/application/dto/ChildCommentResponseDto.java
+++ b/src/main/java/net/causw/application/dto/ChildCommentResponseDto.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 import net.causw.domain.model.BoardDomainModel;
 import net.causw.domain.model.ChildCommentDomainModel;
 import net.causw.domain.model.Role;
+import net.causw.domain.model.StaticValue;
 import net.causw.domain.model.UserDomainModel;
 
 import java.time.LocalDateTime;
@@ -63,6 +64,7 @@ public class ChildCommentResponseDto {
     ) {
         boolean updatable = false;
         boolean deletable = false;
+        String content = comment.getContent();
 
         if (user.getRole() == Role.ADMIN) {
             updatable = true;
@@ -89,11 +91,12 @@ public class ChildCommentResponseDto {
         if (comment.getIsDeleted()) {
             updatable = false;
             deletable = false;
+            content = StaticValue.contentDeletedComment;
         }
 
         return new ChildCommentResponseDto(
                 comment.getId(),
-                comment.getContent(),
+                content,
                 comment.getCreatedAt(),
                 comment.getUpdatedAt(),
                 comment.getIsDeleted(),

--- a/src/main/java/net/causw/application/dto/CommentResponseDto.java
+++ b/src/main/java/net/causw/application/dto/CommentResponseDto.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 import net.causw.domain.model.BoardDomainModel;
 import net.causw.domain.model.CommentDomainModel;
 import net.causw.domain.model.Role;
+import net.causw.domain.model.StaticValue;
 import net.causw.domain.model.UserDomainModel;
 
 import java.time.LocalDateTime;
@@ -61,6 +62,7 @@ public class CommentResponseDto {
     ) {
         boolean updatable = false;
         boolean deletable = false;
+        String content = comment.getContent();
 
         if (user.getRole() == Role.ADMIN) {
             updatable = true;
@@ -87,11 +89,12 @@ public class CommentResponseDto {
         if (comment.getIsDeleted()) {
             updatable = false;
             deletable = false;
+            content = StaticValue.contentDeletedComment;
         }
 
         return new CommentResponseDto(
                 comment.getId(),
-                comment.getContent(),
+                content,
                 comment.getCreatedAt(),
                 comment.getUpdatedAt(),
                 comment.getIsDeleted(),

--- a/src/main/java/net/causw/domain/model/StaticValue.java
+++ b/src/main/java/net/causw/domain/model/StaticValue.java
@@ -1,0 +1,5 @@
+package net.causw.domain.model;
+
+public class StaticValue {
+    public final static String contentDeletedComment = "삭제된 댓글입니다";
+}


### PR DESCRIPTION
## Related issue
- #278 

## Description
삭제된 댓글의 content 수정

## Changes detail
- String 값 static value 이용
- 

### Checklist

- [ ] Test case
- [x] End of work
