### PR TITLE
feat/restore posts

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/port/PostPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/PostPortImpl.java
@@ -95,4 +95,14 @@ public class PostPortImpl extends DomainModelMapper implements PostPort {
         return this.postRepository.findByUserId(userId, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE))
                 .map(this::entityToDomainModel);
     }
+
+    @Override
+    public Optional<PostDomainModel> restore(String id, PostDomainModel postDomainModel) {
+        return this.postRepository.findById(id).map(
+                srcPost -> {
+                    srcPost.setIsDeleted(false);
+                    return this.entityToDomainModel(this.postRepository.save(srcPost));
+                }
+        );
+    }
 }

--- a/src/main/java/net/causw/adapter/web/PostController.java
+++ b/src/main/java/net/causw/adapter/web/PostController.java
@@ -99,7 +99,7 @@ public class PostController {
         );
     }
 
-    @PutMapping(value = "/restore/{id}")
+    @PutMapping(value = "/{id}/restore")
     @ResponseStatus(value = HttpStatus.OK)
     public PostResponseDto restore(
             @AuthenticationPrincipal String requestUserId,

--- a/src/main/java/net/causw/adapter/web/PostController.java
+++ b/src/main/java/net/causw/adapter/web/PostController.java
@@ -98,4 +98,16 @@ public class PostController {
                 postUpdateRequestDto
         );
     }
+
+    @PutMapping(value = "/restore/{id}")
+    @ResponseStatus(value = HttpStatus.OK)
+    public PostResponseDto restore(
+            @AuthenticationPrincipal String requestUserId,
+            @PathVariable String id
+    ) {
+        return this.postService.restore(
+                requestUserId,
+                id
+        );
+    }
 }

--- a/src/main/java/net/causw/application/PostService.java
+++ b/src/main/java/net/causw/application/PostService.java
@@ -648,7 +648,6 @@ public class PostService {
                         postDomainModel.getWriter().getId(),
                         List.of()
                 ))
-                .consistOf(ConstraintValidator.of(postDomainModel, this.validator))
                 .validate();
 
         PostDomainModel restoredPostDomainModel = this.postPort.restore(postId, postDomainModel).orElseThrow(

--- a/src/main/java/net/causw/application/spi/PostPort.java
+++ b/src/main/java/net/causw/application/spi/PostPort.java
@@ -24,4 +24,6 @@ public interface PostPort {
     Optional<PostDomainModel> findLatest(String boardId);
 
     Page<PostDomainModel> findByUserId(String userId, Integer pageNum);
+
+    Optional<PostDomainModel> restore(String id, PostDomainModel postDomainModel);
 }

--- a/src/main/java/net/causw/domain/validation/TargetIsNotDeletedValidator.java
+++ b/src/main/java/net/causw/domain/validation/TargetIsNotDeletedValidator.java
@@ -1,0 +1,30 @@
+package net.causw.domain.validation;
+
+import net.causw.domain.exceptions.BadRequestException;
+import net.causw.domain.exceptions.ErrorCode;
+
+public class TargetIsNotDeletedValidator extends AbstractValidator {
+
+    private final boolean isDeleted;
+
+    private final String domain;
+
+    private TargetIsNotDeletedValidator(boolean isDeleted, String domain) {
+        this.isDeleted = isDeleted;
+        this.domain = domain;
+    }
+
+    public static TargetIsNotDeletedValidator of(boolean isDeleted, String domain) {
+        return new TargetIsNotDeletedValidator(isDeleted, domain);
+    }
+
+    @Override
+    public void validate() {
+        if (!this.isDeleted) {
+            throw new BadRequestException(
+                    ErrorCode.TARGET_DELETED,
+                    String.format("삭제되지 않은 %s 입니다.", this.domain)
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Related issue
resolves #214

## Description
post restore 기능

## Changes detail
Post Controller, Post Service, PostPort에 restore 메소드 추가했습니다.
삭제되지 않은 게시물을 복구하는 경우를 위해서 TargetIsNotDeletedValidator 추가했습니다.

### Checklist

- [ ] Test case
- [ ] End of work
