### PR TITLE
fix: Excluding app notice from find all boards

### DIFF
--- a/src/main/java/net/causw/application/BoardService.java
+++ b/src/main/java/net/causw/application/BoardService.java
@@ -63,6 +63,7 @@ public class BoardService {
 
         return this.boardPort.findAll()
                 .stream()
+                .filter(boardDomainModel -> !boardDomainModel.getCategory().equals(StaticValue.BOARD_NAME_APP_NOTICE))
                 .map(boardDomainModel -> BoardResponseDto.from(boardDomainModel, userDomainModel.getRole()))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
## Related issue
- #319 

## Description
Excluding app notice from find all boards

### Checklist

- [x] Test case
- [x] End of work
