### PR TITLE
feat: favorite board delete

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/FavoriteBoardRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/FavoriteBoardRepository.java
@@ -3,7 +3,10 @@ package net.causw.adapter.persistence;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FavoriteBoardRepository extends JpaRepository<FavoriteBoard, String> {
+    Optional<FavoriteBoard> findByUser_IdAndBoard_Id(String userId, String boardId);
+
     List<FavoriteBoard> findByUser_Id(String name);
 }

--- a/src/main/java/net/causw/adapter/persistence/port/FavoriteBoardPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/FavoriteBoardPortImpl.java
@@ -1,20 +1,13 @@
 package net.causw.adapter.persistence.port;
 
-import net.causw.adapter.persistence.Board;
-import net.causw.adapter.persistence.Circle;
 import net.causw.adapter.persistence.FavoriteBoard;
 import net.causw.adapter.persistence.FavoriteBoardRepository;
-import net.causw.adapter.persistence.User;
 import net.causw.application.spi.FavoriteBoardPort;
-import net.causw.domain.model.BoardDomainModel;
-import net.causw.domain.model.CircleDomainModel;
 import net.causw.domain.model.FavoriteBoardDomainModel;
-import net.causw.domain.model.UserDomainModel;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Component
@@ -33,10 +26,19 @@ public class FavoriteBoardPortImpl extends DomainModelMapper implements Favorite
     }
 
     @Override
+    public void delete(FavoriteBoardDomainModel favoriteBoardDomainModel) {
+        this.favoriteBoardRepository.delete(FavoriteBoard.from(favoriteBoardDomainModel));
+    }
+
+    @Override
+    public Optional<FavoriteBoardDomainModel> findByUserIdAndBoardId(String userId, String boardId) {
+        return this.favoriteBoardRepository.findByUser_IdAndBoard_Id(userId, boardId).map(this::entityToDomainModel);
+    }
+
+    @Override
     public List<FavoriteBoardDomainModel> findByUserId(String userId) {
         return this.favoriteBoardRepository.findByUser_Id(userId)
                 .stream()
-                .filter(favoriteBoard -> !favoriteBoard.getBoard().getIsDeleted())
                 .map(this::entityToDomainModel)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/net/causw/adapter/web/UserController.java
+++ b/src/main/java/net/causw/adapter/web/UserController.java
@@ -1,20 +1,20 @@
 package net.causw.adapter.web;
 
 import net.causw.application.UserService;
-import net.causw.application.dto.user.UserFindEmailRequestDto;
+import net.causw.application.dto.DuplicatedCheckResponseDto;
 import net.causw.application.dto.board.BoardResponseDto;
 import net.causw.application.dto.circle.CircleResponseDto;
-import net.causw.application.dto.DuplicatedCheckResponseDto;
-import net.causw.application.dto.user.UserAdmissionsResponseDto;
 import net.causw.application.dto.user.UserAdmissionCreateRequestDto;
 import net.causw.application.dto.user.UserAdmissionResponseDto;
+import net.causw.application.dto.user.UserAdmissionsResponseDto;
 import net.causw.application.dto.user.UserCommentsResponseDto;
 import net.causw.application.dto.user.UserCreateRequestDto;
-import net.causw.application.dto.user.UserUpdatePasswordRequestDto;
+import net.causw.application.dto.user.UserFindEmailRequestDto;
 import net.causw.application.dto.user.UserPostsResponseDto;
 import net.causw.application.dto.user.UserPrivilegedResponseDto;
 import net.causw.application.dto.user.UserResponseDto;
 import net.causw.application.dto.user.UserSignInRequestDto;
+import net.causw.application.dto.user.UserUpdatePasswordRequestDto;
 import net.causw.application.dto.user.UserUpdateRequestDto;
 import net.causw.application.dto.user.UserUpdateRoleRequestDto;
 import org.springframework.data.domain.Page;
@@ -249,6 +249,18 @@ public class UserController {
             @PathVariable String boardId
     ) {
         return this.userService.createFavoriteBoard(
+                requestUserId,
+                boardId
+        );
+    }
+
+    @DeleteMapping(value = "/favorite-boards/{boardId}")
+    @ResponseStatus(value = HttpStatus.OK)
+    public BoardResponseDto deleteFavoriteBoard(
+            @AuthenticationPrincipal String requestUserId,
+            @PathVariable String boardId
+    ) {
+        return this.userService.deleteFavoriteBoard(
                 requestUserId,
                 boardId
         );

--- a/src/main/java/net/causw/application/HomePageService.java
+++ b/src/main/java/net/causw/application/HomePageService.java
@@ -4,12 +4,15 @@ import net.causw.application.dto.HomePageResponseDto;
 import net.causw.application.dto.board.BoardResponseDto;
 import net.causw.application.dto.post.PostsResponseDto;
 import net.causw.application.spi.BoardPort;
+import net.causw.application.spi.CircleMemberPort;
 import net.causw.application.spi.CommentPort;
 import net.causw.application.spi.FavoriteBoardPort;
 import net.causw.application.spi.PostPort;
 import net.causw.application.spi.UserPort;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
+import net.causw.domain.model.CircleMemberDomainModel;
+import net.causw.domain.model.CircleMemberStatus;
 import net.causw.domain.model.FavoriteBoardDomainModel;
 import net.causw.domain.model.StaticValue;
 import net.causw.domain.model.UserDomainModel;
@@ -18,7 +21,9 @@ import net.causw.domain.validation.UserStateValidator;
 import net.causw.domain.validation.ValidatorBucket;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 @Service
@@ -28,21 +33,25 @@ public class HomePageService {
     private final BoardPort boardPort;
     private final PostPort postPort;
     private final CommentPort commentPort;
+    private final CircleMemberPort circleMemberPort;
 
     public HomePageService(
             FavoriteBoardPort favoriteBoardPort,
             UserPort userPort,
             BoardPort boardPort,
             PostPort postPort,
-            CommentPort commentPort
+            CommentPort commentPort,
+            CircleMemberPort circleMemberPort
     ) {
         this.favoriteBoardPort = favoriteBoardPort;
         this.userPort = userPort;
         this.boardPort = boardPort;
         this.postPort = postPort;
         this.commentPort = commentPort;
+        this.circleMemberPort = circleMemberPort;
     }
 
+    @Transactional
     public List<HomePageResponseDto> getHomePage(String userId) {
         UserDomainModel userDomainModel = this.userPort.findById(userId).orElseThrow(
                 () -> new BadRequestException(
@@ -56,8 +65,46 @@ public class HomePageService {
                 .consistOf(UserRoleIsNoneValidator.of(userDomainModel.getRole()))
                 .validate();
 
-        // Create default favorite board if not exist
         List<FavoriteBoardDomainModel> favoriteBoardDomainModelList = this.favoriteBoardPort.findByUserId(userId);
+        AtomicBoolean requireReload = new AtomicBoolean(false);
+
+        // Delete favorite board if
+        // 1) The board is deleted
+        // 2) The circle is deleted if the board is circle's one
+        // 3) The user is not a member of circle if the board is circle's one
+        favoriteBoardDomainModelList.forEach(
+                favoriteBoardDomainModel -> {
+                    if (favoriteBoardDomainModel.getBoardDomainModel().getIsDeleted()) {
+                        this.favoriteBoardPort.delete(favoriteBoardDomainModel);
+                        requireReload.set(true);
+                        return;
+                    }
+
+                    favoriteBoardDomainModel.getBoardDomainModel().getCircle().ifPresent(
+                            circleDomainModel -> {
+                                if (circleDomainModel.getIsDeleted()) {
+                                    this.favoriteBoardPort.delete(favoriteBoardDomainModel);
+                                    requireReload.set(true);
+                                    return;
+                                }
+
+                                CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(userId, circleDomainModel.getId()).orElse(null);
+                                if (circleMemberDomainModel == null ||
+                                        circleMemberDomainModel.getStatus() != CircleMemberStatus.MEMBER
+                                ) {
+                                    this.favoriteBoardPort.delete(favoriteBoardDomainModel);
+                                    requireReload.set(true);
+                                }
+                            }
+                    );
+                }
+        );
+
+        if (requireReload.get()) {
+            favoriteBoardDomainModelList = this.favoriteBoardPort.findByUserId(userId);
+        }
+
+        // Create default favorite board if not exist
         if (favoriteBoardDomainModelList.isEmpty()) {
             favoriteBoardDomainModelList = this.boardPort.findBasicBoards()
                     .stream()

--- a/src/main/java/net/causw/application/spi/FavoriteBoardPort.java
+++ b/src/main/java/net/causw/application/spi/FavoriteBoardPort.java
@@ -3,9 +3,14 @@ package net.causw.application.spi;
 import net.causw.domain.model.FavoriteBoardDomainModel;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FavoriteBoardPort {
     FavoriteBoardDomainModel create(FavoriteBoardDomainModel favoriteBoardDomainModel);
+
+    void delete(FavoriteBoardDomainModel favoriteBoardDomainModel);
+
+    Optional<FavoriteBoardDomainModel> findByUserIdAndBoardId(String userId, String boardId);
 
     List<FavoriteBoardDomainModel> findByUserId(String userId);
 }

--- a/src/main/java/net/causw/domain/model/StaticValue.java
+++ b/src/main/java/net/causw/domain/model/StaticValue.java
@@ -5,7 +5,7 @@ public class StaticValue {
     public static final String BOARD_NAME_APP_NOTICE = "APP_NOTICE";
 
     public static final Integer CAUSW_CREATED = 1972;
-    public static final Integer MAX_NUM_FILE_ATTACHMENTS = 3;
+    public static final Integer MIN_NUM_HOME_BOARD = 1;
 
     // Pagination
     public static final Integer DEFAULT_PAGE_SIZE = 20;
@@ -27,6 +27,7 @@ public class StaticValue {
     public static final String GOOGLE_MAIL = "causwdevteam@gmail.com";
 
     // GCP configuration
+    public static final Integer MAX_NUM_FILE_ATTACHMENTS = 3;
     public static final Long ATTACHMENT_LIMIT_SIZE = (long) (50 * 1024 * 1024);
     public static final Long IMAGE_LIMIT_SIZE = (long) (10 * 1024 * 1024);
     public static final String GCS_PUBLIC_LINK_PREFIX = "https://storage.googleapis.com/";


### PR DESCRIPTION
## Related issue
- #360 

## Description
즐겨찾는 게시판 삭제 로직 추가

## Changes detail
- `/home` API 호출 시, 기존 즐겨찾는 게시판으로 등록된 게시판이 다음 조건을 가지는 경우 Row 삭제
  1) 삭제 되었거나
  2) 소모임의 게시판인 경우 소모임이 삭제되었거나
  3) 소모임의 게시판인 경우 소모임 회원에서 탈퇴한 경우
- 즐겨찾는 게시판 삭제 로직 추가
  - 최소 1개의 게시판은 보유하도록 검사 진행

### Checklist

- [ ] Test case
- [x] End of work
