### PR TITLE
feat: Implement Inquiry

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/Inquiry.java
+++ b/src/main/java/net/causw/adapter/persistence/Inquiry.java
@@ -1,0 +1,104 @@
+package net.causw.adapter.persistence;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import net.causw.domain.model.InquiryDomainModel;
+import net.causw.domain.model.PostDomainModel;
+import org.hibernate.annotations.ColumnDefault;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@Table(name = "TB_INQUIRY")
+public class Inquiry extends BaseEntity{
+    @Column(name = "title",nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", name = "content", nullable = false)
+    private String content;
+
+    @ManyToOne(targetEntity = User.class)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User writer;
+
+    @Column(name = "is_deleted")
+    @ColumnDefault("false")
+    private Boolean isDeleted;
+
+
+    private Inquiry(
+            String title,
+            String content,
+            User writer,
+            Boolean isDeleted
+    ){
+        this.title = title;
+        this.content = content;
+        this.writer = writer;
+        this.isDeleted = isDeleted;
+    }
+
+    private Inquiry(
+            String id,
+            String title,
+            String content,
+            User writer,
+            Boolean isDeleted
+    ){
+        super(id);
+        this.title = title;
+        this.content = content;
+        this.writer = writer;
+        this.isDeleted = isDeleted;
+    }
+
+    public static Inquiry of(
+            String title,
+            String content,
+            User writer,
+            Boolean isDeleted
+    ){
+        return new Inquiry(
+                title,
+                content,
+                writer,
+                isDeleted
+        );
+    }
+
+    public static Inquiry of(
+            String id,
+            String title,
+            String content,
+            User writer,
+            Boolean isDeleted,
+            Boolean isPublic
+    ){
+        return new Inquiry(
+                id,
+                title,
+                content,
+                writer,
+                isDeleted
+        );
+    }
+
+    public static Inquiry from(InquiryDomainModel inquiryDomainModel) {
+        return new Inquiry(
+                inquiryDomainModel.getId(),
+                inquiryDomainModel.getTitle(),
+                inquiryDomainModel.getContent(),
+                User.from(inquiryDomainModel.getWriter()),
+                inquiryDomainModel.getIsDeleted()
+        );
+    }
+
+}

--- a/src/main/java/net/causw/adapter/persistence/port/DomainModelMapper.java
+++ b/src/main/java/net/causw/adapter/persistence/port/DomainModelMapper.java
@@ -11,6 +11,7 @@ import net.causw.adapter.persistence.LockerLocation;
 import net.causw.adapter.persistence.Post;
 import net.causw.adapter.persistence.User;
 import net.causw.adapter.persistence.UserAdmission;
+import net.causw.adapter.persistence.Inquiry;
 import net.causw.domain.model.BoardDomainModel;
 import net.causw.domain.model.ChildCommentDomainModel;
 import net.causw.domain.model.CircleDomainModel;
@@ -22,6 +23,7 @@ import net.causw.domain.model.LockerLocationDomainModel;
 import net.causw.domain.model.PostDomainModel;
 import net.causw.domain.model.UserAdmissionDomainModel;
 import net.causw.domain.model.UserDomainModel;
+import net.causw.domain.model.InquiryDomainModel;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -155,6 +157,18 @@ public abstract class DomainModelMapper {
                 circleMember.getUser().getName(),
                 circleMember.getCreatedAt(),
                 circleMember.getUpdatedAt()
+        );
+    }
+
+    protected InquiryDomainModel entityToDomainModel(Inquiry inquiry){
+        return InquiryDomainModel.of(
+                inquiry.getId(),
+                inquiry.getTitle(),
+                inquiry.getContent(),
+                this.entityToDomainModel(inquiry.getWriter()),
+                inquiry.getIsDeleted(),
+                inquiry.getCreatedAt(),
+                inquiry.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/net/causw/adapter/persistence/port/InquiryPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/InquiryPortImpl.java
@@ -1,0 +1,27 @@
+package net.causw.adapter.persistence.port;
+
+import net.causw.adapter.persistence.Inquiry;
+import net.causw.application.spi.InquiryPort;
+import net.causw.domain.model.InquiryDomainModel;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class InquiryPortImpl extends DomainModelMapper implements InquiryPort {
+    private final InquiryRepository inquiryRepository;
+
+    public InquiryPortImpl(InquiryRepository inquiryRepository) {
+        this.inquiryRepository = inquiryRepository;
+    }
+
+    @Override
+    public Optional<InquiryDomainModel> findById(String id){
+        return this.inquiryRepository.findById(id).map(this::entityToDomainModel);
+    }
+
+    @Override
+    public InquiryDomainModel create(InquiryDomainModel inquiryDomainModel) {
+        return this.entityToDomainModel(this.inquiryRepository.save(Inquiry.from(inquiryDomainModel)));
+    }
+}

--- a/src/main/java/net/causw/adapter/persistence/port/InquiryRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/port/InquiryRepository.java
@@ -1,0 +1,8 @@
+package net.causw.adapter.persistence.port;
+
+import net.causw.adapter.persistence.Inquiry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InquiryRepository extends JpaRepository<Inquiry, String> {
+
+}

--- a/src/main/java/net/causw/adapter/web/InquiryController.java
+++ b/src/main/java/net/causw/adapter/web/InquiryController.java
@@ -1,0 +1,39 @@
+package net.causw.adapter.web;
+
+import net.causw.application.InquiryService;
+import net.causw.application.dto.inquiry.InquiryCreateRequestDto;
+import net.causw.application.dto.inquiry.InquiryResponseDto;
+import net.causw.application.dto.post.BoardPostsResponseDto;
+import net.causw.application.dto.post.PostResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/inquirys")
+public class InquiryController {
+
+    private final InquiryService inquiryService;
+
+    public InquiryController(InquiryService inquiryService) {
+        this.inquiryService = inquiryService;
+    }
+
+    @GetMapping(value = "/{id}")
+    @ResponseStatus(value = HttpStatus.OK)
+    public InquiryResponseDto findById(
+            @AuthenticationPrincipal String requestUserId,
+            @PathVariable String id
+    ) {
+        return this.inquiryService.findById(requestUserId,id);
+    }
+
+    @PostMapping
+    @ResponseStatus(value = HttpStatus.CREATED)
+    public InquiryResponseDto create(
+            @AuthenticationPrincipal String requestUserId,
+            @RequestBody InquiryCreateRequestDto inquiryCreateRequestDto
+    ) {
+        return this.inquiryService.create(requestUserId, inquiryCreateRequestDto);
+    }
+}

--- a/src/main/java/net/causw/adapter/web/InquiryController.java
+++ b/src/main/java/net/causw/adapter/web/InquiryController.java
@@ -10,7 +10,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/inquirys")
+@RequestMapping("/api/v1/inquiries")
 public class InquiryController {
 
     private final InquiryService inquiryService;

--- a/src/main/java/net/causw/application/InquiryService.java
+++ b/src/main/java/net/causw/application/InquiryService.java
@@ -13,8 +13,14 @@ import net.causw.application.spi.UserPort;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.UnauthorizedException;
-import net.causw.domain.model.*;
-import net.causw.domain.validation.*;
+import net.causw.domain.model.InquiryDomainModel;
+import net.causw.domain.model.StaticValue;
+import net.causw.domain.model.UserDomainModel;
+import net.causw.domain.validation.ValidatorBucket;
+import net.causw.domain.validation.UserStateValidator;
+import net.causw.domain.validation.UserRoleIsNoneValidator;
+import net.causw.domain.validation.TargetIsDeletedValidator;
+import net.causw.domain.validation.ConstraintValidator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -58,7 +64,7 @@ public class InquiryService {
         validatorBucket
                 .consistOf(UserStateValidator.of(userDomainModel.getState()))
                 .consistOf(UserRoleIsNoneValidator.of(userDomainModel.getRole()))
-                .consistOf(TargetIsDeletedValidator.of(inquiryDomainModel.getIsDeleted(), "문의글"));
+                .consistOf(TargetIsDeletedValidator.of(inquiryDomainModel.getIsDeleted(), StaticValue.DOMAIN_INQUIRY));
 
         validatorBucket
                 .validate();

--- a/src/main/java/net/causw/application/InquiryService.java
+++ b/src/main/java/net/causw/application/InquiryService.java
@@ -1,0 +1,103 @@
+package net.causw.application;
+
+import net.causw.adapter.persistence.Inquiry;
+import net.causw.application.dto.comment.CommentResponseDto;
+import net.causw.application.dto.inquiry.InquiryCreateRequestDto;
+import net.causw.application.dto.inquiry.InquiryResponseDto;
+import net.causw.application.dto.post.BoardPostsResponseDto;
+import net.causw.application.dto.post.PostCreateRequestDto;
+import net.causw.application.dto.post.PostResponseDto;
+import net.causw.application.dto.post.PostsResponseDto;
+import net.causw.application.spi.InquiryPort;
+import net.causw.application.spi.UserPort;
+import net.causw.domain.exceptions.BadRequestException;
+import net.causw.domain.exceptions.ErrorCode;
+import net.causw.domain.exceptions.UnauthorizedException;
+import net.causw.domain.model.*;
+import net.causw.domain.validation.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.validation.Validator;
+import java.util.List;
+
+@Service
+public class InquiryService {
+
+    private final UserPort userPort;
+    private final Validator validator;
+    private final InquiryPort inquiryPort;
+
+    public InquiryService(UserPort userPort, Validator validator, InquiryPort inquiryPort) {
+        this.userPort = userPort;
+        this.validator = validator;
+        this.inquiryPort = inquiryPort;
+    }
+
+    @Transactional(readOnly = true)
+    public InquiryResponseDto findById(
+            String requestUserId,
+            String inquiryId
+    ) {
+        ValidatorBucket validatorBucket = ValidatorBucket.of();
+
+        UserDomainModel userDomainModel = this.userPort.findById(requestUserId).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        "로그인된 사용자를 찾을 수 없습니다."
+                )
+        );
+
+        InquiryDomainModel inquiryDomainModel = this.inquiryPort.findById(inquiryId).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        "문의글을 찾을 수 없습니다."
+                )
+        );
+
+        validatorBucket
+                .consistOf(UserStateValidator.of(userDomainModel.getState()))
+                .consistOf(UserRoleIsNoneValidator.of(userDomainModel.getRole()))
+                .consistOf(TargetIsDeletedValidator.of(inquiryDomainModel.getIsDeleted(), "문의글"));
+
+        validatorBucket
+                .validate();
+
+        return InquiryResponseDto.from(
+                inquiryDomainModel,
+                userDomainModel
+        );
+    }
+
+    @Transactional
+    public InquiryResponseDto create(String requestUserId, InquiryCreateRequestDto inquiryCreateRequestDto) {
+        ValidatorBucket validatorBucket = ValidatorBucket.of();
+
+        UserDomainModel creatorDomainModel = this.userPort.findById(requestUserId).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        "로그인된 사용자를 찾을 수 없습니다."
+                )
+        );
+
+        validatorBucket
+                .consistOf(UserStateValidator.of(creatorDomainModel.getState()))
+                .consistOf(UserRoleIsNoneValidator.of(creatorDomainModel.getRole()));
+
+        InquiryDomainModel inquiryDomainModel = InquiryDomainModel.of(
+                inquiryCreateRequestDto.getTitle(),
+                inquiryCreateRequestDto.getContent(),
+                creatorDomainModel
+        );
+
+        validatorBucket
+                .consistOf(ConstraintValidator.of(inquiryDomainModel, this.validator))
+                .validate();
+
+        return InquiryResponseDto.from(
+                this.inquiryPort.create(inquiryDomainModel),
+                creatorDomainModel
+        );
+    }
+
+}

--- a/src/main/java/net/causw/application/dto/inquiry/InquiryCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/inquiry/InquiryCreateRequestDto.java
@@ -1,0 +1,13 @@
+package net.causw.application.dto.inquiry;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class InquiryCreateRequestDto {
+    private String title;
+    private String content;
+}

--- a/src/main/java/net/causw/application/dto/inquiry/InquiryResponseDto.java
+++ b/src/main/java/net/causw/application/dto/inquiry/InquiryResponseDto.java
@@ -21,7 +21,7 @@ public class InquiryResponseDto {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public InquiryResponseDto(
+    private InquiryResponseDto(
             String id,
             String title,
             String content,

--- a/src/main/java/net/causw/application/dto/inquiry/InquiryResponseDto.java
+++ b/src/main/java/net/causw/application/dto/inquiry/InquiryResponseDto.java
@@ -1,0 +1,69 @@
+package net.causw.application.dto.inquiry;
+
+import lombok.Getter;
+import lombok.Setter;
+import net.causw.domain.model.InquiryDomainModel;
+import net.causw.domain.model.Role;
+import net.causw.domain.model.UserDomainModel;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class InquiryResponseDto {
+    private String id;
+    private String title;
+    private String content;
+    private Boolean isDeleted;
+    private String writerName;
+    private Boolean updatable;
+    private Boolean deletable;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public InquiryResponseDto(
+            String id,
+            String title,
+            String content,
+            Boolean isDeleted,
+            String writerName,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.isDeleted = isDeleted;
+        this.writerName = writerName;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static InquiryResponseDto from(
+            InquiryDomainModel inquiry,
+            UserDomainModel user
+    ){
+        boolean updatable = false;
+        boolean deletable = false;
+
+        if (user.getRole() == Role.ADMIN) {
+            updatable = true;
+            deletable = true;
+        } else if (inquiry.getWriter().getId().equals(user.getId())) {
+            updatable = true;
+            deletable = true;
+        } else {
+
+        }
+
+        return new InquiryResponseDto(
+                inquiry.getId(),
+                inquiry.getTitle(),
+                inquiry.getContent(),
+                inquiry.getIsDeleted(),
+                inquiry.getWriter().getName(),
+                inquiry.getCreatedAt(),
+                inquiry.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/net/causw/application/spi/InquiryPort.java
+++ b/src/main/java/net/causw/application/spi/InquiryPort.java
@@ -1,0 +1,12 @@
+package net.causw.application.spi;
+
+import net.causw.domain.model.InquiryDomainModel;
+import net.causw.domain.model.UserDomainModel;
+
+import java.util.Optional;
+
+public interface InquiryPort {
+    Optional<InquiryDomainModel> findById(String id);
+    InquiryDomainModel create(InquiryDomainModel inquiryDomainModel);
+
+}

--- a/src/main/java/net/causw/domain/model/InquiryDomainModel.java
+++ b/src/main/java/net/causw/domain/model/InquiryDomainModel.java
@@ -1,0 +1,84 @@
+package net.causw.domain.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+public class InquiryDomainModel {
+
+    private String id;
+
+    @NotBlank(message = "문의글 제목이 입력되지 않았습니다.")
+    private String title;
+    private String content;
+
+    @NotNull(message = "작성자가 입력되지 않았습니다.")
+    private UserDomainModel writer;
+
+    @NotNull(message = "문의글 상태가 입력되지 않았습니다.")
+    private Boolean isDeleted;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private InquiryDomainModel(
+            String id,
+            String title,
+            String content,
+            UserDomainModel writer,
+            Boolean isDeleted,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.writer = writer;
+        this.isDeleted = isDeleted;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static InquiryDomainModel of(
+            String id,
+            String title,
+            String content,
+            UserDomainModel writer,
+            Boolean isDeleted,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        return new InquiryDomainModel(
+                id,
+                title,
+                content,
+                writer,
+                isDeleted,
+                createdAt,
+                updatedAt
+        );
+    }
+    public static InquiryDomainModel of(
+            String title,
+            String content,
+            UserDomainModel writer
+    ) {
+        return new InquiryDomainModel(
+                null,
+                title,
+                content,
+                writer,
+                false,
+                null,
+                null
+        );
+    }
+
+}

--- a/src/main/java/net/causw/domain/model/StaticValue.java
+++ b/src/main/java/net/causw/domain/model/StaticValue.java
@@ -40,6 +40,7 @@ public class StaticValue {
     public static final String DOMAIN_CIRCLE = "소모임";
     public static final String DOMAIN_COMMENT = "댓글";
     public static final String DOMAIN_CHILD_COMMENT = "답글";
+    public static final String DOMAIN_INQUIRY = "문의글";
 
     // Flag
     public static final String LOCKER_ACCESS = "LOCKER_ACCESS";


### PR DESCRIPTION
## Related issue
resolves #394 

## Description
"문의하기 " 기능 기획시 1. 이메일을 통한 문의내용 발송 2. 채팅으로 문의 3. 게시판 형식으로 문의 세 가지 방식으로 기획 구성을 했습니다. 1,2 번의 방식은 별도의 이메일 로그인 구현, 웹소켓 적용 등 부가적인 의견을 여쭤봐야 할 것 같아 3번 컨셉으로 우선적으로 구현해보았습니다. 다른 분들의 "문의하기" 기획안을 듣고 3번 이외 다른 방식이 적절하다면 이에 맞춰 다시 진행하도록 하겠습니다. 이와 같은 방식이 적절하다면 구체적인 메서드, validation을 해당 풀리퀘릍 통해 추가할 예정입니다.

- "문의하기" 구현을 위해 "TB_INQUIRY"를 추가하였습니다
- Inquiry를 조회하기 위해 Id를 통해 조회하는 findById메서드를 구현하였습니다.
- Inquriy를 생성하기 위해 create 메서드를 구현하였습니다.
- Inquiry처리를 위해 부가적으로  InquiryController, InquriyService, InquriyRepository 등을 생성하였습니다.

Post를 레퍼런스로 작성하였으며 Post를 떠올리시면 이해하시기 쉬울 것 같습니다.

## Changes detail

- Inquriy, InquiryController, InquriySerivce, InquriyPort, InquiryPortImpl, InquiryRepository, InquiryCreateRequestDto, InquriyResponseDto, InquiryDomainModel을 생성했습니다.
- InquriyDomainModel을 처리하기 위해 DomainModelMapper에 관련 메서드를 수정하였습니다.

### Checklist

- [ ] Test case
- [ ] End of work
