### PR TITLE
fix: add exception handling for reject user sign-in

### DIFF
--- a/src/main/java/net/causw/domain/exceptions/ErrorCode.java
+++ b/src/main/java/net/causw/domain/exceptions/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     GRANT_ROLE_NOT_ALLOWED(4106),
     API_NOT_ALLOWED(4107),
     NOT_MEMBER(4108),
+    REJECT_USER(4109),
 
     /**
      * 500 Internal Server Error

--- a/src/main/java/net/causw/domain/validation/UserStateValidator.java
+++ b/src/main/java/net/causw/domain/validation/UserStateValidator.java
@@ -38,5 +38,12 @@ public class UserStateValidator extends AbstractValidator {
                     "대기 중인 사용자 입니다."
             );
         }
+
+        if (this.userState == UserState.REJECT) {
+            throw new UnauthorizedException(
+                    ErrorCode.REJECT_USER,
+                    "가입이 거절된 사용자 입니다."
+            );
+        }
     }
 }


### PR DESCRIPTION
## Related issue

## Description
`Reject` 유저의 로그인 시 exception handling이 안되던 현상 수정

## Changes detail

- 
- 

### Checklist

- [ ] Test case
- [x] End of work
