### PR TITLE
feat: restore board

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/port/BoardPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/BoardPortImpl.java
@@ -80,4 +80,15 @@ public class BoardPortImpl extends DomainModelMapper implements BoardPort {
                 }
         );
     }
+
+    @Override
+    public Optional<BoardDomainModel> restore(String id) {
+        return this.boardRepository.findById(id).map(
+                srcBoard -> {
+                    srcBoard.setIsDeleted(false);
+
+                    return this.entityToDomainModel(this.boardRepository.save(srcBoard));
+                }
+        );
+    }
 }

--- a/src/main/java/net/causw/adapter/web/BoardController.java
+++ b/src/main/java/net/causw/adapter/web/BoardController.java
@@ -60,4 +60,13 @@ public class BoardController {
     ) {
         return this.boardService.delete(deleterId, id);
     }
+
+    @PutMapping(value = "/restore/{id}")
+    @ResponseStatus(value =  HttpStatus.OK)
+    public BoardResponseDto restore(
+            @AuthenticationPrincipal String restorerId,
+            @PathVariable String id
+    ){
+        return this.boardService.restore(restorerId, id);
+    }
 }

--- a/src/main/java/net/causw/application/spi/BoardPort.java
+++ b/src/main/java/net/causw/application/spi/BoardPort.java
@@ -21,4 +21,6 @@ public interface BoardPort {
     Optional<BoardDomainModel> update(String id, BoardDomainModel boardDomainModel);
 
     Optional<BoardDomainModel> delete(String id);
+
+    Optional<BoardDomainModel> restore(String id);
 }

--- a/src/main/java/net/causw/domain/validation/TargetIsNotDeletedValidator.java
+++ b/src/main/java/net/causw/domain/validation/TargetIsNotDeletedValidator.java
@@ -1,0 +1,30 @@
+package net.causw.domain.validation;
+
+import net.causw.domain.exceptions.BadRequestException;
+import net.causw.domain.exceptions.ErrorCode;
+
+public class TargetIsNotDeletedValidator extends AbstractValidator {
+
+    private final boolean isDeleted;
+
+    private final String domain;
+
+    private TargetIsNotDeletedValidator(boolean isDeleted, String domain) {
+        this.isDeleted = isDeleted;
+        this.domain = domain;
+    }
+
+    public static TargetIsNotDeletedValidator of(boolean isDeleted, String domain) {
+        return new TargetIsNotDeletedValidator(isDeleted, domain);
+    }
+
+    @Override
+    public void validate() {
+        if (!this.isDeleted) {
+            throw new BadRequestException(
+                    ErrorCode.TARGET_DELETED,
+                    String.format("삭제되지 않은 %s 입니다.", this.domain)
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Related issue
- \#213

## Description
Add restoring board API

## Changes detail
- BoardController, BoardService, BoardPort, BoardPortImpl 에 restore 관련 메서드를  추가해 restore board API를 구현
-  삭제되지 않은 게시판에 대한 restore 접근 제어를 위해 TargetIsNotDeletedValidator 추가
- 삭제된 게시판에 대해 restore하면 Board table의 is_deleted를 false로 변경

### Checklist

- [ ] Test case
- [ ] End of work
