### PR TITLE
hotfix : 게시글 전체 조회 api에서 게시글 삭제여부 추가

### DIFF
--- a/src/main/java/net/causw/application/dto/post/PostsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/PostsResponseDto.java
@@ -31,6 +31,9 @@ public class PostsResponseDto {
     @ApiModelProperty(value = "게시글 업데이트 시간", example =  "2024-01-26T18:40:40.643Z")
     private LocalDateTime updatedAt;
 
+    @ApiModelProperty(value = "게시글 삭제여부", example = "false")
+    private Boolean isDeleted;
+
     private PostsResponseDto(
             String id,
             String title,
@@ -38,7 +41,8 @@ public class PostsResponseDto {
             Integer writerAdmissionYear,
             Long numComment,
             LocalDateTime createdAt,
-            LocalDateTime updatedAt
+            LocalDateTime updatedAt,
+            Boolean isDeleted
     ) {
         this.id = id;
         this.title = title;
@@ -47,6 +51,7 @@ public class PostsResponseDto {
         this.numComment = numComment;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
+        this.isDeleted = isDeleted;
     }
 
     public static PostsResponseDto from(
@@ -60,7 +65,8 @@ public class PostsResponseDto {
                 post.getWriter().getAdmissionYear(),
                 numComment,
                 post.getCreatedAt(),
-                post.getUpdatedAt()
+                post.getUpdatedAt(),
+                post.getIsDeleted()
         );
     }
 }


### PR DESCRIPTION
### 🚩 관련사항
#439 


### 📢 전달사항
게시글 전체 조회 api에서 권한에 따라 삭제된 게시글도 확인할 수 있으므로 isDeleted 값을 함께 반환해서 프론트단에서 별도 정렬 가능하게 하기 위해 필요하여 추가하였습니다.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 20분