### PR TITLE
feat : 게시글 API 검증 및 수정 / swagger 보강

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/port/post/PostPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/post/PostPortImpl.java
@@ -26,7 +26,7 @@ public class PostPortImpl extends DomainModelMapper implements PostPort {
     }
 
     @Override
-    public Optional<PostDomainModel> findById(String id) {
+    public Optional<PostDomainModel> findPostById(String id) {
         return this.postRepository.findById(id).map(this::entityToDomainModel);
     }
 
@@ -61,7 +61,13 @@ public class PostPortImpl extends DomainModelMapper implements PostPort {
 
     @Override
     public Page<PostDomainModel> findAll(String boardId, Integer pageNum) {
-        return this.postRepository.findAllByBoard_IdAndIsDeletedIsFalseOrderByCreatedAtDesc(boardId, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE))
+        return this.postRepository.findAllByBoard_IdOrderByCreatedAtDesc(boardId, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE))
+                .map(this::entityToDomainModel);
+    }
+
+    @Override
+    public Page<PostDomainModel> findAll(String boardId, Integer pageNum, boolean isDeleted) {
+        return this.postRepository.findAllByBoard_IdAndIsDeletedOrderByCreatedAtDesc(boardId, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE), isDeleted)
                 .map(this::entityToDomainModel);
     }
 
@@ -71,14 +77,29 @@ public class PostPortImpl extends DomainModelMapper implements PostPort {
                 .map(this::entityToDomainModel);
     }
 
+
     @Override
-    public Page<PostDomainModel> search(SearchOption option, String keyword, Integer pageNum) {
+    public Page<PostDomainModel> search(SearchOption option, String keyword, String boardId, Integer pageNum) {
         switch (option){
             case TITLE:
-                return this.postRepository.searchByTitle(keyword, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE))
+                return this.postRepository.searchByTitle(keyword, boardId, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE))
                         .map(this::entityToDomainModel);
             case WRITER:
-                return this.postRepository.searchByWriter(keyword, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE))
+                return this.postRepository.searchByWriter(keyword, boardId, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE))
+                        .map(this::entityToDomainModel);
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public Page<PostDomainModel> search(SearchOption option, String keyword, String boardId, Integer pageNum, boolean isDeleted) {
+        switch (option){
+            case TITLE:
+                return this.postRepository.searchByTitle(keyword, boardId, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE), isDeleted)
+                        .map(this::entityToDomainModel);
+            case WRITER:
+                return this.postRepository.searchByWriter(keyword, boardId, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE), isDeleted)
                         .map(this::entityToDomainModel);
             default:
                 return null;

--- a/src/main/java/net/causw/adapter/persistence/post/Post.java
+++ b/src/main/java/net/causw/adapter/persistence/post/Post.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 @Setter
 @Entity
 @NoArgsConstructor
-@Table(name = "TB_POST")
+@Table(name = "tb_post")
 public class Post extends BaseEntity {
     @Column(name = "title", nullable = false)
     private String title;

--- a/src/main/java/net/causw/adapter/persistence/repository/PostRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/PostRepository.java
@@ -13,17 +13,40 @@ import java.util.Optional;
 @Repository
 public interface PostRepository extends JpaRepository<Post, String> {
     Page<Post> findAllByBoard_IdAndIsDeletedIsFalseOrderByCreatedAtDesc(String boardId, Pageable pageable);
+    Page<Post> findAllByBoard_IdAndIsDeletedOrderByCreatedAtDesc(String boardId, Pageable pageable, boolean IsDeleted);
+    Page<Post> findAllByBoard_IdOrderByCreatedAtDesc(String boardId, Pageable pageable);
     Optional<Post> findTop1ByBoard_IdAndIsDeletedIsFalseOrderByCreatedAtDesc(String boardId);
 
+
+    //해당 동아리의 동아리장, 관리자, 학생회장인 경우 삭제여부와 관계없이 모든 게시글 검색
     @Query(value = "SELECT * " +
-            "FROM TB_POST AS p " +
-            "WHERE p.title = %:title% ORDER BY p.created_at DESC", nativeQuery = true)
-    Page<Post> searchByTitle(@Param("title") String userName, Pageable pageable);
+            "FROM tb_post AS p " +
+            "WHERE p.title LIKE CONCAT('%', :title, '%')AND p.board_id = :boardId ORDER BY p.created_at DESC", nativeQuery = true)
+    Page<Post> searchByTitle(@Param("title") String title, @Param("boardId") String boardId, Pageable pageable);
+
     @Query(value = "SELECT * " +
-            "FROM TB_POST AS p " +
-            "LEFT JOIN TB_USER AS u ON p.user_id = u.id " +
-            "WHERE u.name = %:user_name% ORDER BY p.created_at DESC", nativeQuery = true)
-    Page<Post> searchByWriter(@Param("user_name") String userName, Pageable pageable);
+            "FROM tb_post AS p " +
+            "LEFT JOIN tb_user AS u ON p.user_id = u.id " +
+            "WHERE u.name LIKE CONCAT('%', :userName, '%') AND p.board_id = :boardId ORDER BY p.created_at DESC", nativeQuery = true)
+    Page<Post> searchByWriter(@Param("userName") String userName, @Param("boardId") String boardId, Pageable pageable);
+
+
+    //해당 동아리의 동아리장, 관리자, 학생회장이 아닌경우 삭제되지 않은 게시글 검색
+    @Query(value = "SELECT * " +
+            "FROM tb_post AS p " +
+            "WHERE p.title LIKE CONCAT('%', :title, '%')AND p.board_id = :boardId AND p.is_deleted = :isDeleted ORDER BY p.created_at DESC", nativeQuery = true)
+    Page<Post> searchByTitle(@Param("title") String title, @Param("boardId") String boardId, Pageable pageable, boolean isDeleted);
+
+    @Query(value = "SELECT * " +
+            "FROM tb_post AS p " +
+            "LEFT JOIN tb_user AS u ON p.user_id = u.id " +
+            "WHERE u.name LIKE CONCAT('%', :userName, '%') AND p.board_id = :boardId AND p.is_deleted = :isDeleted ORDER BY p.created_at DESC", nativeQuery = true)
+    Page<Post> searchByWriter(@Param("userName") String userName, @Param("boardId") String boardId, Pageable pageable, boolean isDeleted);
+
+
+
+
+
 
     @Query(value = "select * from tb_post as p " +
             "join tb_board as b on p.board_id = b.id " +

--- a/src/main/java/net/causw/adapter/persistence/user/User.java
+++ b/src/main/java/net/causw/adapter/persistence/user/User.java
@@ -24,7 +24,7 @@ import java.util.List;
 @Setter
 @Entity
 @NoArgsConstructor
-@Table(name = "TB_USER")
+@Table(name = "tb_user")
 public class User extends BaseEntity {
     @Column(name = "email", unique = true, nullable = false)
     private String email;

--- a/src/main/java/net/causw/adapter/web/PostController.java
+++ b/src/main/java/net/causw/adapter/web/PostController.java
@@ -6,7 +6,7 @@ import net.causw.application.dto.post.PostCreateRequestDto;
 import net.causw.application.dto.post.PostResponseDto;
 import net.causw.application.dto.post.PostUpdateRequestDto;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -30,70 +30,77 @@ public class PostController {
     @GetMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.OK)
     public PostResponseDto findById(
-            @AuthenticationPrincipal String requestUserId,
             @PathVariable String id
     ) {
-        return this.postService.findById(requestUserId, id);
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String loginUserId = ((String) principal);
+        return this.postService.findById(loginUserId, id);
     }
 
     @GetMapping
     @ResponseStatus(value = HttpStatus.OK)
     public BoardPostsResponseDto findAll(
-            @AuthenticationPrincipal String requestUserId,
             @RequestParam String boardId,
             @RequestParam(defaultValue = "0") Integer pageNum
     ) {
-        return this.postService.findAll(requestUserId, boardId, pageNum);
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String loginUserId = ((String) principal);
+        return this.postService.findAll(loginUserId, boardId, pageNum);
     }
 
     @GetMapping("/search")
     @ResponseStatus(value = HttpStatus.OK)
     public BoardPostsResponseDto search(
-            @AuthenticationPrincipal String requestUserId,
             @RequestParam String boardId,
             @RequestParam(defaultValue = "title") String option,
             @RequestParam(defaultValue = "") String keyword,
             @RequestParam(defaultValue = "0") Integer pageNum
     ) {
-        return this.postService.search(requestUserId, boardId, option, keyword, pageNum);
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String loginUserId = ((String) principal);
+        return this.postService.search(loginUserId, boardId, option, keyword, pageNum);
     }
 
     @GetMapping("/app/notice")
     @ResponseStatus(value = HttpStatus.OK)
     public BoardPostsResponseDto findAllAppNotice(
-            @AuthenticationPrincipal String requestUserId,
             @RequestParam(defaultValue = "0") Integer pageNum
     ) {
-        return this.postService.findAllAppNotice(requestUserId, pageNum);
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String loginUserId = ((String) principal);
+        return this.postService.findAllAppNotice(loginUserId, pageNum);
     }
 
     @PostMapping
     @ResponseStatus(value = HttpStatus.CREATED)
     public PostResponseDto create(
-            @AuthenticationPrincipal String requestUserId,
             @RequestBody PostCreateRequestDto postCreateRequestDto
     ) {
-        return this.postService.create(requestUserId, postCreateRequestDto);
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String loginUserId = ((String) principal);
+        return this.postService.create(loginUserId, postCreateRequestDto);
     }
 
     @DeleteMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.OK)
     public PostResponseDto delete(
-            @AuthenticationPrincipal String requestUserId,
             @PathVariable String id
     ) {
-        return this.postService.delete(requestUserId, id);
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String loginUserId = ((String) principal);
+        return this.postService.delete(loginUserId, id);
     }
 
     @PutMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.OK)
     public PostResponseDto update(
-            @AuthenticationPrincipal String requestUserId,
             @PathVariable String id,
             @RequestBody PostUpdateRequestDto postUpdateRequestDto
     ) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String loginUserId = ((String) principal);
         return this.postService.update(
-                requestUserId,
+                loginUserId,
                 id,
                 postUpdateRequestDto
         );
@@ -102,11 +109,12 @@ public class PostController {
     @PutMapping(value = "/{id}/restore")
     @ResponseStatus(value = HttpStatus.OK)
     public PostResponseDto restore(
-            @AuthenticationPrincipal String requestUserId,
             @PathVariable String id
     ) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String loginUserId = ((String) principal);
         return this.postService.restore(
-                requestUserId,
+                loginUserId,
                 id
         );
     }

--- a/src/main/java/net/causw/adapter/web/PostController.java
+++ b/src/main/java/net/causw/adapter/web/PostController.java
@@ -1,5 +1,6 @@
 package net.causw.adapter.web;
 
+import io.swagger.annotations.ApiOperation;
 import net.causw.application.post.PostService;
 import net.causw.application.dto.post.BoardPostsResponseDto;
 import net.causw.application.dto.post.PostCreateRequestDto;
@@ -29,17 +30,19 @@ public class PostController {
 
     @GetMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.OK)
-    public PostResponseDto findById(
+    @ApiOperation(value = "게시글 열람 API(validator응답값 추가 예정 / 사용가능)", notes = "게시판에서 게시글을 선택했을 때 게시글을 열람할 수 있습니다.")
+    public PostResponseDto findPostById(
             @PathVariable String id
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         String loginUserId = ((String) principal);
-        return this.postService.findById(loginUserId, id);
+        return this.postService.findPostById(loginUserId, id);
     }
 
     @GetMapping
     @ResponseStatus(value = HttpStatus.OK)
-    public BoardPostsResponseDto findAll(
+    @ApiOperation(value = "게시글 전체 조회 API(validator응답값 추가 예정 / 사용가능)", notes = "전체 게시글을 불러오는 api로 페이지 별로 불러올 수 있습니다.\n현재 한 페이지당 20개의 게시글이 조회 가능합니다 \n 1페이지는 value값이 0입니다")
+    public BoardPostsResponseDto findAllPost(
             @RequestParam String boardId,
             @RequestParam(defaultValue = "0") Integer pageNum
     ) {
@@ -50,7 +53,8 @@ public class PostController {
 
     @GetMapping("/search")
     @ResponseStatus(value = HttpStatus.OK)
-    public BoardPostsResponseDto search(
+    @ApiOperation(value = "게시글 검색 API(validator응답값 추가 예정 / 사용가능)", notes = "게시글을 검색하는 api로 검색 option은 writer와 title 중 택1입니다.")
+    public BoardPostsResponseDto searchPost(
             @RequestParam String boardId,
             @RequestParam(defaultValue = "title") String option,
             @RequestParam(defaultValue = "") String keyword,
@@ -63,6 +67,7 @@ public class PostController {
 
     @GetMapping("/app/notice")
     @ResponseStatus(value = HttpStatus.OK)
+    @ApiOperation(value = "앱 자체 공지사항 확인 API(프론트에 없음)", notes = "현재 프론트단에 코드가 존재하지 않습니다")
     public BoardPostsResponseDto findAllAppNotice(
             @RequestParam(defaultValue = "0") Integer pageNum
     ) {
@@ -73,7 +78,8 @@ public class PostController {
 
     @PostMapping
     @ResponseStatus(value = HttpStatus.CREATED)
-    public PostResponseDto create(
+    @ApiOperation(value = "게시글 생성 API(validator응답값 추가 예정 / 사용가능)", notes = "게시글을 생성하는 api로 각 게시판의 createrolelist에 따라서 작성할 수 있는 권한이 달라집니다.")
+    public PostResponseDto createPost(
             @RequestBody PostCreateRequestDto postCreateRequestDto
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
@@ -83,7 +89,8 @@ public class PostController {
 
     @DeleteMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.OK)
-    public PostResponseDto delete(
+    @ApiOperation(value = "게시글 삭제 API(validator응답값 추가 예정 / 사용가능)", notes = "게시글을 삭제하는 api로 작성자 본인이나 해당 게시판이 속한 동아리의 동아리장, 관리자, 학생회장의 경우 삭제 가능합니다.")
+    public PostResponseDto deletePost(
             @PathVariable String id
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
@@ -93,7 +100,8 @@ public class PostController {
 
     @PutMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.OK)
-    public PostResponseDto update(
+    @ApiOperation(value = "게시글 업데이트 API(validator응답값 추가 예정 / 사용가능)", notes = "게시글을 업뎅이트하는 api로 작성자 본인이나 해당 게시판이 속한 동아리의 동아리장, 관리자, 학생회장의 경우 업데이트 가능합니다.")
+    public PostResponseDto updatePost(
             @PathVariable String id,
             @RequestBody PostUpdateRequestDto postUpdateRequestDto
     ) {
@@ -108,7 +116,8 @@ public class PostController {
 
     @PutMapping(value = "/{id}/restore")
     @ResponseStatus(value = HttpStatus.OK)
-    public PostResponseDto restore(
+    @ApiOperation(value = "게시글 복구 API(validator응답값 추가 예정 / 사용가능)", notes = "게시글을 복구하는 api로 작성자 본인이나 해당 게시판이 속한 동아리의 동아리장, 관리자, 학생회장의 경우 복구 가능합니다.")
+    public PostResponseDto restorePost(
             @PathVariable String id
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();

--- a/src/main/java/net/causw/application/comment/ChildCommentService.java
+++ b/src/main/java/net/causw/application/comment/ChildCommentService.java
@@ -93,7 +93,7 @@ public class ChildCommentService {
                 )
         );
 
-        PostDomainModel postDomainModel = this.postPort.findById(parentCommentDomainModel.getPostId()).orElseThrow(
+        PostDomainModel postDomainModel = this.postPort.findPostById(parentCommentDomainModel.getPostId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
                         "게시글을 찾을 수 없습니다."
@@ -171,7 +171,7 @@ public class ChildCommentService {
                 )
         );
 
-        PostDomainModel postDomainModel = this.postPort.findById(parentCommentDomainModel.getPostId()).orElseThrow(
+        PostDomainModel postDomainModel = this.postPort.findPostById(parentCommentDomainModel.getPostId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
                         "게시글을 찾을 수 없습니다."
@@ -250,7 +250,7 @@ public class ChildCommentService {
                 )
         );
 
-        PostDomainModel postDomainModel = this.postPort.findById(childCommentDomainModel.getParentComment().getPostId()).orElseThrow(
+        PostDomainModel postDomainModel = this.postPort.findPostById(childCommentDomainModel.getParentComment().getPostId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
                         "게시글을 찾을 수 없습니다."
@@ -331,7 +331,7 @@ public class ChildCommentService {
                 )
         );
 
-        PostDomainModel postDomainModel = this.postPort.findById(childCommentDomainModel.getParentComment().getPostId()).orElseThrow(
+        PostDomainModel postDomainModel = this.postPort.findPostById(childCommentDomainModel.getParentComment().getPostId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
                         "게시글을 찾을 수 없습니다."

--- a/src/main/java/net/causw/application/comment/CommentService.java
+++ b/src/main/java/net/causw/application/comment/CommentService.java
@@ -74,7 +74,7 @@ public class CommentService {
                 .consistOf(UserStateValidator.of(creatorDomainModel.getState()))
                 .consistOf(UserRoleIsNoneValidator.of(creatorDomainModel.getRole()));
 
-        PostDomainModel postDomainModel = this.postPort.findById(commentCreateDto.getPostId()).orElseThrow(
+        PostDomainModel postDomainModel = this.postPort.findPostById(commentCreateDto.getPostId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
                         "게시글을 찾을 수 없습니다."
@@ -137,7 +137,7 @@ public class CommentService {
                 )
         );
 
-        PostDomainModel postDomainModel = this.postPort.findById(postId).orElseThrow(
+        PostDomainModel postDomainModel = this.postPort.findPostById(postId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
                         "게시글을 찾을 수 없습니다."
@@ -209,7 +209,7 @@ public class CommentService {
                 )
         );
 
-        PostDomainModel postDomainModel = this.postPort.findById(commentDomainModel.getPostId()).orElseThrow(
+        PostDomainModel postDomainModel = this.postPort.findPostById(commentDomainModel.getPostId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
                         "게시글을 찾을 수 없습니다."
@@ -291,7 +291,7 @@ public class CommentService {
                 )
         );
 
-        PostDomainModel postDomainModel = this.postPort.findById(commentDomainModel.getPostId()).orElseThrow(
+        PostDomainModel postDomainModel = this.postPort.findPostById(commentDomainModel.getPostId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
                         "게시글을 찾을 수 없습니다."

--- a/src/main/java/net/causw/application/dto/post/BoardPostsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/BoardPostsResponseDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.post;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.domain.model.board.BoardDomainModel;
@@ -9,10 +10,20 @@ import org.springframework.data.domain.Page;
 @Getter
 @Setter
 public class BoardPostsResponseDto {
+
+    @ApiModelProperty(value = "게시판 id", example = "uuid 형식의 String 값입니다.")
     private String boardId;
+
+    @ApiModelProperty(value = "게시판 이름", example = "게시판 이름입니다.")
     private String boardName;
+
+    @ApiModelProperty(value = "게시글 작성 가능여부", example = "true")
     private Boolean writable;
+
+    @ApiModelProperty(value = "즐겨찾기 게시판 여부", example = "false")
     private Boolean isFavorite;
+
+    @ApiModelProperty(value = "게시글 정보입니다", example = "게시글 정보입니다")
     private Page<PostsResponseDto> post;
 
     private BoardPostsResponseDto(

--- a/src/main/java/net/causw/application/dto/post/PostCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/post/PostCreateRequestDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.post;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,9 +14,16 @@ import java.util.Optional;
 @AllArgsConstructor
 @NoArgsConstructor
 public class PostCreateRequestDto {
+    @ApiModelProperty(value = "게시글 제목", example = "공지사항입니다.")
     private String title;
+
+    @ApiModelProperty(value = "게시글 내용", example = "안녕하세요. 학생회입니다. 공지사항입니다.")
     private String content;
+
+    @ApiModelProperty(value = "게시판 id", example = "uuid 형식의 String 값입니다.")
     private String boardId;
+
+    @ApiModelProperty(value = "첨부파일", example = "첨부파일 url 작성")
     private List<String> attachmentList;
 
     public List<String> getAttachmentList() {

--- a/src/main/java/net/causw/application/dto/post/PostResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/PostResponseDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.post;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.application.dto.file.FileResponseDto;
@@ -17,23 +18,55 @@ import java.util.stream.Collectors;
 @Getter
 @Setter
 public class PostResponseDto {
+    @ApiModelProperty(value = "게시글 id", example = "uuid 형식의 String 값입니다.")
     private String id;
+
+    @ApiModelProperty(value = "게시글 제목", example = "게시글의 제목입니다.")
     private String title;
+
+    @ApiModelProperty(value = "게시글 내용", example = "안녕하세요. 학생회입니다. 공지사항입니다.")
     private String content;
+
+    @ApiModelProperty(value = "게시글 삭제여부", example = "false")
     private Boolean isDeleted;
+
+    @ApiModelProperty(value = "게시글 작성자 이름", example = "관리자")
     private String writerName;
+
+    @ApiModelProperty(value = "게시글 작성자의 승인년도", example = "2020")
     private Integer writerAdmissionYear;
+
+    @ApiModelProperty(value = "게시글 작성자의 프로필 이미지", example = "프로필 이미지 url 작성")
     private String writerProfileImage;
+
+    @ApiModelProperty(value = "첨부파일", example = "첨부파일 url 작성")
     private List<FileResponseDto> attachmentList;
+
+    @ApiModelProperty(value = "답글 개수", example = "13")
     private Long numComment;
+
+    @ApiModelProperty(value = "게시글이 속한 게시판 정보", example = "게시판 정보 조회")
     private BoardResponseDto board;
+
+    @ApiModelProperty(value = "게시글 업데이트 가능여부", example = "true")
     private Boolean updatable;
+
+    @ApiModelProperty(value = "게시글 삭제 가능여부", example = "true")
     private Boolean deletable;
+
+    @ApiModelProperty(value = "게시글 생성 시간", example =  "2024-01-26T18:40:40.643Z")
     private LocalDateTime createdAt;
+
+    @ApiModelProperty(value = "게시글 업데이트 시간", example =  "2024-01-26T18:40:40.643Z")
     private LocalDateTime updatedAt;
+
+    @ApiModelProperty(value = "게시글의 답글 정보", example =  "답글에 대한 정보 조회")
     private Page<CommentResponseDto> commentList;
 
+    @ApiModelProperty(value = "게시판 id", example =  "uuid 형식의 String 값입니다.")
     private String boardId;
+
+    @ApiModelProperty(value = "게시판 이름", example =  "게시판 이름입니다.")
     private String boardName;
 
     private PostResponseDto(

--- a/src/main/java/net/causw/application/dto/post/PostUpdateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/post/PostUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.post;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,8 +14,13 @@ import java.util.Optional;
 @AllArgsConstructor
 @NoArgsConstructor
 public class PostUpdateRequestDto {
+    @ApiModelProperty(value = "게시글 제목", example = "게시글의 제목입니다.")
     private String title;
+
+    @ApiModelProperty(value = "게시글 내용", example = "게시글의 내용입니다.")
     private String content;
+
+    @ApiModelProperty(value = "첨부파일", example = "첨부파일 url 작성")
     private List<String> attachmentList;
 
     public List<String> getAttachmentList() {

--- a/src/main/java/net/causw/application/dto/post/PostsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/PostsResponseDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.post;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.domain.model.post.PostDomainModel;
@@ -9,12 +10,25 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 public class PostsResponseDto {
+    @ApiModelProperty(value = "게시글 id", example = "uuid 형식의 String 값입니다.")
     private String id;
+
+    @ApiModelProperty(value = "게시글 제목", example = "게시글의 제목입니다.")
     private String title;
+
+    @ApiModelProperty(value = "게시글 작성자 이름", example = "관리자")
     private String writerName;
+
+    @ApiModelProperty(value = "게시글 작성자의 승인년도", example = "2020")
     private Integer writerAdmissionYear;
+
+    @ApiModelProperty(value = "답글 개수", example = "13")
     private Long numComment;
+
+    @ApiModelProperty(value = "게시글 생성 시간", example =  "2024-01-26T18:40:40.643Z")
     private LocalDateTime createdAt;
+
+    @ApiModelProperty(value = "게시글 업데이트 시간", example =  "2024-01-26T18:40:40.643Z")
     private LocalDateTime updatedAt;
 
     private PostsResponseDto(

--- a/src/main/java/net/causw/application/post/PostService.java
+++ b/src/main/java/net/causw/application/post/PostService.java
@@ -76,10 +76,10 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public PostResponseDto findById(String requestUserId, String postId) {
+    public PostResponseDto findById(String loginUserId, String postId) {
         ValidatorBucket validatorBucket = ValidatorBucket.of();
 
-        UserDomainModel userDomainModel = this.userPort.findById(requestUserId).orElseThrow(
+        UserDomainModel userDomainModel = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
                         "로그인된 사용자를 찾을 수 없습니다."
@@ -143,13 +143,13 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public BoardPostsResponseDto findAll(
-            String requestUserId,
+            String loginUserId,
             String boardId,
             Integer pageNum
     ) {
         ValidatorBucket validatorBucket = ValidatorBucket.of();
 
-        UserDomainModel userDomainModel = this.userPort.findById(requestUserId).orElseThrow(
+        UserDomainModel userDomainModel = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
                         "로그인된 사용자를 찾을 수 없습니다."
@@ -197,7 +197,7 @@ public class PostService {
         return BoardPostsResponseDto.from(
                 boardDomainModel,
                 userDomainModel.getRole(),
-                this.favoriteBoardPort.findByUserId(requestUserId)
+                this.favoriteBoardPort.findByUserId(loginUserId)
                         .stream()
                         .anyMatch(favoriteBoardDomainModel -> favoriteBoardDomainModel.getBoardDomainModel().getId().equals(boardDomainModel.getId())),
                 this.postPort.findAll(boardId, pageNum)
@@ -210,7 +210,7 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public BoardPostsResponseDto search(
-            String requestUserId,
+            String loginUserId,
             String boardId,
             String option,
             String keyword,
@@ -218,7 +218,7 @@ public class PostService {
     ) {
         ValidatorBucket validatorBucket = ValidatorBucket.of();
 
-        UserDomainModel userDomainModel = this.userPort.findById(requestUserId).orElseThrow(
+        UserDomainModel userDomainModel = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
                         "로그인된 사용자를 찾을 수 없습니다."
@@ -274,7 +274,7 @@ public class PostService {
         return BoardPostsResponseDto.from(
                 boardDomainModel,
                 userDomainModel.getRole(),
-                this.favoriteBoardPort.findByUserId(requestUserId)
+                this.favoriteBoardPort.findByUserId(loginUserId)
                         .stream()
                         .anyMatch(favoriteBoardDomainModel -> favoriteBoardDomainModel.getBoardDomainModel().getId().equals(boardDomainModel.getId())),
                 this.postPort.search(searchOption, keyword, pageNum)
@@ -286,8 +286,8 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public BoardPostsResponseDto findAllAppNotice(String requestUserId, Integer pageNum) {
-        UserDomainModel userDomainModel = this.userPort.findById(requestUserId).orElseThrow(
+    public BoardPostsResponseDto findAllAppNotice(String loginUserId, Integer pageNum) {
+        UserDomainModel userDomainModel = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
                         "로그인된 사용자를 찾을 수 없습니다."
@@ -304,7 +304,7 @@ public class PostService {
         return BoardPostsResponseDto.from(
                 boardDomainModel,
                 userDomainModel.getRole(),
-                this.favoriteBoardPort.findByUserId(requestUserId)
+                this.favoriteBoardPort.findByUserId(loginUserId)
                         .stream()
                         .anyMatch(favoriteBoardDomainModel -> favoriteBoardDomainModel.getBoardDomainModel().getId().equals(boardDomainModel.getId())),
                 this.postPort.findAll(boardDomainModel.getId(), pageNum)
@@ -316,10 +316,10 @@ public class PostService {
     }
 
     @Transactional
-    public PostResponseDto create(String requestUserId, PostCreateRequestDto postCreateRequestDto) {
+    public PostResponseDto create(String loginUserId, PostCreateRequestDto postCreateRequestDto) {
         ValidatorBucket validatorBucket = ValidatorBucket.of();
 
-        UserDomainModel creatorDomainModel = this.userPort.findById(requestUserId).orElseThrow(
+        UserDomainModel creatorDomainModel = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
                         "로그인된 사용자를 찾을 수 없습니다."
@@ -359,7 +359,7 @@ public class PostService {
                 .ifPresent(
                         circleDomainModel -> {
                             CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
-                                    requestUserId,
+                                    loginUserId,
                                     circleDomainModel.getId()
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
@@ -396,10 +396,10 @@ public class PostService {
     }
 
     @Transactional
-    public PostResponseDto delete(String requestUserId, String postId) {
+    public PostResponseDto delete(String loginUserId, String postId) {
         ValidatorBucket validatorBucket = ValidatorBucket.of();
 
-        UserDomainModel requestUser = this.userPort.findById(requestUserId).orElseThrow(
+        UserDomainModel requestUser = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
                         "로그인된 사용자를 찾을 수 없습니다."
@@ -448,7 +448,7 @@ public class PostService {
                                     ))
                                     .consistOf(ContentsAdminValidator.of(
                                             requestUser.getRole(),
-                                            requestUserId,
+                                            loginUserId,
                                             postDomainModel.getWriter().getId(),
                                             List.of(Role.LEADER_CIRCLE)
                                     ));
@@ -462,14 +462,14 @@ public class PostService {
                                                                 "The board has circle without circle leader"
                                                         )
                                                 ),
-                                                requestUserId
+                                                loginUserId
                                         ));
                             }
                         },
                         () -> validatorBucket
                                 .consistOf(ContentsAdminValidator.of(
                                         requestUser.getRole(),
-                                        requestUserId,
+                                        loginUserId,
                                         postDomainModel.getWriter().getId(),
                                         List.of(Role.PRESIDENT)
                                 ))
@@ -491,13 +491,13 @@ public class PostService {
 
     @Transactional
     public PostResponseDto update(
-            String requestUserId,
+            String loginUserId,
             String postId,
             PostUpdateRequestDto postUpdateRequestDto
     ) {
         ValidatorBucket validatorBucket = ValidatorBucket.of();
 
-        UserDomainModel requestUser = this.userPort.findById(requestUserId).orElseThrow(
+        UserDomainModel requestUser = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
                         "로그인된 사용자를 찾을 수 없습니다."
@@ -531,7 +531,7 @@ public class PostService {
                 .ifPresent(
                         circleDomainModel -> {
                             CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
-                                    requestUserId,
+                                    loginUserId,
                                     circleDomainModel.getId()
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
@@ -558,7 +558,7 @@ public class PostService {
         validatorBucket
                 .consistOf(ContentsAdminValidator.of(
                         requestUser.getRole(),
-                        requestUserId,
+                        loginUserId,
                         postDomainModel.getWriter().getId(),
                         List.of()
                 ))
@@ -586,11 +586,11 @@ public class PostService {
         );
     }
 
-    public PostResponseDto restore(String requestUserId, String postId) {
+    public PostResponseDto restore(String loginUserId, String postId) {
 
         ValidatorBucket validatorBucket = ValidatorBucket.of();
 
-        UserDomainModel requestUser = this.userPort.findById(requestUserId).orElseThrow(
+        UserDomainModel requestUser = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
                         "로그인된 사용자를 찾을 수 없습니다."
@@ -623,7 +623,7 @@ public class PostService {
                 .ifPresent(
                         circleDomainModel -> {
                             CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
-                                    requestUserId,
+                                    loginUserId,
                                     circleDomainModel.getId()
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
@@ -644,7 +644,7 @@ public class PostService {
         validatorBucket
                 .consistOf(ContentsAdminValidator.of(
                         requestUser.getRole(),
-                        requestUserId,
+                        loginUserId,
                         postDomainModel.getWriter().getId(),
                         List.of()
                 ))

--- a/src/main/java/net/causw/application/spi/PostPort.java
+++ b/src/main/java/net/causw/application/spi/PostPort.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Page;
 import java.util.Optional;
 
 public interface PostPort {
-    Optional<PostDomainModel> findById(String id);
+    Optional<PostDomainModel> findPostById(String id);
 
     PostDomainModel create(PostDomainModel postDomainModel);
 
@@ -17,9 +17,14 @@ public interface PostPort {
 
     Page<PostDomainModel> findAll(String boardId, Integer pageNum);
 
+    Page<PostDomainModel> findAll(String boardId, Integer pageNum, boolean isDeleted);
+
     Page<PostDomainModel> findAll(String boardId, Integer pageNum, Integer pageSize);
 
-    Page<PostDomainModel> search(SearchOption option, String keyword, Integer pageNum);
+
+    Page<PostDomainModel> search(SearchOption option, String keyword, String boardId, Integer pageNum);
+
+    Page<PostDomainModel> search(SearchOption option, String keyword, String boardId, Integer pageNum, boolean isDeleted);
 
     Optional<PostDomainModel> findLatest(String boardId);
 

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -272,7 +272,7 @@ public class UserService {
         return UserCommentsResponseDto.from(
                 requestUser,
                 this.commentPort.findByUserId(requestUserId, pageNum).map(comment -> {
-                    PostDomainModel post = this.postPort.findById(comment.getPostId()).orElseThrow(
+                    PostDomainModel post = this.postPort.findPostById(comment.getPostId()).orElseThrow(
                             () -> new BadRequestException(
                                     ErrorCode.ROW_DOES_NOT_EXIST,
                                     "게시글을 찾을 수 없습니다."


### PR DESCRIPTION
### 🚩 관련사항


### 📢 전달사항
findAllAppNotice API는 프론트 단에서 구현되어 있지 않아서 당장은 사용하지 않습니다.
기존 코드가 역할만 동아리장인 것을 확인하기 때문에 타 동아리의 동아리장이면서 해당 동아리의 동아리 부원일 경우가 존재하기 때문에 권한에 대해서 수정하였습니다.
native 쿼리가 테이블을 인지하지 못하여 테이블 명을 데이터베이스와 동일하게 소문자로 변경해주었습니다.
swagger의 validator 응답값은 추후 추가할 예정입니다.


### 📸 스크린샷
<img width="1418" alt="스크린샷 2024-02-06 오후 10 40 54" src="https://github.com/CAUCSE/CAUSW_backend/assets/63050966/27e0266f-34a2-4739-b002-c2964f9238a3">


### 📃 진행사항
- [x] 게시글 api 검증 및 권한 수정
- [ ] validator 응답값 추가예정
- [ ] user Role 변경시 validator 수정
- [ ] search 옵션 중 작성자 검색 옵션 제거(프론트와 합의 완료)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 1주