### PR TITLE
feat: user findById for searching another user case

### DIFF
--- a/src/main/java/net/causw/adapter/web/UserController.java
+++ b/src/main/java/net/causw/adapter/web/UserController.java
@@ -43,6 +43,15 @@ public class UserController {
         this.userService = userService;
     }
 
+    @GetMapping(value = "/{id}")
+    @ResponseStatus(value = HttpStatus.OK)
+    public UserResponseDto findById(
+            @AuthenticationPrincipal String requestUserId,
+            @PathVariable String id
+    ) {
+        return this.userService.findById(id, requestUserId);
+    }
+
     @GetMapping(value = "/me")
     @ResponseStatus(value = HttpStatus.OK)
     public UserResponseDto findCurrentUser(@AuthenticationPrincipal String currentUserId) {
@@ -89,7 +98,11 @@ public class UserController {
             @PathVariable String state,
             @RequestParam(defaultValue = "0") Integer pageNum
     ) {
-        return this.userService.findByState(currentUserId, state, pageNum);
+        return this.userService.findByState(
+                currentUserId,
+                state,
+                pageNum
+        );
     }
 
     @PostMapping(value = "/sign-up")


### PR DESCRIPTION
## Related issue
- #311 

## Description
관리 페이지를 위한 user `findById` API 구현

## Changes detail
- 기존 API들 중 `LEADER_CIRCLE` 의 `ResponseDto` 가 잘못 구성된 경우의 수정
- 기존 `/me` API 에서 사용하던 `findById` 에 오버로딩 구현: 학생회장 / 소모임장의 회원 관리 페이지를 위한 API

### Checklist

- [ ] Test case
- [x] End of work
