### PR TITLE
feat/restore_circles

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/port/CirclePortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/CirclePortImpl.java
@@ -84,4 +84,15 @@ public class CirclePortImpl extends DomainModelMapper implements CirclePort {
                 }
         );
     }
+
+    @Override
+    public Optional<CircleDomainModel> restore(String id) {
+        return this.circleRepository.findById(id).map(
+                srcCircle -> {
+                    srcCircle.setIsDeleted(false);
+                    return this.entityToDomainModel(this.circleRepository.save(srcCircle));
+                }
+        );
+
+    }
 }

--- a/src/main/java/net/causw/adapter/web/CircleController.java
+++ b/src/main/java/net/causw/adapter/web/CircleController.java
@@ -159,7 +159,7 @@ public class CircleController {
         return this.circleService.delete(requestUserId, id);
     }
 
-    @PutMapping(value = "/restore/{circleId}")
+    @PutMapping(value = "/{circleId}/restore")
     @ResponseStatus(value = HttpStatus.OK)
     public CircleResponseDto restore(
             @AuthenticationPrincipal String requestUserId,

--- a/src/main/java/net/causw/adapter/web/CircleController.java
+++ b/src/main/java/net/causw/adapter/web/CircleController.java
@@ -158,4 +158,13 @@ public class CircleController {
     ) {
         return this.circleService.delete(requestUserId, id);
     }
+
+    @PutMapping(value = "/restore/{circleId}")
+    @ResponseStatus(value = HttpStatus.OK)
+    public CircleResponseDto restore(
+            @AuthenticationPrincipal String requestUserId,
+            @PathVariable String circleId
+    ) {
+        return this.circleService.restore(requestUserId, circleId);
+    }
 }

--- a/src/main/java/net/causw/application/CircleService.java
+++ b/src/main/java/net/causw/application/CircleService.java
@@ -17,6 +17,7 @@ import net.causw.application.spi.UserPort;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
+import net.causw.domain.exceptions.UnauthorizedException;
 import net.causw.domain.model.BoardDomainModel;
 import net.causw.domain.model.CircleDomainModel;
 import net.causw.domain.model.CircleMemberDomainModel;
@@ -450,9 +451,9 @@ public class CircleService {
             validatorBucket
                     .consistOf(UserEqualValidator.of(
                             circle.getLeader().map(UserDomainModel::getId).orElseThrow(
-                                    () -> new InternalServerException(
-                                            ErrorCode.INTERNAL_SERVER,
-                                            "This circle has not circle leader"
+                                    () -> new UnauthorizedException(
+                                            ErrorCode.API_NOT_ALLOWED,
+                                            "해당 소모임의 소모임장이 아닙니다."
                                     )
                             ),
                             user.getId()
@@ -765,21 +766,8 @@ public class CircleService {
                 .consistOf(TargetIsNotDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
                 .consistOf(UserRoleValidator.of(
                         user.getRole(),
-                        List.of(Role.PRESIDENT, Role.LEADER_CIRCLE)
+                        List.of(Role.ADMIN)
                 ));
-
-        if (user.getRole().equals(Role.LEADER_CIRCLE)) {
-            validatorBucket
-                    .consistOf(UserEqualValidator.of(
-                            circle.getLeader().map(UserDomainModel::getId).orElseThrow(
-                                    () -> new InternalServerException(
-                                            ErrorCode.INTERNAL_SERVER,
-                                            "This circle has not circle leader"
-                                    )
-                            ),
-                            requestUserId
-                    ));
-        }
 
         validatorBucket
                 .validate();

--- a/src/main/java/net/causw/application/spi/CirclePort.java
+++ b/src/main/java/net/causw/application/spi/CirclePort.java
@@ -22,4 +22,6 @@ public interface CirclePort {
     Optional<CircleDomainModel> updateLeader(String id, UserDomainModel newLeader);
 
     Optional<CircleDomainModel> delete(String id);
+
+    Optional<CircleDomainModel> restore(String id);
 }

--- a/src/main/java/net/causw/domain/validation/TargetIsNotDeletedValidator.java
+++ b/src/main/java/net/causw/domain/validation/TargetIsNotDeletedValidator.java
@@ -1,0 +1,30 @@
+package net.causw.domain.validation;
+
+import net.causw.domain.exceptions.BadRequestException;
+import net.causw.domain.exceptions.ErrorCode;
+
+public class TargetIsDeletedValidator extends AbstractValidator {
+
+    private final boolean isDeleted;
+
+    private final String domain;
+
+    private TargetIsDeletedValidator(boolean isDeleted, String domain) {
+        this.isDeleted = isDeleted;
+        this.domain = domain;
+    }
+
+    public static TargetIsDeletedValidator of(boolean isDeleted, String domain) {
+        return new TargetIsDeletedValidator(isDeleted, domain);
+    }
+
+    @Override
+    public void validate() {
+        if (this.isDeleted) {
+            throw new BadRequestException(
+                    ErrorCode.TARGET_DELETED,
+                    String.format("삭제된 %s 입니다.", this.domain)
+            );
+        }
+    }
+}

--- a/src/main/java/net/causw/domain/validation/TargetIsNotDeletedValidator.java
+++ b/src/main/java/net/causw/domain/validation/TargetIsNotDeletedValidator.java
@@ -3,27 +3,27 @@ package net.causw.domain.validation;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 
-public class TargetIsDeletedValidator extends AbstractValidator {
+public class TargetIsNotDeletedValidator extends AbstractValidator {
 
     private final boolean isDeleted;
 
     private final String domain;
 
-    private TargetIsDeletedValidator(boolean isDeleted, String domain) {
+    private TargetIsNotDeletedValidator(boolean isDeleted, String domain) {
         this.isDeleted = isDeleted;
         this.domain = domain;
     }
 
-    public static TargetIsDeletedValidator of(boolean isDeleted, String domain) {
-        return new TargetIsDeletedValidator(isDeleted, domain);
+    public static TargetIsNotDeletedValidator of(boolean isDeleted, String domain) {
+        return new TargetIsNotDeletedValidator(isDeleted, domain);
     }
 
     @Override
     public void validate() {
-        if (this.isDeleted) {
+        if (!this.isDeleted) {
             throw new BadRequestException(
                     ErrorCode.TARGET_DELETED,
-                    String.format("삭제된 %s 입니다.", this.domain)
+                    String.format("삭제되지 않은 %s 입니다.", this.domain)
             );
         }
     }


### PR DESCRIPTION
## Related issue
resolves #212

## Description
삭제된 동아리 복구하는 api 입니다.

## Changes detail
- CircleController, Service, Port에 restore 메소드 추가
- 삭제되지 않은 동아리를 복구하려는 경우를 위해 TargetIsNotDeletedValidator 추가
- 예외 처리는 유저id, 소모임id가 존재하지 않는 경우, 삭제되지 않은 소모임인 경우, 요청 사용자가 학생회장, 관리자, 소모임장이 아닌 경우, 소모임장이 요청했을 때 해당 소모임의 소모임장이 아닌경우에 적용했습니다.

### Checklist

- [ ] Test case
- [ ] End of work
