### PR TITLE
fix: favorite board initialize

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/BoardRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/BoardRepository.java
@@ -19,7 +19,7 @@ public interface BoardRepository extends JpaRepository<Board, String> {
             "WHERE TB_BOARD.name = '앱 공지사항' " +
             "OR TB_BOARD.name = '학생회 공지게시판' " +
             "OR TB_BOARD.name = '전체 자유게시판'", nativeQuery = true)
-    List<Board> findHomeBoards();
+    List<Board> findBasicBoards();
 
     @Query(value = "SELECT * FROM TB_BOARD WHERE TB_BOARD.category = 'APP_NOTICE'", nativeQuery = true)
     Optional<Board> findAppNotice();

--- a/src/main/java/net/causw/adapter/persistence/port/BoardPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/BoardPortImpl.java
@@ -45,16 +45,8 @@ public class BoardPortImpl extends DomainModelMapper implements BoardPort {
     }
 
     @Override
-    public List<BoardDomainModel> findOldest3Boards() {
-        return this.boardRepository.findTop3ByCircle_IdIsNullAndIsDeletedIsFalseOrderByCreatedAtAsc()
-                .stream()
-                .map(this::entityToDomainModel)
-                .collect(Collectors.toList());
-    }
-
-    @Override
-    public List<BoardDomainModel> findHomeBoards() {
-        return this.boardRepository.findHomeBoards()
+    public List<BoardDomainModel> findBasicBoards() {
+        return this.boardRepository.findBasicBoards()
                 .stream()
                 .map(this::entityToDomainModel)
                 .collect(Collectors.toList());

--- a/src/main/java/net/causw/adapter/web/CommonController.java
+++ b/src/main/java/net/causw/adapter/web/CommonController.java
@@ -26,7 +26,7 @@ public class CommonController {
     @GetMapping("/api/v1/home")
     @ResponseStatus(value = HttpStatus.OK)
     public List<HomePageResponseDto> getHomePage(@AuthenticationPrincipal String userId) {
-        return this.homePageService.getHomePageDefault(userId);
+        return this.homePageService.getHomePage(userId);
     }
 
     /*

--- a/src/main/java/net/causw/adapter/web/PostController.java
+++ b/src/main/java/net/causw/adapter/web/PostController.java
@@ -61,9 +61,10 @@ public class PostController {
     @GetMapping("/app/notice")
     @ResponseStatus(value = HttpStatus.OK)
     public BoardPostsResponseDto findAllAppNotice(
+            @AuthenticationPrincipal String requestUserId,
             @RequestParam(defaultValue = "0") Integer pageNum
     ) {
-        return this.postService.findAllAppNotice(pageNum);
+        return this.postService.findAllAppNotice(requestUserId, pageNum);
     }
 
     @PostMapping

--- a/src/main/java/net/causw/application/PostService.java
+++ b/src/main/java/net/causw/application/PostService.java
@@ -10,6 +10,7 @@ import net.causw.application.spi.BoardPort;
 import net.causw.application.spi.ChildCommentPort;
 import net.causw.application.spi.CircleMemberPort;
 import net.causw.application.spi.CommentPort;
+import net.causw.application.spi.FavoriteBoardPort;
 import net.causw.application.spi.PostPort;
 import net.causw.application.spi.UserPort;
 import net.causw.domain.exceptions.BadRequestException;
@@ -50,6 +51,7 @@ public class PostService {
     private final CircleMemberPort circleMemberPort;
     private final CommentPort commentPort;
     private final ChildCommentPort childCommentPort;
+    private final FavoriteBoardPort favoriteBoardPort;
     private final Validator validator;
 
     public PostService(
@@ -59,6 +61,7 @@ public class PostService {
             CircleMemberPort circleMemberPort,
             CommentPort commentPort,
             ChildCommentPort childCommentPort,
+            FavoriteBoardPort favoriteBoardPort,
             Validator validator
     ) {
         this.postPort = postPort;
@@ -67,6 +70,7 @@ public class PostService {
         this.circleMemberPort = circleMemberPort;
         this.commentPort = commentPort;
         this.childCommentPort = childCommentPort;
+        this.favoriteBoardPort = favoriteBoardPort;
         this.validator = validator;
     }
 
@@ -183,6 +187,9 @@ public class PostService {
         return BoardPostsResponseDto.from(
                 boardDomainModel,
                 userDomainModel.getRole(),
+                this.favoriteBoardPort.findByUserId(requestUserId)
+                        .stream()
+                        .anyMatch(favoriteBoardDomainModel -> favoriteBoardDomainModel.getBoardDomainModel().getId().equals(boardDomainModel.getId())),
                 this.postPort.findAll(boardId, pageNum)
                         .map(postDomainModel -> PostsResponseDto.from(
                                 postDomainModel,
@@ -252,6 +259,9 @@ public class PostService {
         return BoardPostsResponseDto.from(
                 boardDomainModel,
                 userDomainModel.getRole(),
+                this.favoriteBoardPort.findByUserId(requestUserId)
+                        .stream()
+                        .anyMatch(favoriteBoardDomainModel -> favoriteBoardDomainModel.getBoardDomainModel().getId().equals(boardDomainModel.getId())),
                 this.postPort.search(searchOption, keyword, pageNum)
                         .map(postDomainModel -> PostsResponseDto.from(
                                 postDomainModel,
@@ -261,7 +271,14 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public BoardPostsResponseDto findAllAppNotice(Integer pageNum) {
+    public BoardPostsResponseDto findAllAppNotice(String requestUserId, Integer pageNum) {
+        UserDomainModel userDomainModel = this.userPort.findById(requestUserId).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        "로그인된 사용자를 찾을 수 없습니다."
+                )
+        );
+
         BoardDomainModel boardDomainModel = this.boardPort.findAppNotice().orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
@@ -271,7 +288,10 @@ public class PostService {
 
         return BoardPostsResponseDto.from(
                 boardDomainModel,
-                Role.ADMIN,
+                userDomainModel.getRole(),
+                this.favoriteBoardPort.findByUserId(requestUserId)
+                        .stream()
+                        .anyMatch(favoriteBoardDomainModel -> favoriteBoardDomainModel.getBoardDomainModel().getId().equals(boardDomainModel.getId())),
                 this.postPort.findAll(boardDomainModel.getId(), pageNum)
                         .map(postDomainModel -> PostsResponseDto.from(
                                 postDomainModel,

--- a/src/main/java/net/causw/application/UserService.java
+++ b/src/main/java/net/causw/application/UserService.java
@@ -964,20 +964,6 @@ public class UserService {
                 .consistOf(UserRoleValidator.of(requestUser.getRole(), List.of(Role.PRESIDENT)))
                 .validate();
 
-        /*
-        * TODO: Favorite Board
-        // Create default favorite board
-        if (this.favoriteBoardPort.findByUserId(userAdmissionDomainModel.getUser().getId()).isEmpty()) {
-            this.boardPort.findOldest3Boards()
-                    .forEach(boardDomainModel ->
-                            this.favoriteBoardPort.create(FavoriteBoardDomainModel.of(
-                                    userAdmissionDomainModel.getUser(),
-                                    boardDomainModel
-                            ))
-                    );
-        }
-        */
-
         // Update user role to COMMON
         this.userPort.updateRole(userAdmissionDomainModel.getUser().getId(), Role.COMMON).orElseThrow(
                 () -> new InternalServerException(

--- a/src/main/java/net/causw/application/dto/post/BoardPostsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/BoardPostsResponseDto.java
@@ -12,29 +12,34 @@ public class BoardPostsResponseDto {
     private String boardId;
     private String boardName;
     private Boolean writable;
+    private Boolean isFavorite;
     private Page<PostsResponseDto> post;
 
     private BoardPostsResponseDto(
             String boardId,
             String boardName,
             Boolean writable,
+            Boolean isFavorite,
             Page<PostsResponseDto> post
     ) {
         this.boardId = boardId;
         this.boardName = boardName;
         this.writable = writable;
+        this.isFavorite = isFavorite;
         this.post = post;
     }
 
     public static BoardPostsResponseDto from(
             BoardDomainModel boardDomainModel,
             Role userRole,
+            Boolean isFavorite,
             Page<PostsResponseDto> post
     ) {
         return new BoardPostsResponseDto(
                 boardDomainModel.getId(),
                 boardDomainModel.getName(),
                 boardDomainModel.getCreateRoleList().contains(userRole.getValue()),
+                isFavorite,
                 post
         );
     }

--- a/src/main/java/net/causw/application/spi/BoardPort.java
+++ b/src/main/java/net/causw/application/spi/BoardPort.java
@@ -14,9 +14,7 @@ public interface BoardPort {
 
     List<BoardDomainModel> findByCircleId(String circleId);
 
-    List<BoardDomainModel> findOldest3Boards();
-
-    List<BoardDomainModel> findHomeBoards();
+    List<BoardDomainModel> findBasicBoards();
 
     BoardDomainModel create(BoardDomainModel boardDomainModel);
 

--- a/src/test/groovy/net/causw/application/PostServiceTest.groovy
+++ b/src/test/groovy/net/causw/application/PostServiceTest.groovy
@@ -35,6 +35,7 @@ class PostServiceTest extends Specification {
     private CircleMemberPort circleMemberPort = Mock(CircleMemberPort.class)
     private CommentPort commentPort = Mock(CommentPort.class)
     private ChildCommentPort childCommentPort = Mock(ChildCommentPort.class)
+    private FavoriteBoardPort favoriteBoardPort = Mock(FavoriteBoardPort.class)
     private Validator validator = Validation.buildDefaultValidatorFactory().getValidator()
     private PostService postService = new PostService(
             this.postPort,
@@ -43,6 +44,7 @@ class PostServiceTest extends Specification {
             this.circleMemberPort,
             this.commentPort,
             this.childCommentPort,
+            this.favoriteBoardPort,
             this.validator
     )
 
@@ -185,7 +187,8 @@ class PostServiceTest extends Specification {
         this.postPort.findById(((PostDomainModel) this.mockPostDomainModel).getId()) >> Optional.of(this.mockPostDomainModel)
         this.boardPort.findById(((BoardDomainModel) this.mockBoardDomainModel).getId()) >> Optional.of(this.mockBoardDomainModel)
         this.circleMemberPort.findByUserIdAndCircleId(requestUserDomainModel.getId(), ((CircleDomainModel) this.mockCircleDomainModel).getId()) >> Optional.of(circleMemberDomainModel)
-        this.postPort.search(SearchOption.TITLE, "keyword", 0) >> new PageImpl<PostDomainModel>(List.of((PostDomainModel)this.mockPostDomainModel))
+        this.postPort.search(SearchOption.TITLE, "keyword", 0) >> new PageImpl<PostDomainModel>(List.of((PostDomainModel) this.mockPostDomainModel))
+        this.favoriteBoardPort.findByUserId(requestUserDomainModel.getId()) >> List.of()
 
         when: "post findById without circle"
         def postFind = this.postService.search("test user id", "test board id", "title", "keyword", 0)
@@ -226,6 +229,7 @@ class PostServiceTest extends Specification {
         this.userPort.findById(requestUserDomainModel.getId()) >> Optional.of(requestUserDomainModel)
         this.postPort.findById(((PostDomainModel) this.mockPostDomainModel).getId()) >> Optional.of(this.mockPostDomainModel)
         this.boardPort.findById(((BoardDomainModel) this.mockBoardDomainModel).getId()) >> Optional.of(this.mockBoardDomainModel)
+        this.favoriteBoardPort.findByUserId(requestUserDomainModel.getId()) >> List.of()
 
         when:
         this.mockBoardDomainModel.setIsDeleted(true)
@@ -265,6 +269,7 @@ class PostServiceTest extends Specification {
         this.postPort.findById(((PostDomainModel) this.mockPostDomainModel).getId()) >> Optional.of(this.mockPostDomainModel)
         this.boardPort.findById(((BoardDomainModel) this.mockBoardDomainModel).getId()) >> Optional.of(this.mockBoardDomainModel)
         this.circleMemberPort.findByUserIdAndCircleId(requestUserDomainModel.getId(), ((CircleDomainModel) this.mockCircleDomainModel).getId()) >> Optional.of(circleMemberDomainModel)
+        this.favoriteBoardPort.findByUserId(requestUserDomainModel.getId()) >> List.of()
 
         when: "bad request case - leave"
         ((BoardDomainModel) this.mockBoardDomainModel).setCircle((CircleDomainModel) this.mockCircleDomainModel)
@@ -315,7 +320,8 @@ class PostServiceTest extends Specification {
         this.postPort.findById(((PostDomainModel) this.mockPostDomainModel).getId()) >> Optional.of(this.mockPostDomainModel)
         this.boardPort.findById(((BoardDomainModel) this.mockBoardDomainModel).getId()) >> Optional.of(this.mockBoardDomainModel)
         this.circleMemberPort.findByUserIdAndCircleId(requestUserDomainModel.getId(), ((CircleDomainModel) this.mockCircleDomainModel).getId()) >> Optional.of(circleMemberDomainModel)
-        this.postPort.findAll(((BoardDomainModel) this.mockBoardDomainModel).getId(), 0) >> new PageImpl<PostDomainModel>(List.of((PostDomainModel)this.mockPostDomainModel))
+        this.postPort.findAll(((BoardDomainModel) this.mockBoardDomainModel).getId(), 0) >> new PageImpl<PostDomainModel>(List.of((PostDomainModel) this.mockPostDomainModel))
+        this.favoriteBoardPort.findByUserId(requestUserDomainModel.getId()) >> List.of()
 
         when: "post findById without circle"
         def postFind = this.postService.findAll("test user id", "test board id", 0)
@@ -356,7 +362,8 @@ class PostServiceTest extends Specification {
         this.userPort.findById(requestUserDomainModel.getId()) >> Optional.of(requestUserDomainModel)
         this.postPort.findById(((PostDomainModel) this.mockPostDomainModel).getId()) >> Optional.of(this.mockPostDomainModel)
         this.boardPort.findById(((BoardDomainModel) this.mockBoardDomainModel).getId()) >> Optional.of(this.mockBoardDomainModel)
-        this.postPort.findAll(((BoardDomainModel) this.mockBoardDomainModel).getId(), 0) >> new PageImpl<PostDomainModel>(List.of((PostDomainModel)this.mockPostDomainModel))
+        this.postPort.findAll(((BoardDomainModel) this.mockBoardDomainModel).getId(), 0) >> new PageImpl<PostDomainModel>(List.of((PostDomainModel) this.mockPostDomainModel))
+        this.favoriteBoardPort.findByUserId(requestUserDomainModel.getId()) >> List.of()
 
         when:
         this.mockBoardDomainModel.setIsDeleted(true)
@@ -396,7 +403,8 @@ class PostServiceTest extends Specification {
         this.postPort.findById(((PostDomainModel) this.mockPostDomainModel).getId()) >> Optional.of(this.mockPostDomainModel)
         this.boardPort.findById(((BoardDomainModel) this.mockBoardDomainModel).getId()) >> Optional.of(this.mockBoardDomainModel)
         this.circleMemberPort.findByUserIdAndCircleId(requestUserDomainModel.getId(), ((CircleDomainModel) this.mockCircleDomainModel).getId()) >> Optional.of(circleMemberDomainModel)
-        this.postPort.findAll(((BoardDomainModel) this.mockBoardDomainModel).getId(), 0) >> Page.of((PostDomainModel)this.mockPostDomainModel)
+        this.postPort.findAll(((BoardDomainModel) this.mockBoardDomainModel).getId(), 0) >> Page.of((PostDomainModel) this.mockPostDomainModel)
+        this.favoriteBoardPort.findByUserId(requestUserDomainModel.getId()) >> List.of()
 
         when: "bad request case - leave"
         ((BoardDomainModel) this.mockBoardDomainModel).setCircle((CircleDomainModel) this.mockCircleDomainModel)


### PR DESCRIPTION
## Related issue
- #361

## Description
즐겨찾는 게시판 조회 / 초기화 로직 변경

## Changes detail
- 기본 등록 로직의 변경 (가장 오래된 3개 -> `앱 공지사항`, `학생회 공지게시판`, `전체 자유게시판`)
- 기본 등록 시점의 변경 (유저 승인 시점 -> Home 화면 호출 시 즐겨찾는 게시판 존재여부 확인)
- 게시판 상세 (게시글 리스트 조회) API의 ResponseDto에 즐겨찾기 여부 포함

### Checklist

- [x] Test case
- [x] End of work
