### PR TITLE
update : 게시글 API 요청사항 수정 및 개선

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/port/post/PostPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/post/PostPortImpl.java
@@ -31,12 +31,12 @@ public class PostPortImpl extends DomainModelMapper implements PostPort {
     }
 
     @Override
-    public PostDomainModel create(PostDomainModel postDomainModel) {
+    public PostDomainModel createPost(PostDomainModel postDomainModel) {
         return this.entityToDomainModel(this.postRepository.save(Post.from(postDomainModel)));
     }
 
     @Override
-    public Optional<PostDomainModel> delete(String id) {
+    public Optional<PostDomainModel> deletePost(String id) {
         return this.postRepository.findById(id).map(
                 srcPost -> {
                     srcPost.setIsDeleted(true);
@@ -47,7 +47,7 @@ public class PostPortImpl extends DomainModelMapper implements PostPort {
     }
 
     @Override
-    public Optional<PostDomainModel> update(String id, PostDomainModel postDomainModel) {
+    public Optional<PostDomainModel> updatePost(String id, PostDomainModel postDomainModel) {
         return this.postRepository.findById(id).map(
                 srcPost -> {
                     srcPost.setTitle(postDomainModel.getTitle());
@@ -60,26 +60,26 @@ public class PostPortImpl extends DomainModelMapper implements PostPort {
     }
 
     @Override
-    public Page<PostDomainModel> findAll(String boardId, Integer pageNum) {
+    public Page<PostDomainModel> findAllPost(String boardId, Integer pageNum) {
         return this.postRepository.findAllByBoard_IdOrderByCreatedAtDesc(boardId, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE))
                 .map(this::entityToDomainModel);
     }
 
     @Override
-    public Page<PostDomainModel> findAll(String boardId, Integer pageNum, boolean isDeleted) {
+    public Page<PostDomainModel> findAllPost(String boardId, Integer pageNum, boolean isDeleted) {
         return this.postRepository.findAllByBoard_IdAndIsDeletedOrderByCreatedAtDesc(boardId, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE), isDeleted)
                 .map(this::entityToDomainModel);
     }
 
     @Override
-    public Page<PostDomainModel> findAll(String boardId, Integer pageNum, Integer pageSize) {
+    public Page<PostDomainModel> findAllPost(String boardId, Integer pageNum, Integer pageSize) {
         return this.postRepository.findAllByBoard_IdAndIsDeletedIsFalseOrderByCreatedAtDesc(boardId, this.pageableFactory.create(pageNum, pageSize))
                 .map(this::entityToDomainModel);
     }
 
 
     @Override
-    public Page<PostDomainModel> search(SearchOption option, String keyword, String boardId, Integer pageNum) {
+    public Page<PostDomainModel> searchPost(SearchOption option, String keyword, String boardId, Integer pageNum) {
         switch (option){
             case TITLE:
                 return this.postRepository.searchByTitle(keyword, boardId, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE))
@@ -93,7 +93,7 @@ public class PostPortImpl extends DomainModelMapper implements PostPort {
     }
 
     @Override
-    public Page<PostDomainModel> search(SearchOption option, String keyword, String boardId, Integer pageNum, boolean isDeleted) {
+    public Page<PostDomainModel> searchPost(SearchOption option, String keyword, String boardId, Integer pageNum, boolean isDeleted) {
         switch (option){
             case TITLE:
                 return this.postRepository.searchByTitle(keyword, boardId, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE), isDeleted)
@@ -107,19 +107,19 @@ public class PostPortImpl extends DomainModelMapper implements PostPort {
     }
 
     @Override
-    public Optional<PostDomainModel> findLatest(String boardId) {
+    public Optional<PostDomainModel> findLatestPost(String boardId) {
         return this.postRepository.findTop1ByBoard_IdAndIsDeletedIsFalseOrderByCreatedAtDesc(boardId)
                 .map(this::entityToDomainModel);
     }
 
     @Override
-    public Page<PostDomainModel> findByUserId(String userId, Integer pageNum) {
+    public Page<PostDomainModel> findPostByUserId(String userId, Integer pageNum) {
         return this.postRepository.findByUserId(userId, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE))
                 .map(this::entityToDomainModel);
     }
 
     @Override
-    public Optional<PostDomainModel> restore(String id, PostDomainModel postDomainModel) {
+    public Optional<PostDomainModel> restorePost(String id, PostDomainModel postDomainModel) {
         return this.postRepository.findById(id).map(
                 srcPost -> {
                     srcPost.setIsDeleted(false);

--- a/src/main/java/net/causw/adapter/persistence/port/post/PostPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/post/PostPortImpl.java
@@ -6,7 +6,6 @@ import net.causw.adapter.persistence.post.Post;
 import net.causw.adapter.persistence.repository.PostRepository;
 import net.causw.application.spi.PostPort;
 import net.causw.domain.model.post.PostDomainModel;
-import net.causw.domain.model.enums.SearchOption;
 import net.causw.domain.model.util.StaticValue;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
@@ -79,31 +78,15 @@ public class PostPortImpl extends DomainModelMapper implements PostPort {
 
 
     @Override
-    public Page<PostDomainModel> searchPost(SearchOption option, String keyword, String boardId, Integer pageNum) {
-        switch (option){
-            case TITLE:
-                return this.postRepository.searchByTitle(keyword, boardId, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE))
-                        .map(this::entityToDomainModel);
-            case WRITER:
-                return this.postRepository.searchByWriter(keyword, boardId, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE))
-                        .map(this::entityToDomainModel);
-            default:
-                return null;
-        }
+    public Page<PostDomainModel> searchPost(String keyword, String boardId, Integer pageNum) {
+        return this.postRepository.searchByTitle(keyword, boardId, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE))
+                .map(this::entityToDomainModel);
     }
 
     @Override
-    public Page<PostDomainModel> searchPost(SearchOption option, String keyword, String boardId, Integer pageNum, boolean isDeleted) {
-        switch (option){
-            case TITLE:
-                return this.postRepository.searchByTitle(keyword, boardId, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE), isDeleted)
-                        .map(this::entityToDomainModel);
-            case WRITER:
-                return this.postRepository.searchByWriter(keyword, boardId, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE), isDeleted)
-                        .map(this::entityToDomainModel);
-            default:
-                return null;
-        }
+    public Page<PostDomainModel> searchPost(String keyword, String boardId, Integer pageNum, boolean isDeleted) {
+        return this.postRepository.searchByTitle(keyword, boardId, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE), isDeleted)
+                .map(this::entityToDomainModel);
     }
 
     @Override

--- a/src/main/java/net/causw/adapter/persistence/repository/PostRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/PostRepository.java
@@ -24,28 +24,11 @@ public interface PostRepository extends JpaRepository<Post, String> {
             "WHERE p.title LIKE CONCAT('%', :title, '%')AND p.board_id = :boardId ORDER BY p.created_at DESC", nativeQuery = true)
     Page<Post> searchByTitle(@Param("title") String title, @Param("boardId") String boardId, Pageable pageable);
 
-    @Query(value = "SELECT * " +
-            "FROM tb_post AS p " +
-            "LEFT JOIN tb_user AS u ON p.user_id = u.id " +
-            "WHERE u.name LIKE CONCAT('%', :userName, '%') AND p.board_id = :boardId ORDER BY p.created_at DESC", nativeQuery = true)
-    Page<Post> searchByWriter(@Param("userName") String userName, @Param("boardId") String boardId, Pageable pageable);
-
-
     //해당 동아리의 동아리장, 관리자, 학생회장이 아닌경우 삭제되지 않은 게시글 검색
     @Query(value = "SELECT * " +
             "FROM tb_post AS p " +
             "WHERE p.title LIKE CONCAT('%', :title, '%')AND p.board_id = :boardId AND p.is_deleted = :isDeleted ORDER BY p.created_at DESC", nativeQuery = true)
     Page<Post> searchByTitle(@Param("title") String title, @Param("boardId") String boardId, Pageable pageable, boolean isDeleted);
-
-    @Query(value = "SELECT * " +
-            "FROM tb_post AS p " +
-            "LEFT JOIN tb_user AS u ON p.user_id = u.id " +
-            "WHERE u.name LIKE CONCAT('%', :userName, '%') AND p.board_id = :boardId AND p.is_deleted = :isDeleted ORDER BY p.created_at DESC", nativeQuery = true)
-    Page<Post> searchByWriter(@Param("userName") String userName, @Param("boardId") String boardId, Pageable pageable, boolean isDeleted);
-
-
-
-
 
 
     @Query(value = "select * from tb_post as p " +

--- a/src/main/java/net/causw/adapter/web/PostController.java
+++ b/src/main/java/net/causw/adapter/web/PostController.java
@@ -1,5 +1,6 @@
 package net.causw.adapter.web;
 
+import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
@@ -92,7 +93,7 @@ public class PostController {
 
     @GetMapping("/search")
     @ResponseStatus(value = HttpStatus.OK)
-    @ApiOperation(value = "게시글 검색 API(완료)", notes = "게시글을 검색하는 api로 검색 option은 writer와 title 중 택1입니다.")
+    @ApiOperation(value = "게시글 검색 API(완료)", notes = "게시글을 검색하는 api로 제목의 연관검색어로 검색 가능합니다.")
     @ApiResponses({
             @ApiResponse(code = 200, message = "OK", response = String.class),
             @ApiResponse(code = 4000, message = "로그인된 사용자를 찾을 수 없습니다.", response = BadRequestException.class),
@@ -110,17 +111,21 @@ public class PostController {
             @ApiResponse(code = 4102, message = "동아리 가입 거절된 사용자입니다.", response = UnauthorizedException.class),
             @ApiResponse(code = 4102, message = "동아리에서 추방된 사용자입니다.", response = UnauthorizedException.class),
             @ApiResponse(code = 4004, message = "삭제된 게시판입니다.", response = BadRequestException.class),
-            @ApiResponse(code = 4002, message = "잘못된 검색 옵션입니다.(추후 옵션 title로 고정)", response = BadRequestException.class)
     })
+    @ApiImplicitParam(name = "keyword",
+            value = "제목 연관검색어",
+            required = true,
+            dataType = "String",
+            paramType = "query"
+    )
     public BoardPostsResponseDto searchPost(
             @RequestParam String boardId,
-            @RequestParam(defaultValue = "title") String option,
             @RequestParam(defaultValue = "") String keyword,
             @RequestParam(defaultValue = "0") Integer pageNum
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         String loginUserId = ((String) principal);
-        return this.postService.searchPost(loginUserId, boardId, option, keyword, pageNum);
+        return this.postService.searchPost(loginUserId, boardId, keyword, pageNum);
     }
 
     @GetMapping("/app/notice")

--- a/src/main/java/net/causw/adapter/web/PostController.java
+++ b/src/main/java/net/causw/adapter/web/PostController.java
@@ -87,7 +87,7 @@ public class PostController {
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         String loginUserId = ((String) principal);
-        return this.postService.findAll(loginUserId, boardId, pageNum);
+        return this.postService.findAllPost(loginUserId, boardId, pageNum);
     }
 
     @GetMapping("/search")
@@ -120,7 +120,7 @@ public class PostController {
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         String loginUserId = ((String) principal);
-        return this.postService.search(loginUserId, boardId, option, keyword, pageNum);
+        return this.postService.searchPost(loginUserId, boardId, option, keyword, pageNum);
     }
 
     @GetMapping("/app/notice")
@@ -160,7 +160,7 @@ public class PostController {
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         String loginUserId = ((String) principal);
-        return this.postService.create(loginUserId, postCreateRequestDto);
+        return this.postService.createPost(loginUserId, postCreateRequestDto);
     }
 
     @DeleteMapping(value = "/{id}")
@@ -191,7 +191,7 @@ public class PostController {
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         String loginUserId = ((String) principal);
-        return this.postService.delete(loginUserId, id);
+        return this.postService.deletePost(loginUserId, id);
     }
 
     @PutMapping(value = "/{id}")
@@ -226,7 +226,7 @@ public class PostController {
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         String loginUserId = ((String) principal);
-        return this.postService.update(
+        return this.postService.updatePost(
                 loginUserId,
                 id,
                 postUpdateRequestDto
@@ -264,7 +264,7 @@ public class PostController {
     ) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         String loginUserId = ((String) principal);
-        return this.postService.restore(
+        return this.postService.restorePost(
                 loginUserId,
                 id
         );

--- a/src/main/java/net/causw/application/circle/CircleService.java
+++ b/src/main/java/net/causw/application/circle/CircleService.java
@@ -183,7 +183,7 @@ public class CircleService {
                 ),
                 this.boardPort.findByCircleId(circleId)
                         .stream()
-                        .map(boardDomainModel -> this.postPort.findLatest(boardDomainModel.getId()).map(
+                        .map(boardDomainModel -> this.postPort.findLatestPost(boardDomainModel.getId()).map(
                                 postDomainModel -> BoardOfCircleResponseDto.from(
                                         boardDomainModel,
                                         userDomainModel.getRole(),

--- a/src/main/java/net/causw/application/dto/post/PostResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/PostResponseDto.java
@@ -4,7 +4,6 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.application.dto.file.FileResponseDto;
-import net.causw.application.dto.board.BoardResponseDto;
 import net.causw.application.dto.comment.CommentResponseDto;
 import net.causw.domain.model.post.PostDomainModel;
 import net.causw.domain.model.enums.Role;
@@ -45,9 +44,6 @@ public class PostResponseDto {
     @ApiModelProperty(value = "답글 개수", example = "13")
     private Long numComment;
 
-    @ApiModelProperty(value = "게시글이 속한 게시판 정보", example = "게시판 정보 조회")
-    private BoardResponseDto board;
-
     @ApiModelProperty(value = "게시글 업데이트 가능여부", example = "true")
     private Boolean updatable;
 
@@ -63,9 +59,6 @@ public class PostResponseDto {
     @ApiModelProperty(value = "게시글의 답글 정보", example =  "답글에 대한 정보 조회")
     private Page<CommentResponseDto> commentList;
 
-    @ApiModelProperty(value = "게시판 id", example =  "uuid 형식의 String 값입니다.")
-    private String boardId;
-
     @ApiModelProperty(value = "게시판 이름", example =  "게시판 이름입니다.")
     private String boardName;
 
@@ -79,13 +72,11 @@ public class PostResponseDto {
             Integer writerAdmissionYear,
             List<FileResponseDto> attachmentList,
             Long numComment,
-            BoardResponseDto board,
             Boolean updatable,
             Boolean deletable,
             LocalDateTime createdAt,
             LocalDateTime updatedAt,
             Page<CommentResponseDto> commentList,
-            String boardId,
             String boardName
     ) {
         this.id = id;
@@ -97,13 +88,11 @@ public class PostResponseDto {
         this.writerAdmissionYear = writerAdmissionYear;
         this.attachmentList = attachmentList;
         this.numComment = numComment;
-        this.board = board;
         this.updatable = updatable;
         this.deletable = deletable;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.commentList = commentList;
-        this.boardId = boardId;
         this.boardName = boardName;
     }
 
@@ -146,12 +135,10 @@ public class PostResponseDto {
                 post.getWriter().getAdmissionYear(),
                 post.getAttachmentList().stream().map(FileResponseDto::from).collect(Collectors.toList()),
                 0L,
-                BoardResponseDto.from(post.getBoard(), user.getRole()),
                 updatable,
                 deletable,
                 post.getCreatedAt(),
                 post.getUpdatedAt(),
-                null,
                 null,
                 null
         );
@@ -198,13 +185,11 @@ public class PostResponseDto {
                 post.getWriter().getAdmissionYear(),
                 post.getAttachmentList().stream().map(FileResponseDto::from).collect(Collectors.toList()),
                 numComment,
-                BoardResponseDto.from(post.getBoard(), user.getRole()),
                 updatable,
                 deletable,
                 post.getCreatedAt(),
                 post.getUpdatedAt(),
                 commentList,
-                post.getBoard().getId(),
                 post.getBoard().getName()
         );
     }

--- a/src/main/java/net/causw/application/homepage/HomePageService.java
+++ b/src/main/java/net/causw/application/homepage/HomePageService.java
@@ -74,7 +74,7 @@ public class HomePageService {
                 .stream()
                 .map(favoriteBoardDomainModel -> HomePageResponseDto.from(
                         BoardResponseDto.from(favoriteBoardDomainModel.getBoardDomainModel(), userDomainModel.getRole()),
-                        this.postPort.findAll(
+                        this.postPort.findAllPost(
                                 favoriteBoardDomainModel.getBoardDomainModel().getId(),
                                 0,
                                 StaticValue.HOME_POST_PAGE_SIZE

--- a/src/main/java/net/causw/application/post/PostService.java
+++ b/src/main/java/net/causw/application/post/PostService.java
@@ -141,7 +141,7 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public BoardPostsResponseDto findAll(
+    public BoardPostsResponseDto findAllPost(
             String loginUserId,
             String boardId,
             Integer pageNum
@@ -204,7 +204,7 @@ public class PostService {
                     this.favoriteBoardPort.findByUserId(loginUserId)
                             .stream()
                             .anyMatch(favoriteBoardDomainModel -> favoriteBoardDomainModel.getBoardDomainModel().getId().equals(boardDomainModel.getId())),
-                    this.postPort.findAll(boardId, pageNum)
+                    this.postPort.findAllPost(boardId, pageNum)
                             .map(postDomainModel -> PostsResponseDto.from(
                                     postDomainModel,
                                     this.commentPort.countByPostId(postDomainModel.getId())
@@ -218,7 +218,7 @@ public class PostService {
                     this.favoriteBoardPort.findByUserId(loginUserId)
                             .stream()
                             .anyMatch(favoriteBoardDomainModel -> favoriteBoardDomainModel.getBoardDomainModel().getId().equals(boardDomainModel.getId())),
-                    this.postPort.findAll(boardId, pageNum, false)
+                    this.postPort.findAllPost(boardId, pageNum, false)
                             .map(postDomainModel -> PostsResponseDto.from(
                                     postDomainModel,
                                     this.commentPort.countByPostId(postDomainModel.getId())
@@ -229,7 +229,7 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public BoardPostsResponseDto search(
+    public BoardPostsResponseDto searchPost(
             String loginUserId,
             String boardId,
             String option,
@@ -306,7 +306,7 @@ public class PostService {
                     this.favoriteBoardPort.findByUserId(loginUserId)
                             .stream()
                             .anyMatch(favoriteBoardDomainModel -> favoriteBoardDomainModel.getBoardDomainModel().getId().equals(boardDomainModel.getId())),
-                    this.postPort.search(searchOption, keyword, boardId, pageNum)
+                    this.postPort.searchPost(searchOption, keyword, boardId, pageNum)
                             .map(postDomainModel -> PostsResponseDto.from(
                                     postDomainModel,
                                     this.commentPort.countByPostId(postDomainModel.getId())
@@ -320,7 +320,7 @@ public class PostService {
                     this.favoriteBoardPort.findByUserId(loginUserId)
                             .stream()
                             .anyMatch(favoriteBoardDomainModel -> favoriteBoardDomainModel.getBoardDomainModel().getId().equals(boardDomainModel.getId())),
-                    this.postPort.search(searchOption, keyword, boardId, pageNum, false)
+                    this.postPort.searchPost(searchOption, keyword, boardId, pageNum, false)
                             .map(postDomainModel -> PostsResponseDto.from(
                                     postDomainModel,
                                     this.commentPort.countByPostId(postDomainModel.getId())
@@ -353,7 +353,7 @@ public class PostService {
                 this.favoriteBoardPort.findByUserId(loginUserId)
                         .stream()
                         .anyMatch(favoriteBoardDomainModel -> favoriteBoardDomainModel.getBoardDomainModel().getId().equals(boardDomainModel.getId())),
-                this.postPort.findAll(boardDomainModel.getId(), pageNum)
+                this.postPort.findAllPost(boardDomainModel.getId(), pageNum)
                         .map(postDomainModel -> PostsResponseDto.from(
                                 postDomainModel,
                                 this.commentPort.countByPostId(postDomainModel.getId())
@@ -362,7 +362,7 @@ public class PostService {
     }
 
     @Transactional
-    public PostResponseDto create(String loginUserId, PostCreateRequestDto postCreateRequestDto) {
+    public PostResponseDto createPost(String loginUserId, PostCreateRequestDto postCreateRequestDto) {
         ValidatorBucket validatorBucket = ValidatorBucket.of();
 
         UserDomainModel creatorDomainModel = this.userPort.findById(loginUserId).orElseThrow(
@@ -449,13 +449,13 @@ public class PostService {
                 .validate();
 
         return PostResponseDto.from(
-                this.postPort.create(postDomainModel),
+                this.postPort.createPost(postDomainModel),
                 creatorDomainModel
         );
     }
 
     @Transactional
-    public PostResponseDto delete(String loginUserId, String postId) {
+    public PostResponseDto deletePost(String loginUserId, String postId) {
         ValidatorBucket validatorBucket = ValidatorBucket.of();
 
         UserDomainModel deleterDomainModel = this.userPort.findById(loginUserId).orElseThrow(
@@ -531,7 +531,7 @@ public class PostService {
                 .validate();
 
         return PostResponseDto.from(
-                this.postPort.delete(postId).orElseThrow(
+                this.postPort.deletePost(postId).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
                                 "Post id checked, but exception occurred"
@@ -542,7 +542,7 @@ public class PostService {
     }
 
     @Transactional
-    public PostResponseDto update(
+    public PostResponseDto updatePost(
             String loginUserId,
             String postId,
             PostUpdateRequestDto postUpdateRequestDto
@@ -630,7 +630,7 @@ public class PostService {
                 .consistOf(ConstraintValidator.of(postDomainModel, this.validator))
                 .validate();
 
-        PostDomainModel updatedPostDomainModel = this.postPort.update(postId, postDomainModel).orElseThrow(
+        PostDomainModel updatedPostDomainModel = this.postPort.updatePost(postId, postDomainModel).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
                         "Post id checked, but exception occurred"
@@ -651,7 +651,7 @@ public class PostService {
         );
     }
 
-    public PostResponseDto restore(String loginUserId, String postId) {
+    public PostResponseDto restorePost(String loginUserId, String postId) {
 
         ValidatorBucket validatorBucket = ValidatorBucket.of();
 
@@ -728,7 +728,7 @@ public class PostService {
                 ))
                 .validate();
 
-        PostDomainModel restoredPostDomainModel = this.postPort.restore(postId, postDomainModel).orElseThrow(
+        PostDomainModel restoredPostDomainModel = this.postPort.restorePost(postId, postDomainModel).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
                         "Post id checked, but exception occurred"

--- a/src/main/java/net/causw/application/post/PostService.java
+++ b/src/main/java/net/causw/application/post/PostService.java
@@ -22,7 +22,6 @@ import net.causw.domain.model.circle.CircleMemberDomainModel;
 import net.causw.domain.model.enums.CircleMemberStatus;
 import net.causw.domain.model.post.PostDomainModel;
 import net.causw.domain.model.enums.Role;
-import net.causw.domain.model.enums.SearchOption;
 import net.causw.domain.model.util.StaticValue;
 import net.causw.domain.model.user.UserDomainModel;
 import net.causw.domain.validation.CircleMemberStatusValidator;
@@ -41,7 +40,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.validation.Validator;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -232,7 +230,6 @@ public class PostService {
     public BoardPostsResponseDto searchPost(
             String loginUserId,
             String boardId,
-            String option,
             String keyword,
             Integer pageNum
     ) {
@@ -285,14 +282,6 @@ public class PostService {
                 .validate();
 
 
-
-        SearchOption searchOption = Optional.ofNullable(SearchOption.of(option)).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.INVALID_PARAMETER,
-                        "잘못된 검색 옵션입니다."
-                )
-        );
-
         boolean isCircleLeader = false;
         if(userDomainModel.getRole().equals(Role.LEADER_CIRCLE)){
             isCircleLeader = boardDomainModel.getCircle().get()
@@ -306,7 +295,7 @@ public class PostService {
                     this.favoriteBoardPort.findByUserId(loginUserId)
                             .stream()
                             .anyMatch(favoriteBoardDomainModel -> favoriteBoardDomainModel.getBoardDomainModel().getId().equals(boardDomainModel.getId())),
-                    this.postPort.searchPost(searchOption, keyword, boardId, pageNum)
+                    this.postPort.searchPost(keyword, boardId, pageNum)
                             .map(postDomainModel -> PostsResponseDto.from(
                                     postDomainModel,
                                     this.commentPort.countByPostId(postDomainModel.getId())
@@ -320,7 +309,7 @@ public class PostService {
                     this.favoriteBoardPort.findByUserId(loginUserId)
                             .stream()
                             .anyMatch(favoriteBoardDomainModel -> favoriteBoardDomainModel.getBoardDomainModel().getId().equals(boardDomainModel.getId())),
-                    this.postPort.searchPost(searchOption, keyword, boardId, pageNum, false)
+                    this.postPort.searchPost(keyword, boardId, pageNum, false)
                             .map(postDomainModel -> PostsResponseDto.from(
                                     postDomainModel,
                                     this.commentPort.countByPostId(postDomainModel.getId())

--- a/src/main/java/net/causw/application/post/PostService.java
+++ b/src/main/java/net/causw/application/post/PostService.java
@@ -410,7 +410,7 @@ public class PostService {
                                             List.of(CircleMemberStatus.MEMBER)
                                     ));
 
-                            if (creatorDomainModel.getRole().equals(Role.LEADER_CIRCLE)) {
+                            if (creatorDomainModel.getRole().equals(Role.LEADER_CIRCLE) && !boardDomainModel.getCreateRoleList().contains("COMMON")) {
                                 validatorBucket
                                         .consistOf(UserEqualValidator.of(
                                                 circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
@@ -495,7 +495,7 @@ public class PostService {
                                             List.of(CircleMemberStatus.MEMBER)
                                     ));
 
-                            if (deleterDomainModel.getRole().equals(Role.LEADER_CIRCLE)) {
+                            if (deleterDomainModel.getRole().equals(Role.LEADER_CIRCLE) && !postDomainModel.getWriter().getId().equals(loginUserId)) {
                                 validatorBucket
                                         .consistOf(UserEqualValidator.of(
                                                 circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
@@ -588,7 +588,7 @@ public class PostService {
                                             List.of(CircleMemberStatus.MEMBER)
                                     ));
 
-                            if (updaterDomainModel.getRole().equals(Role.LEADER_CIRCLE)) {
+                            if (updaterDomainModel.getRole().equals(Role.LEADER_CIRCLE) && !postDomainModel.getWriter().getId().equals(loginUserId)) {
                                 validatorBucket
                                         .consistOf(UserEqualValidator.of(
                                                 circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
@@ -693,7 +693,7 @@ public class PostService {
                                             List.of(CircleMemberStatus.MEMBER)
                                     ));
 
-                            if (restorerDomainModel.getRole().equals(Role.LEADER_CIRCLE)) {
+                            if (restorerDomainModel.getRole().equals(Role.LEADER_CIRCLE) && !postDomainModel.getWriter().getId().equals(loginUserId)) {
                                 validatorBucket
                                         .consistOf(UserEqualValidator.of(
                                                 circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(

--- a/src/main/java/net/causw/application/spi/PostPort.java
+++ b/src/main/java/net/causw/application/spi/PostPort.java
@@ -9,26 +9,26 @@ import java.util.Optional;
 public interface PostPort {
     Optional<PostDomainModel> findPostById(String id);
 
-    PostDomainModel create(PostDomainModel postDomainModel);
+    PostDomainModel createPost(PostDomainModel postDomainModel);
 
-    Optional<PostDomainModel> delete(String id);
+    Optional<PostDomainModel> deletePost(String id);
 
-    Optional<PostDomainModel> update(String id, PostDomainModel postDomainModel);
+    Optional<PostDomainModel> updatePost(String id, PostDomainModel postDomainModel);
 
-    Page<PostDomainModel> findAll(String boardId, Integer pageNum);
+    Page<PostDomainModel> findAllPost(String boardId, Integer pageNum);
 
-    Page<PostDomainModel> findAll(String boardId, Integer pageNum, boolean isDeleted);
+    Page<PostDomainModel> findAllPost(String boardId, Integer pageNum, boolean isDeleted);
 
-    Page<PostDomainModel> findAll(String boardId, Integer pageNum, Integer pageSize);
+    Page<PostDomainModel> findAllPost(String boardId, Integer pageNum, Integer pageSize);
 
 
-    Page<PostDomainModel> search(SearchOption option, String keyword, String boardId, Integer pageNum);
+    Page<PostDomainModel> searchPost(SearchOption option, String keyword, String boardId, Integer pageNum);
 
-    Page<PostDomainModel> search(SearchOption option, String keyword, String boardId, Integer pageNum, boolean isDeleted);
+    Page<PostDomainModel> searchPost(SearchOption option, String keyword, String boardId, Integer pageNum, boolean isDeleted);
 
-    Optional<PostDomainModel> findLatest(String boardId);
+    Optional<PostDomainModel> findLatestPost(String boardId);
 
-    Page<PostDomainModel> findByUserId(String userId, Integer pageNum);
+    Page<PostDomainModel> findPostByUserId(String userId, Integer pageNum);
 
-    Optional<PostDomainModel> restore(String id, PostDomainModel postDomainModel);
+    Optional<PostDomainModel> restorePost(String id, PostDomainModel postDomainModel);
 }

--- a/src/main/java/net/causw/application/spi/PostPort.java
+++ b/src/main/java/net/causw/application/spi/PostPort.java
@@ -1,7 +1,6 @@
 package net.causw.application.spi;
 
 import net.causw.domain.model.post.PostDomainModel;
-import net.causw.domain.model.enums.SearchOption;
 import org.springframework.data.domain.Page;
 
 import java.util.Optional;
@@ -22,9 +21,9 @@ public interface PostPort {
     Page<PostDomainModel> findAllPost(String boardId, Integer pageNum, Integer pageSize);
 
 
-    Page<PostDomainModel> searchPost(SearchOption option, String keyword, String boardId, Integer pageNum);
+    Page<PostDomainModel> searchPost(String keyword, String boardId, Integer pageNum);
 
-    Page<PostDomainModel> searchPost(SearchOption option, String keyword, String boardId, Integer pageNum, boolean isDeleted);
+    Page<PostDomainModel> searchPost(String keyword, String boardId, Integer pageNum, boolean isDeleted);
 
     Optional<PostDomainModel> findLatestPost(String boardId);
 

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -244,7 +244,7 @@ public class UserService {
 
         return UserPostsResponseDto.from(
                 requestUser,
-                this.postPort.findByUserId(requestUserId, pageNum).map(postDomainModel -> UserPostResponseDto.from(
+                this.postPort.findPostByUserId(requestUserId, pageNum).map(postDomainModel -> UserPostResponseDto.from(
                         postDomainModel,
                         postDomainModel.getBoard().getId(),
                         postDomainModel.getBoard().getName(),


### PR DESCRIPTION
### 🚩 관련사항
#439 


### 📢 전달사항
post 관련 메서드명을 모두 아래와 같이 변경하여 게시글 관련 메서드임을 명시하였습니다.
(ex. findAll -> findAllPost)
게시글 검색 옵션이 기존 writer와 title에서 title검색으로만 변경하여서 옵션 선택 관련 부분을 삭제하였습니다.
postresponsedto에서 게시글이 속한 게시판의 전체 정보가 필요하지 않아서 프론트 측의 요청에 따라 boardname만을 전달해주도록 수정하였습니다.
타 동아리의 동아리장이지만 해당 동아리의 동아리 부원일 경우를 고려하여 권한을 수정하였습니다.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] userRole list로 변경시 validator 수정
- [ ] board 권한 점검


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 6시간