### PR TITLE
[FEAT]: 백엔드 에러로그 Discord로 LogBack 설정 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     testImplementation "org.junit.vintage:junit-vintage-engine"
     testImplementation "org.powermock:powermock-api-mockito2:2.0.2"
     testImplementation "org.powermock:powermock-module-junit4:2.0.2"
+
+    // Discord LogBack
+    implementation 'com.github.napstr:logback-discord-appender:1.0.0'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 jar {


### PR DESCRIPTION
### 📢 전달사항
프론트 <-> 백엔드 / 백엔드 <-> 백엔드 소통을 위해 에러 로그를 공유할 수 있도록 디스코드에 연결했습니다.
스프링부트 단에서 Error 레벨의 로그가 발생하면 디스코드로 전송할 수 있도록 구현했습니다.
정보 채널 -> back-end-error 채널에 전송할 수 있도록 연결했습니다
gitignore 파일이 대부분이라 노션에 있는 파일 꼭 적용 부탁드립니다.

### 📸 스크린샷
<img width="1440" alt="image" src="https://github.com/CAUCSE/CAUSW_backend/assets/91439717/b77bbbb7-c644-4078-ade5-761423ec8deb">


### 📃 진행사항
- [ ] SpringBoot Error 로그 Discord WebHook 연결


개발기간: 60m