### PR TITLE
fix: discord webhook 관련 gitignore 속성 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,11 @@ out/
 .LSOverride
 
 ### Project security ###
-**/resources/
+**/resources/application.yml
+**/resources/email-config.yaml
+**/resources/password-config.yaml
+**/resources/causw-dev-51ab1a030da2.json
+
 Dockerfile
 docker-compose.yaml
 deploy_*.sh

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProperty name="DISCORD_WEBHOOK_URL" source="logging.discord.webhook-uri"/>
+    <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
+        <webhookUri>${DISCORD_WEBHOOK_URL}</webhookUri>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{HH:mm:ss} [%thread] [%-5level] %logger{36} - %msg%n```%ex{full}```</pattern>
+        </layout>
+        <username>BACKEND-ERROR!</username>
+        <tts>false</tts>
+    </appender>
+
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="DISCORD" />
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="ASYNC_DISCORD"/>
+        <appender-ref ref="Console"/>
+    </root>
+</configuration>


### PR DESCRIPTION
### 📢 전달사항
로컬에서는 webhook이 정상 동작하지만 개발계 서버에서는 webhook이 정상 동작하지 않는 이슈 해결


### 📃 진행사항
- [ ] gitignore 속성 변경

### ⚙️ 기타사항
기존 logback.xml이 gitignore 처리 되어있었지만 이를 public으로 바꾸고 안의 민감정보(webhook-uri)를 gitignore 처리해준 뒤에 속성화 사용