### PR TITLE
fix: refactor Locker Structure to remove unnecessary field

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/LockerLocation.java
+++ b/src/main/java/net/causw/adapter/persistence/LockerLocation.java
@@ -18,29 +18,23 @@ public class LockerLocation extends BaseEntity {
     @Column(name = "name", unique = true, nullable = false)
     private String name;
 
-    @Column(name ="description", unique = false, nullable = true)
-    private String description;
-
-    private LockerLocation(String id, String name, String description) {
+    private LockerLocation(String id, String name) {
         super(id);
         this.name = name;
-        this.description = description;
     }
 
-    private LockerLocation(String name, String description) {
+    private LockerLocation(String name) {
         this.name = name;
-        this.description = description;
     }
 
-    public static LockerLocation of(String name, String description) {
-        return new LockerLocation(name, description);
+    public static LockerLocation of(String name) {
+        return new LockerLocation(name);
     }
 
     public static LockerLocation from(LockerLocationDomainModel lockerLocationDomainModel) {
         return new LockerLocation(
                 lockerLocationDomainModel.getId(),
-                lockerLocationDomainModel.getName(),
-                lockerLocationDomainModel.getDescription()
+                lockerLocationDomainModel.getName()
         );
     }
 }

--- a/src/main/java/net/causw/adapter/persistence/port/DomainModelMapper.java
+++ b/src/main/java/net/causw/adapter/persistence/port/DomainModelMapper.java
@@ -25,7 +25,6 @@ import net.causw.domain.model.UserDomainModel;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.stream.Collectors;
 
 // TODO: Refactoring
 public abstract class DomainModelMapper {
@@ -111,8 +110,7 @@ public abstract class DomainModelMapper {
     protected LockerLocationDomainModel entityToDomainModel(LockerLocation lockerLocation) {
         return LockerLocationDomainModel.of(
                 lockerLocation.getId(),
-                lockerLocation.getName(),
-                lockerLocation.getDescription()
+                lockerLocation.getName()
         );
     }
 

--- a/src/main/java/net/causw/adapter/persistence/port/LockerLocationPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/LockerLocationPortImpl.java
@@ -48,7 +48,6 @@ public class LockerLocationPortImpl extends DomainModelMapper implements LockerL
         return this.lockerLocationRepository.findById(id).map(
                 srcLockerLocation -> {
                     srcLockerLocation.setName(lockerLocationDomainModel.getName());
-                    srcLockerLocation.setDescription(lockerLocationDomainModel.getDescription());
 
                     return this.entityToDomainModel(this.lockerLocationRepository.save(srcLockerLocation));
                 }

--- a/src/main/java/net/causw/application/LockerService.java
+++ b/src/main/java/net/causw/application/LockerService.java
@@ -176,7 +176,7 @@ public class LockerService {
                             resLockerDomainModel.getLockerNumber(),
                             updaterDomainModel,
                             LockerLogAction.of(lockerUpdateRequestDto.getAction()),
-                            lockerUpdateRequestDto.getMessage()
+                            lockerUpdateRequestDto.getMessage().orElse(lockerUpdateRequestDto.getAction())
                     );
                     return LockerResponseDto.from(resLockerDomainModel, updaterDomainModel);
                 })
@@ -343,8 +343,7 @@ public class LockerService {
         }
 
         LockerLocationDomainModel lockerLocationDomainModel = LockerLocationDomainModel.of(
-                lockerLocationCreateRequestDto.getName(),
-                lockerLocationCreateRequestDto.getDescription()
+                lockerLocationCreateRequestDto.getName()
         );
 
         ValidatorBucket.of()
@@ -391,8 +390,7 @@ public class LockerService {
         }
 
         lockerLocationDomainModel.update(
-                lockerLocationRequestDto.getName(),
-                lockerLocationRequestDto.getDescription()
+                lockerLocationRequestDto.getName()
         );
 
         ValidatorBucket.of()

--- a/src/main/java/net/causw/application/dto/LockerLocationCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/LockerLocationCreateRequestDto.java
@@ -11,5 +11,4 @@ import lombok.Setter;
 @NoArgsConstructor
 public class LockerLocationCreateRequestDto {
     private String name;
-    private String description;
 }

--- a/src/main/java/net/causw/application/dto/LockerLocationResponseDto.java
+++ b/src/main/java/net/causw/application/dto/LockerLocationResponseDto.java
@@ -9,20 +9,17 @@ import net.causw.domain.model.LockerLocationDomainModel;
 public class LockerLocationResponseDto {
     private String id;
     private String name;
-    private String description;
     private Long enableLockerCount;
     private Long totalLockerCount;
 
     private LockerLocationResponseDto(
             String id,
             String name,
-            String description,
             Long enableLockerCount,
             Long totalLockerCount
     ) {
         this.id = id;
         this.name = name;
-        this.description = description;
         this.enableLockerCount = enableLockerCount;
         this.totalLockerCount = totalLockerCount;
     }
@@ -35,7 +32,6 @@ public class LockerLocationResponseDto {
         return new LockerLocationResponseDto(
                 lockerLocation.getId(),
                 lockerLocation.getName(),
-                lockerLocation.getDescription(),
                 enableLockerCount,
                 totalLockerCount
         );

--- a/src/main/java/net/causw/application/dto/LockerLocationUpdateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/LockerLocationUpdateRequestDto.java
@@ -11,5 +11,4 @@ import lombok.Setter;
 @NoArgsConstructor
 public class LockerLocationUpdateRequestDto {
     private String name;
-    private String description;
 }

--- a/src/main/java/net/causw/application/dto/LockerLogDetailDto.java
+++ b/src/main/java/net/causw/application/dto/LockerLogDetailDto.java
@@ -1,12 +1,14 @@
 package net.causw.application.dto;
 
 import lombok.Getter;
+import lombok.Setter;
 import net.causw.adapter.persistence.LockerLog;
 import net.causw.domain.model.LockerLogAction;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 public class LockerLogDetailDto {
     private Long lockerNumber;
     private String userEmail;
@@ -24,7 +26,7 @@ public class LockerLogDetailDto {
             String message,
             LocalDateTime createdAt,
             LocalDateTime updatedAt
-    ){
+    ) {
         this.lockerNumber = lockerNumber;
         this.userEmail = userEmail;
         this.userName = userName;

--- a/src/main/java/net/causw/application/dto/LockerMoveRequestDto.java
+++ b/src/main/java/net/causw/application/dto/LockerMoveRequestDto.java
@@ -10,5 +10,5 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LockerMoveRequestDto {
-    String locationId;
+    private String locationId;
 }

--- a/src/main/java/net/causw/application/dto/LockerUpdateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/LockerUpdateRequestDto.java
@@ -4,13 +4,18 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import net.causw.domain.model.LockerLogAction;
+
+import java.util.Optional;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class LockerUpdateRequestDto {
-    String action;
-    String message;
+    private String action;
+    private String message;
+
+    public Optional<String> getMessage() {
+        return Optional.ofNullable(this.message);
+    }
 }

--- a/src/main/java/net/causw/domain/model/LockerLocationDomainModel.java
+++ b/src/main/java/net/causw/domain/model/LockerLocationDomainModel.java
@@ -13,46 +13,32 @@ public class LockerLocationDomainModel {
     @NotBlank(message = "사물함 위치명이 입력되지 않았습니다.")
     private String name;
 
-    private String description;
-
     private LockerLocationDomainModel(
             String id,
-            String name,
-            String description
+            String name
     ) {
         this.id = id;
         this.name = name;
-        this.description = description;
     }
 
     public static LockerLocationDomainModel of(
             String id,
-            String name,
-            String description
+            String name
     ) {
         return new LockerLocationDomainModel(
                 id,
-                name,
-                description
+                name
         );
     }
 
-    public static LockerLocationDomainModel of(
-            String name,
-            String description
-    ) {
+    public static LockerLocationDomainModel of(String name) {
         return new LockerLocationDomainModel(
                 null,
-                name,
-                description
+                name
         );
     }
 
-    public void update(
-            String name,
-            String description
-    ) {
+    public void update(String name) {
         this.name = name;
-        this.description = description;
     }
 }


### PR DESCRIPTION
## Related issue

## Description
Locker entity의 불필요한 부분 제거

## Changes detail
- `LockerLocation` 내부 `description` 제거
- `LockerLog` 내부 `message` 필드 프론트 요청 Dto 에서 제거

### Checklist

- [ ] Test case
- [x] End of work
