### PR TITLE
fix: modify locker response for duplicate locker number

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/Locker.java
+++ b/src/main/java/net/causw/adapter/persistence/Locker.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 @NoArgsConstructor
 @Table(name = "TB_LOCKER")
 public class Locker extends BaseEntity {
-    @Column(name = "locker_number", unique = true, nullable = false)
+    @Column(name = "locker_number", nullable = false)
     private Long lockerNumber;
 
     @Column(name = "is_active")

--- a/src/main/java/net/causw/application/LockerService.java
+++ b/src/main/java/net/causw/application/LockerService.java
@@ -308,7 +308,11 @@ public class LockerService {
         LockerResponseDto myLocker = null;
         if (!userDomainModel.getRole().equals(Role.ADMIN))
             myLocker = this.lockerPort.findByUserId(userId)
-                    .map(lockerDomainModel -> LockerResponseDto.from(lockerDomainModel, userDomainModel))
+                    .map(lockerDomainModel -> LockerResponseDto.from(
+                            lockerDomainModel,
+                            userDomainModel,
+                            lockerDomainModel.getLockerLocation().getName()
+                    ))
                     .orElse(null);
 
         return LockerLocationsResponseDto.of(

--- a/src/main/java/net/causw/application/dto/locker/LockerResponseDto.java
+++ b/src/main/java/net/causw/application/dto/locker/LockerResponseDto.java
@@ -13,14 +13,14 @@ import java.time.LocalDateTime;
 @Setter
 public class LockerResponseDto {
     private String id;
-    private Long lockerNumber;
+    private String lockerNumber;
     private Boolean isActive;
     private Boolean isMine;
     private LocalDateTime updatedAt;
 
     private LockerResponseDto(
             String id,
-            Long lockerNumber,
+            String lockerNumber,
             Boolean isActive,
             Boolean isMine,
             LocalDateTime updateAt
@@ -35,7 +35,7 @@ public class LockerResponseDto {
     public static LockerResponseDto from(Locker locker, UserDomainModel user) {
         return new LockerResponseDto(
                 locker.getId(),
-                locker.getLockerNumber(),
+                String.valueOf(locker.getLockerNumber()),
                 locker.getIsActive(),
                 locker.getUser().map(User::getId).orElse("").equals(user.getId()),
                 locker.getUpdatedAt()
@@ -45,7 +45,23 @@ public class LockerResponseDto {
     public static LockerResponseDto from(LockerDomainModel locker, UserDomainModel user) {
         return new LockerResponseDto(
                 locker.getId(),
-                locker.getLockerNumber(),
+                String.valueOf(locker.getLockerNumber()),
+                locker.getIsActive(),
+                locker.getUser().map(UserDomainModel::getId).orElse("").equals(user.getId()),
+                locker.getUpdatedAt()
+        );
+    }
+
+    public static LockerResponseDto from(
+            LockerDomainModel locker,
+            UserDomainModel user,
+            String locationName
+    ) {
+        String location = locationName + " " + locker.getLockerNumber();
+
+        return new LockerResponseDto(
+                locker.getId(),
+                location,
                 locker.getIsActive(),
                 locker.getUser().map(UserDomainModel::getId).orElse("").equals(user.getId()),
                 locker.getUpdatedAt()

--- a/src/test/groovy/net/causw/application/LockerServiceTest.groovy
+++ b/src/test/groovy/net/causw/application/LockerServiceTest.groovy
@@ -100,7 +100,7 @@ class LockerServiceTest extends Specification {
         then:
         lockerCreate instanceof LockerResponseDto
         with(lockerCreate) {
-            getLockerNumber() == 1
+            getLockerNumber() == "1"
         }
     }
 
@@ -487,7 +487,7 @@ class LockerServiceTest extends Specification {
         then:
         lockerResponseDto instanceof LockerResponseDto
         with(lockerResponseDto) {
-            getLockerNumber() == 1
+            getLockerNumber() == "1"
         }
     }
 


### PR DESCRIPTION
## Related issue

## Description
`LockerNumber` 필드의 Unique 옵션 제거에 따라, 본인의 사물함 표기 변경

## Changes detail

- 
- 

### Checklist

- [ ] Test case
- [x] End of work
