### PR TITLE
fix: refactor locker findAllLocations to include my locker information

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/LockerRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/LockerRepository.java
@@ -12,7 +12,9 @@ import java.util.Optional;
 public interface LockerRepository extends JpaRepository<Locker, String> {
     Optional<Locker> findByLockerNumber(Long lockerNumber);
 
-    List<Locker> findByLocation_Id(String locationId);
+    Optional<Locker> findByUser_Id(String userId);
+
+    List<Locker> findByLocation_IdOrderByLockerNumberAsc(String locationId);
 
     @Query(value = "SELECT COUNT(*) " +
             "FROM TB_LOCKER  " +

--- a/src/main/java/net/causw/adapter/persistence/port/LockerPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/LockerPortImpl.java
@@ -31,6 +31,11 @@ public class LockerPortImpl extends DomainModelMapper implements LockerPort {
     }
 
     @Override
+    public Optional<LockerDomainModel> findByUserId(String userId) {
+        return this.lockerRepository.findByUser_Id(userId).map(this::entityToDomainModel);
+    }
+
+    @Override
     public LockerDomainModel create(LockerDomainModel lockerDomainModel) {
         return this.entityToDomainModel(this.lockerRepository.save(Locker.from(lockerDomainModel)));
     }
@@ -65,7 +70,7 @@ public class LockerPortImpl extends DomainModelMapper implements LockerPort {
 
     @Override
     public List<LockerDomainModel> findByLocationId(String locationId) {
-        return this.lockerRepository.findByLocation_Id(locationId)
+        return this.lockerRepository.findByLocation_IdOrderByLockerNumberAsc(locationId)
                 .stream()
                 .map(this::entityToDomainModel)
                 .collect(Collectors.toList());

--- a/src/main/java/net/causw/adapter/web/LockerController.java
+++ b/src/main/java/net/causw/adapter/web/LockerController.java
@@ -1,6 +1,7 @@
 package net.causw.adapter.web;
 
 import net.causw.application.LockerService;
+import net.causw.application.dto.LockerAllLocationResponseDto;
 import net.causw.application.dto.LockerCreateRequestDto;
 import net.causw.application.dto.LockerLocationCreateRequestDto;
 import net.causw.application.dto.LockerLocationResponseDto;
@@ -38,13 +39,13 @@ public class LockerController {
         return this.lockerService.findById(id);
     }
 
-    @PostMapping(value = "/")
+    @PostMapping(value = "")
     @ResponseStatus(value = HttpStatus.CREATED)
     public LockerResponseDto create(
             @AuthenticationPrincipal String creatorId,
-            @RequestBody LockerCreateRequestDto locker
+            @RequestBody LockerCreateRequestDto lockerCreateRequestDto
     ) {
-        return this.lockerService.create(creatorId, locker);
+        return this.lockerService.create(creatorId, lockerCreateRequestDto);
     }
 
     @PutMapping(value = "/{id}")
@@ -75,11 +76,11 @@ public class LockerController {
     ) {
         return this.lockerService.delete(deleterId, id);
     }
-    
+
     @GetMapping(value = "/locations")
     @ResponseStatus(value = HttpStatus.OK)
-    public List<LockerLocationResponseDto> findAllLocation() {
-        return this.lockerService.findAllLocation();
+    public LockerAllLocationResponseDto findAllLocation(@AuthenticationPrincipal String userId) {
+        return this.lockerService.findAllLocation(userId);
     }
 
     @GetMapping(value = "/locations/{locationId}")
@@ -92,9 +93,9 @@ public class LockerController {
     @ResponseStatus(value = HttpStatus.CREATED)
     public LockerLocationResponseDto createLocation(
             @AuthenticationPrincipal String creatorId,
-            @RequestBody LockerLocationCreateRequestDto lockerLocation
+            @RequestBody LockerLocationCreateRequestDto lockerLocationCreateRequestDto
     ) {
-        return this.lockerService.createLocation(creatorId, lockerLocation);
+        return this.lockerService.createLocation(creatorId, lockerLocationCreateRequestDto);
     }
 
     @PutMapping(value = "/locations/{locationId}")
@@ -116,7 +117,7 @@ public class LockerController {
         return this.lockerService.deleteLocation(deleterId, locationId);
     }
 
-    @GetMapping(value="/{id}/log")
+    @GetMapping(value = "/{id}/log")
     @ResponseStatus(value = HttpStatus.OK)
     public List<LockerLogDetailDto> findLog(@PathVariable String id) {
         return this.lockerService.findLog(id);

--- a/src/main/java/net/causw/application/LockerActionEnable.java
+++ b/src/main/java/net/causw/application/LockerActionEnable.java
@@ -5,7 +5,6 @@ import net.causw.application.spi.LockerPort;
 import net.causw.domain.model.LockerDomainModel;
 import net.causw.domain.model.Role;
 import net.causw.domain.model.UserDomainModel;
-import net.causw.domain.validation.ConstraintValidator;
 import net.causw.domain.validation.LockerIsActiveValidator;
 import net.causw.domain.validation.UserRoleValidator;
 import net.causw.domain.validation.ValidatorBucket;
@@ -30,8 +29,6 @@ public class LockerActionEnable implements LockerAction {
                 .validate();
 
         lockerDomainModel.activate();
-
-        System.out.println(lockerPort.update(lockerDomainModel.getId(), lockerDomainModel));
 
         return lockerPort.update(lockerDomainModel.getId(), lockerDomainModel);
     }

--- a/src/main/java/net/causw/application/LockerService.java
+++ b/src/main/java/net/causw/application/LockerService.java
@@ -1,5 +1,6 @@
 package net.causw.application;
 
+import net.causw.application.dto.LockerAllLocationResponseDto;
 import net.causw.application.dto.LockerCreateRequestDto;
 import net.causw.application.dto.LockerLocationCreateRequestDto;
 import net.causw.application.dto.LockerLocationResponseDto;
@@ -204,7 +205,7 @@ public class LockerService {
         );
 
         lockerDomainModel.move(lockerLocationDomainModel);
-        
+
         ValidatorBucket.of()
                 .consistOf(UserStateValidator.of(updaterDomainModel.getState()))
                 .consistOf(UserRoleIsNoneValidator.of(updaterDomainModel.getRole()))
@@ -277,17 +278,20 @@ public class LockerService {
     }
 
     @Transactional(readOnly = true)
-    public List<LockerLocationResponseDto> findAllLocation() {
-        return this.lockerLocationPort.findAll()
-                .stream()
-                .map(
-                        (lockerLocationDomainModel) -> LockerLocationResponseDto.from(
-                                lockerLocationDomainModel,
-                                this.lockerPort.getEnableLockerCountByLocation(lockerLocationDomainModel.getId()),
-                                this.lockerPort.getLockerCountByLocation(lockerLocationDomainModel.getId())
+    public LockerAllLocationResponseDto findAllLocation(String userId) {
+        return LockerAllLocationResponseDto.of(
+                this.lockerLocationPort.findAll()
+                        .stream()
+                        .map(
+                                (lockerLocationDomainModel) -> LockerLocationResponseDto.from(
+                                        lockerLocationDomainModel,
+                                        this.lockerPort.getEnableLockerCountByLocation(lockerLocationDomainModel.getId()),
+                                        this.lockerPort.getLockerCountByLocation(lockerLocationDomainModel.getId())
+                                )
                         )
-                )
-                .collect(Collectors.toList());
+                        .collect(Collectors.toList()),
+                this.lockerPort.findByUserId(userId).map(LockerResponseDto::from).orElse(null)
+        );
     }
 
     @Transactional

--- a/src/main/java/net/causw/application/dto/LockerAllLocationResponseDto.java
+++ b/src/main/java/net/causw/application/dto/LockerAllLocationResponseDto.java
@@ -1,0 +1,28 @@
+package net.causw.application.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class LockerAllLocationResponseDto {
+    private List<LockerLocationResponseDto> lockerLocations;
+    private LockerResponseDto myLocker;
+
+    private LockerAllLocationResponseDto(
+            List<LockerLocationResponseDto> lockerLocations,
+            LockerResponseDto myLocker
+    ) {
+        this.lockerLocations = lockerLocations;
+        this.myLocker = myLocker;
+    }
+
+    public static LockerAllLocationResponseDto of(
+            List<LockerLocationResponseDto> lockerLocations,
+            LockerResponseDto myLocker
+    ) {
+        return new LockerAllLocationResponseDto(lockerLocations, myLocker);
+    }
+}

--- a/src/main/java/net/causw/application/spi/LockerPort.java
+++ b/src/main/java/net/causw/application/spi/LockerPort.java
@@ -10,6 +10,8 @@ public interface LockerPort {
 
     Optional<LockerDomainModel> findByLockerNumber(Long lockerNumber);
 
+    Optional<LockerDomainModel> findByUserId(String userId);
+
     LockerDomainModel create(LockerDomainModel lockerDomainModel);
 
     Optional<LockerDomainModel> update(String id, LockerDomainModel lockerDomainModel);


### PR DESCRIPTION
## Related issue
- #301 

## Description
findAllLocations 에 본인 사물함 정보 포함

## Changes detail
- LockerPort에 `findByUserId` 신규 구현
- `LockerLocationResponseDto` 의 수정
- Locker `findAll` 의 리스트를 번호 오름차순으로 정렬되도록 수정

### Checklist

- [ ] Test case
- [x] End of work
