### PR TITLE
refactor : swagger 상에서 user token header로 받기(circle만)

### DIFF
--- a/src/main/java/net/causw/adapter/web/CircleController.java
+++ b/src/main/java/net/causw/adapter/web/CircleController.java
@@ -1,6 +1,5 @@
 package net.causw.adapter.web;
 
-import io.swagger.v3.oas.annotations.Parameter;
 import net.causw.application.circle.CircleService;
 import net.causw.application.dto.circle.CirclesResponseDto;
 import net.causw.application.dto.circle.CircleCreateRequestDto;
@@ -11,9 +10,7 @@ import net.causw.application.dto.circle.CircleBoardsResponseDto;
 import net.causw.application.dto.duplicate.DuplicatedCheckResponseDto;
 import net.causw.domain.model.enums.CircleMemberStatus;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/main/java/net/causw/adapter/web/CircleController.java
+++ b/src/main/java/net/causw/adapter/web/CircleController.java
@@ -44,9 +44,9 @@ public class CircleController {
     @ResponseStatus(value = HttpStatus.OK)
     public List<CirclesResponseDto> findAll() {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String userId = ((String) principal);
+        String currentUserId = ((String) principal);
 
-        return this.circleService.findAll(userId);
+        return this.circleService.findAll(currentUserId);
     }
 
     @GetMapping("/{id}/boards")
@@ -55,9 +55,9 @@ public class CircleController {
             @PathVariable String id
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String userId = ((String) principal);
+        String currentUserId = ((String) principal);
 
-        return this.circleService.findBoards(userId, id);
+        return this.circleService.findBoards(currentUserId, id);
     }
 
     @GetMapping(value = "/{id}/num-member")
@@ -88,9 +88,9 @@ public class CircleController {
             @RequestBody CircleCreateRequestDto circleCreateRequestDto
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String userId = ((String) principal);
+        String currentUserId = ((String) principal);
 
-        return this.circleService.create(userId, circleCreateRequestDto);
+        return this.circleService.create(currentUserId, circleCreateRequestDto);
     }
 
     @PutMapping(value = "/{circleId}")
@@ -100,9 +100,9 @@ public class CircleController {
             @RequestBody CircleUpdateRequestDto circleUpdateRequestDto
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String userId = ((String) principal);
+        String currentUserId = ((String) principal);
 
-        return this.circleService.update(userId, circleId, circleUpdateRequestDto);
+        return this.circleService.update(currentUserId, circleId, circleUpdateRequestDto);
     }
 
     @GetMapping(value = "/{circleId}/applications")
@@ -111,9 +111,9 @@ public class CircleController {
             @PathVariable String circleId
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String userId = ((String) principal);
+        String currentUserId = ((String) principal);
 
-        return this.circleService.userApply(userId, circleId);
+        return this.circleService.userApply(currentUserId, circleId);
     }
 
     @GetMapping(value = "/{name}/is-duplicated")
@@ -128,9 +128,9 @@ public class CircleController {
             @PathVariable String circleId
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String userId = ((String) principal);
+        String currentUserId = ((String) principal);
 
-        return this.circleService.leaveUser(userId, circleId);
+        return this.circleService.leaveUser(currentUserId, circleId);
     }
 
     @PutMapping(value = "/{circleId}/users/{userId}/drop")
@@ -140,10 +140,10 @@ public class CircleController {
             @PathVariable String circleId
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String requestUserId = ((String) principal);
+        String currentUserId = ((String) principal);
 
         return this.circleService.dropUser(
-                requestUserId,
+                currentUserId,
                 userId,
                 circleId
         );
@@ -155,9 +155,9 @@ public class CircleController {
             @PathVariable String applicationId
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String requestUserId = ((String) principal);
+        String currentUserId = ((String) principal);
 
-        return this.circleService.acceptUser(requestUserId, applicationId);
+        return this.circleService.acceptUser(currentUserId, applicationId);
     }
 
     @PutMapping(value = "/applications/{applicationId}/reject")
@@ -166,9 +166,9 @@ public class CircleController {
             @PathVariable String applicationId
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String requestUserId = ((String) principal);
+        String currentUserId = ((String) principal);
 
-        return this.circleService.rejectUser(requestUserId, applicationId);
+        return this.circleService.rejectUser(currentUserId, applicationId);
     }
 
     @DeleteMapping(value = "/{id}")
@@ -177,9 +177,9 @@ public class CircleController {
             @PathVariable String id
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String requestUserId = ((String) principal);
+        String currentUserId = ((String) principal);
 
-        return this.circleService.delete(requestUserId, id);
+        return this.circleService.delete(currentUserId, id);
     }
 }
 

--- a/src/main/java/net/causw/adapter/web/CircleController.java
+++ b/src/main/java/net/causw/adapter/web/CircleController.java
@@ -1,5 +1,6 @@
 package net.causw.adapter.web;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import net.causw.application.circle.CircleService;
 import net.causw.application.dto.circle.CirclesResponseDto;
 import net.causw.application.dto.circle.CircleCreateRequestDto;
@@ -11,6 +12,8 @@ import net.causw.application.dto.duplicate.DuplicatedCheckResponseDto;
 import net.causw.domain.model.enums.CircleMemberStatus;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -42,16 +45,21 @@ public class CircleController {
 
     @GetMapping
     @ResponseStatus(value = HttpStatus.OK)
-    public List<CirclesResponseDto> findAll(@AuthenticationPrincipal String userId) {
+    public List<CirclesResponseDto> findAll() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String userId = ((String) principal);
+
         return this.circleService.findAll(userId);
     }
 
     @GetMapping("/{id}/boards")
     @ResponseStatus(value = HttpStatus.OK)
     public CircleBoardsResponseDto findBoards(
-            @AuthenticationPrincipal String userId,
             @PathVariable String id
     ) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String userId = ((String) principal);
+
         return this.circleService.findBoards(userId, id);
     }
 
@@ -64,10 +72,12 @@ public class CircleController {
     @GetMapping(value = "/{id}/users")
     @ResponseStatus(value = HttpStatus.OK)
     public List<CircleMemberResponseDto> getUserList(
-            @AuthenticationPrincipal String currentUserId,
             @PathVariable String id,
             @RequestParam CircleMemberStatus status
     ) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String currentUserId = ((String) principal);
+
         return this.circleService.getUserList(
                 currentUserId,
                 id,
@@ -78,28 +88,34 @@ public class CircleController {
     @PostMapping
     @ResponseStatus(value = HttpStatus.CREATED)
     public CircleResponseDto create(
-            @AuthenticationPrincipal String userId,
             @RequestBody CircleCreateRequestDto circleCreateRequestDto
     ) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String userId = ((String) principal);
+
         return this.circleService.create(userId, circleCreateRequestDto);
     }
 
     @PutMapping(value = "/{circleId}")
     @ResponseStatus(value = HttpStatus.OK)
     public CircleResponseDto update(
-            @AuthenticationPrincipal String userId,
             @PathVariable String circleId,
             @RequestBody CircleUpdateRequestDto circleUpdateRequestDto
     ) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String userId = ((String) principal);
+
         return this.circleService.update(userId, circleId, circleUpdateRequestDto);
     }
 
     @GetMapping(value = "/{circleId}/applications")
     @ResponseStatus(value = HttpStatus.CREATED)
     public CircleMemberResponseDto userApply(
-            @AuthenticationPrincipal String userId,
             @PathVariable String circleId
     ) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String userId = ((String) principal);
+
         return this.circleService.userApply(userId, circleId);
     }
 
@@ -112,19 +128,23 @@ public class CircleController {
     @PutMapping(value = "/{circleId}/users/leave")
     @ResponseStatus(value = HttpStatus.OK)
     public CircleMemberResponseDto leaveUser(
-            @AuthenticationPrincipal String userId,
             @PathVariable String circleId
     ) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String userId = ((String) principal);
+
         return this.circleService.leaveUser(userId, circleId);
     }
 
     @PutMapping(value = "/{circleId}/users/{userId}/drop")
     @ResponseStatus(value = HttpStatus.OK)
     public CircleMemberResponseDto dropUser(
-            @AuthenticationPrincipal String requestUserId,
             @PathVariable String userId,
             @PathVariable String circleId
     ) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String requestUserId = ((String) principal);
+
         return this.circleService.dropUser(
                 requestUserId,
                 userId,
@@ -135,27 +155,34 @@ public class CircleController {
     @PutMapping(value = "/applications/{applicationId}/accept")
     @ResponseStatus(value = HttpStatus.OK)
     public CircleMemberResponseDto acceptUser(
-            @AuthenticationPrincipal String requestUserId,
             @PathVariable String applicationId
     ) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String requestUserId = ((String) principal);
+
         return this.circleService.acceptUser(requestUserId, applicationId);
     }
 
     @PutMapping(value = "/applications/{applicationId}/reject")
     @ResponseStatus(value = HttpStatus.OK)
     public CircleMemberResponseDto rejectUser(
-            @AuthenticationPrincipal String requestUserId,
             @PathVariable String applicationId
     ) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String requestUserId = ((String) principal);
+
         return this.circleService.rejectUser(requestUserId, applicationId);
     }
 
     @DeleteMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.OK)
     public CircleResponseDto delete(
-            @AuthenticationPrincipal String requestUserId,
             @PathVariable String id
     ) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String requestUserId = ((String) principal);
+
         return this.circleService.delete(requestUserId, id);
     }
 }
+

--- a/src/main/java/net/causw/config/swagger/SwaggerConfig.java
+++ b/src/main/java/net/causw/config/swagger/SwaggerConfig.java
@@ -3,15 +3,11 @@ package net.causw.config.swagger;
 import net.causw.domain.model.util.StaticValue;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.core.userdetails.UserDetailsService;
+import springfox.documentation.service.*;
 import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.ApiKey;
-import springfox.documentation.service.AuthorizationScope;
-import springfox.documentation.service.SecurityReference;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
@@ -31,16 +27,22 @@ public class SwaggerConfig {
                 .paths(PathSelectors.any())
                 .build()
                 .apiInfo(this.apiInfo())
+                .useDefaultResponseMessages(false)
                 .securityContexts(Collections.singletonList(securityContext()))
                 .securitySchemes(List.of(apiKey()))
-                .globalOperationParameters(Arrays.asList(
-                        new springfox.documentation.builders.ParameterBuilder()
-                                .name("Authorization")
-                                .description("JWT token")
-                                .modelRef(new springfox.documentation.schema.ModelRef("string"))
-                                .parameterType("header")
-                                .required(true)
-                                .build()));
+                .globalOperationParameters(buildGlobalOperationParameters());
+    }
+
+    private List<Parameter> buildGlobalOperationParameters() {
+        return Arrays.asList(
+                new springfox.documentation.builders.ParameterBuilder()
+                        .name("Authorization")
+                        .description("JWT token")
+                        .modelRef(new springfox.documentation.schema.ModelRef("string"))
+                        .parameterType("header")
+                        .required(true)
+                        .build()
+        );
     }
 
     private ApiInfo apiInfo() {

--- a/src/main/java/net/causw/config/swagger/SwaggerConfig.java
+++ b/src/main/java/net/causw/config/swagger/SwaggerConfig.java
@@ -3,6 +3,7 @@ package net.causw.config.swagger;
 import net.causw.domain.model.util.StaticValue;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
@@ -15,6 +16,7 @@ import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -29,9 +31,16 @@ public class SwaggerConfig {
                 .paths(PathSelectors.any())
                 .build()
                 .apiInfo(this.apiInfo())
-                .useDefaultResponseMessages(false)
                 .securityContexts(Collections.singletonList(securityContext()))
-                .securitySchemes(List.of(apiKey()));
+                .securitySchemes(List.of(apiKey()))
+                .globalOperationParameters(Arrays.asList(
+                        new springfox.documentation.builders.ParameterBuilder()
+                                .name("Authorization")
+                                .description("JWT token")
+                                .modelRef(new springfox.documentation.schema.ModelRef("string"))
+                                .parameterType("header")
+                                .required(true)
+                                .build()));
     }
 
     private ApiInfo apiInfo() {
@@ -47,13 +56,10 @@ public class SwaggerConfig {
     }
 
     private SecurityContext securityContext() {
-        return springfox
-                .documentation
-                .spi.service
-                .contexts
-                .SecurityContext
-                .builder()
-                .securityReferences(defaultAuth()).forPaths(PathSelectors.any()).build();
+        return SecurityContext.builder()
+                .securityReferences(defaultAuth())
+                .forPaths(PathSelectors.any())
+                .build();
     }
 
     List<SecurityReference> defaultAuth() {


### PR DESCRIPTION
### 🚩 관련사항
Issue #432 


### 📢 전달사항
기존 Swagger UI에서 user token을 request body로 받으려 해 모든 API 요청 시 request body에 중괄호가 2쌍 생성되어 json parsing error가 발생했었습니다.
SecurityContextHolder.getContext().getAuthentication().getPricipal()을 통해 Swagger UI에서 user token을 통해 상단 Authorize 버튼으로 인증을 하면 자동으로 request header에 user token을 넣어주는 방식으로 변경했습니다.

### 📸 스크린샷
변경 후 Swagger UI
<img width="1407" alt="edited swagger" src="https://github.com/CAUCSE/CAUSW_backend/assets/53044223/7e3fd0b4-ccda-4901-a32c-afe81f5bb265">






### 📃 진행사항
- [x] SwaggerConfig.java 변경
- [x] 모든 domain Controller 변경


### ⚙️ 기타사항

개발기간: 약 10시간