### PR TITLE
feat: restore board

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/port/BoardPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/BoardPortImpl.java
@@ -80,4 +80,15 @@ public class BoardPortImpl extends DomainModelMapper implements BoardPort {
                 }
         );
     }
+
+    @Override
+    public Optional<BoardDomainModel> restore(String id) {
+        return this.boardRepository.findById(id).map(
+                srcBoard -> {
+                    srcBoard.setIsDeleted(false);
+
+                    return this.entityToDomainModel(this.boardRepository.save(srcBoard));
+                }
+        );
+    }
 }

--- a/src/main/java/net/causw/adapter/web/BoardController.java
+++ b/src/main/java/net/causw/adapter/web/BoardController.java
@@ -60,4 +60,13 @@ public class BoardController {
     ) {
         return this.boardService.delete(deleterId, id);
     }
+
+    @PutMapping(value = "/{id}/restore")
+    @ResponseStatus(value =  HttpStatus.OK)
+    public BoardResponseDto restore(
+            @AuthenticationPrincipal String restorerId,
+            @PathVariable String id
+    ){
+        return this.boardService.restore(restorerId, id);
+    }
 }

--- a/src/main/java/net/causw/application/BoardService.java
+++ b/src/main/java/net/causw/application/BoardService.java
@@ -20,6 +20,7 @@ import net.causw.domain.validation.UserEqualValidator;
 import net.causw.domain.validation.UserRoleIsNoneValidator;
 import net.causw.domain.validation.UserRoleValidator;
 import net.causw.domain.validation.UserStateValidator;
+import net.causw.domain.validation.TargetIsNotDeletedValidator;
 import net.causw.domain.validation.ValidatorBucket;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -228,6 +229,14 @@ public class BoardService {
                 )
         );
 
+        if (boardDomainModel.getCategory().equals(StaticValue.BOARD_NAME_APP_NOTICE)) {
+            validatorBucket
+                    .consistOf(UserRoleValidator.of(
+                            deleterDomainModel.getRole(),
+                            List.of()
+                    ));
+        }
+
         validatorBucket
                 .consistOf(UserStateValidator.of(deleterDomainModel.getState()))
                 .consistOf(UserRoleIsNoneValidator.of(deleterDomainModel.getRole()))
@@ -267,6 +276,77 @@ public class BoardService {
                         )
                 ),
                 deleterDomainModel.getRole()
+        );
+    }
+
+    @Transactional
+    public BoardResponseDto restore(
+            String restorerId,
+            String boardId
+    ){
+        ValidatorBucket validatorBucket = ValidatorBucket.of();
+
+        UserDomainModel restorerDomainModel = this.userPort.findById(restorerId).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        "로그인된 사용자를 찾을 수 없습니다."
+                )
+        );
+
+        BoardDomainModel boardDomainModel = this.boardPort.findById(boardId).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        "복구할 게시판을 찾을 수 없습니다."
+                )
+        );
+
+        if (boardDomainModel.getCategory().equals(StaticValue.BOARD_NAME_APP_NOTICE)) {
+            validatorBucket
+                    .consistOf(UserRoleValidator.of(
+                            restorerDomainModel.getRole(),
+                            List.of()
+                    ));
+        }
+
+        validatorBucket
+                .consistOf(UserStateValidator.of(restorerDomainModel.getState()))
+                .consistOf(UserRoleIsNoneValidator.of(restorerDomainModel.getRole()))
+                .consistOf(TargetIsNotDeletedValidator.of(boardDomainModel.getIsDeleted(), StaticValue.DOMAIN_BOARD));
+
+        boardDomainModel.getCircle().ifPresentOrElse(
+                circleDomainModel -> {
+                    validatorBucket
+                            .consistOf(TargetIsDeletedValidator.of(circleDomainModel.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
+                            .consistOf(UserRoleValidator.of(restorerDomainModel.getRole(), List.of(Role.LEADER_CIRCLE)));
+
+                    if (restorerDomainModel.getRole().equals(Role.LEADER_CIRCLE)) {
+                        validatorBucket
+                                .consistOf(UserEqualValidator.of(
+                                        circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
+                                                () -> new InternalServerException(
+                                                        ErrorCode.INTERNAL_SERVER,
+                                                        "The board has circle without circle leader"
+                                                )
+                                        ),
+                                        restorerId
+                                ));
+                    }
+                },
+                () -> validatorBucket
+                        .consistOf(UserRoleValidator.of(restorerDomainModel.getRole(), List.of(Role.PRESIDENT)))
+        );
+
+        validatorBucket
+                .validate();
+
+        return BoardResponseDto.from(
+                this.boardPort.restore(boardId).orElseThrow(
+                        () -> new InternalServerException(
+                                ErrorCode.INTERNAL_SERVER,
+                                "Board id checked, but exception occurred"
+                        )
+                ),
+                restorerDomainModel.getRole()
         );
     }
 }

--- a/src/main/java/net/causw/application/spi/BoardPort.java
+++ b/src/main/java/net/causw/application/spi/BoardPort.java
@@ -21,4 +21,6 @@ public interface BoardPort {
     Optional<BoardDomainModel> update(String id, BoardDomainModel boardDomainModel);
 
     Optional<BoardDomainModel> delete(String id);
+
+    Optional<BoardDomainModel> restore(String id);
 }


### PR DESCRIPTION
## Related issue
resolves #213

## Description
Add restoring board API

## Changes detail

- BoardController, BoardService, BoardPort, BoardPortImpl 에 restore 관련 메서드를 추가해 restore board API를 구현
- 삭제되지 않은 게시판에 대한 restore 접근 제어를 위해 TargetIsNotDeletedValidator 추가
- 삭제된 게시판에 대해 restore하면 Board table의 is_deleted를 false로 변경
- Board delete와 restore에 대해 ADMIN 권한 검증 추가

### Checklist

- [ ] Test case
- [ ] End of work
