### PR TITLE
refac : 동아리장 Enum 개수 증가로 인한 모든 service 단의 권한확인 방법 수정

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/port/user/UserPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/user/UserPortImpl.java
@@ -12,6 +12,7 @@ import net.causw.domain.model.enums.UserState;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -84,9 +85,11 @@ public class UserPortImpl extends DomainModelMapper implements UserPort {
     }
 
     @Override
-    public List<UserDomainModel> findByRole(Role role) {
-        return this.userRepository.findByRole(role)
-                .stream()
+    public List<UserDomainModel> findByRole(String role) {
+
+        return Arrays.stream(Role.values())
+                .filter(enumRole -> enumRole.getValue().contains(role))
+                .flatMap(enumRole -> this.userRepository.findByRole(enumRole).stream())
                 .map(this::entityToDomainModel)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/net/causw/application/board/BoardService.java
+++ b/src/main/java/net/causw/application/board/BoardService.java
@@ -64,7 +64,7 @@ public class BoardService {
                 .consistOf(UserRoleIsNoneValidator.of(userDomainModel.getRole()))
                 .validate();
 
-        if (userDomainModel.getRole().equals(Role.LEADER_CIRCLE)) {
+        if (userDomainModel.getRole().getValue().contains("LEADER_CIRCLE")) {
             List<CircleDomainModel> ownCircles = this.circlePort.findByLeaderId(loginUserId);
             if (ownCircles.isEmpty()) {
                 throw new InternalServerException(
@@ -79,7 +79,7 @@ public class BoardService {
                         .collect(Collectors.toList());
             }
         }
-        else if(userDomainModel.getRole().equals(Role.ADMIN) || userDomainModel.getRole().equals(Role.PRESIDENT) ){
+        else if(userDomainModel.getRole().equals(Role.ADMIN) || userDomainModel.getRole().getValue().contains("PRESIDENT") ){
             return this.boardPort.findAllBoard()
                     .stream()
                     .map(boardDomainModel -> BoardResponseDto.from(boardDomainModel, userDomainModel.getRole()))
@@ -120,9 +120,17 @@ public class BoardService {
 
                     validatorBucket
                             .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
-                            .consistOf(UserRoleValidator.of(creatorDomainModel.getRole(), List.of(Role.LEADER_CIRCLE)));
+                            .consistOf(UserRoleValidator.of(creatorDomainModel.getRole(),
+                                    List.of(Role.LEADER_CIRCLE,
+                                            Role.VICE_PRESIDENT_N_LEADER_CIRCLE,
+                                            Role.COUNCIL_N_LEADER_CIRCLE,
+                                            Role.LEADER_1_N_LEADER_CIRCLE,
+                                            Role.LEADER_2_N_LEADER_CIRCLE,
+                                            Role.LEADER_3_N_LEADER_CIRCLE,
+                                            Role.LEADER_4_N_LEADER_CIRCLE
+                                    )));
 
-                    if (creatorDomainModel.getRole().equals(Role.LEADER_CIRCLE)) {
+                    if (creatorDomainModel.getRole().getValue().contains("LEADER_CIRCLE")) {
                         validatorBucket
                                 .consistOf(UserEqualValidator.of(
                                         circle.getLeader().map(UserDomainModel::getId).orElseThrow(
@@ -140,7 +148,7 @@ public class BoardService {
         ).orElseGet(
                 () -> {
                     validatorBucket
-                            .consistOf(UserRoleValidator.of(creatorDomainModel.getRole(), List.of(Role.PRESIDENT)));
+                            .consistOf(UserRoleValidator.of(creatorDomainModel.getRole(), List.of()));
 
                     return null;
                 }
@@ -192,9 +200,17 @@ public class BoardService {
                 circleDomainModel -> {
                     validatorBucket
                             .consistOf(TargetIsDeletedValidator.of(circleDomainModel.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
-                            .consistOf(UserRoleValidator.of(updaterDomainModel.getRole(), List.of(Role.LEADER_CIRCLE)));
+                            .consistOf(UserRoleValidator.of(updaterDomainModel.getRole(),
+                                    List.of(Role.LEADER_CIRCLE,
+                                            Role.VICE_PRESIDENT_N_LEADER_CIRCLE,
+                                            Role.COUNCIL_N_LEADER_CIRCLE,
+                                            Role.LEADER_1_N_LEADER_CIRCLE,
+                                            Role.LEADER_2_N_LEADER_CIRCLE,
+                                            Role.LEADER_3_N_LEADER_CIRCLE,
+                                            Role.LEADER_4_N_LEADER_CIRCLE
+                                    )));
 
-                    if (updaterDomainModel.getRole().equals(Role.LEADER_CIRCLE)) {
+                    if (updaterDomainModel.getRole().getValue().contains("LEADER_CIRCLE")) {
                         validatorBucket
                                 .consistOf(UserEqualValidator.of(
                                         circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
@@ -208,7 +224,7 @@ public class BoardService {
                     }
                 },
                 () -> validatorBucket
-                        .consistOf(UserRoleValidator.of(updaterDomainModel.getRole(), List.of(Role.PRESIDENT)))
+                        .consistOf(UserRoleValidator.of(updaterDomainModel.getRole(), List.of()))
         );
 
         boardDomainModel.update(
@@ -271,9 +287,17 @@ public class BoardService {
                 circleDomainModel -> {
                     validatorBucket
                             .consistOf(TargetIsDeletedValidator.of(circleDomainModel.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
-                            .consistOf(UserRoleValidator.of(deleterDomainModel.getRole(), List.of(Role.LEADER_CIRCLE)));
+                            .consistOf(UserRoleValidator.of(deleterDomainModel.getRole(),
+                                    List.of(Role.LEADER_CIRCLE,
+                                            Role.VICE_PRESIDENT_N_LEADER_CIRCLE,
+                                            Role.COUNCIL_N_LEADER_CIRCLE,
+                                            Role.LEADER_1_N_LEADER_CIRCLE,
+                                            Role.LEADER_2_N_LEADER_CIRCLE,
+                                            Role.LEADER_3_N_LEADER_CIRCLE,
+                                            Role.LEADER_4_N_LEADER_CIRCLE
+                                    )));
 
-                    if (deleterDomainModel.getRole().equals(Role.LEADER_CIRCLE)) {
+                    if (deleterDomainModel.getRole().getValue().contains("LEADER_CIRCLE")) {
                         validatorBucket
                                 .consistOf(UserEqualValidator.of(
                                         circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
@@ -287,7 +311,7 @@ public class BoardService {
                     }
                 },
                 () -> validatorBucket
-                        .consistOf(UserRoleValidator.of(deleterDomainModel.getRole(), List.of(Role.PRESIDENT)))
+                        .consistOf(UserRoleValidator.of(deleterDomainModel.getRole(), List.of()))
         );
 
         validatorBucket
@@ -342,9 +366,17 @@ public class BoardService {
                 circleDomainModel -> {
                     validatorBucket
                             .consistOf(TargetIsDeletedValidator.of(circleDomainModel.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
-                            .consistOf(UserRoleValidator.of(restorerDomainModel.getRole(), List.of(Role.LEADER_CIRCLE)));
+                            .consistOf(UserRoleValidator.of(restorerDomainModel.getRole(),
+                                    List.of(Role.LEADER_CIRCLE,
+                                            Role.VICE_PRESIDENT_N_LEADER_CIRCLE,
+                                            Role.COUNCIL_N_LEADER_CIRCLE,
+                                            Role.LEADER_1_N_LEADER_CIRCLE,
+                                            Role.LEADER_2_N_LEADER_CIRCLE,
+                                            Role.LEADER_3_N_LEADER_CIRCLE,
+                                            Role.LEADER_4_N_LEADER_CIRCLE
+                                    )));
 
-                    if (restorerDomainModel.getRole().equals(Role.LEADER_CIRCLE)) {
+                    if (restorerDomainModel.getRole().getValue().contains("LEADER_CIRCLE")) {
                         validatorBucket
                                 .consistOf(UserEqualValidator.of(
                                         circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
@@ -358,7 +390,7 @@ public class BoardService {
                     }
                 },
                 () -> validatorBucket
-                        .consistOf(UserRoleValidator.of(restorerDomainModel.getRole(), List.of(Role.PRESIDENT)))
+                        .consistOf(UserRoleValidator.of(restorerDomainModel.getRole(), List.of()))
         );
 
         validatorBucket

--- a/src/main/java/net/causw/application/circle/CircleService.java
+++ b/src/main/java/net/causw/application/circle/CircleService.java
@@ -236,7 +236,15 @@ public class CircleService {
                 .consistOf(UserStateValidator.of(user.getState()))
                 .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
                 .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
-                .consistOf(UserRoleValidator.of(user.getRole(), List.of(Role.LEADER_CIRCLE, Role.PRESIDENT)))
+                .consistOf(UserRoleValidator.of(user.getRole(),
+                        List.of(Role.LEADER_CIRCLE,
+                                Role.VICE_PRESIDENT_N_LEADER_CIRCLE,
+                                Role.COUNCIL_N_LEADER_CIRCLE,
+                                Role.LEADER_1_N_LEADER_CIRCLE,
+                                Role.LEADER_2_N_LEADER_CIRCLE,
+                                Role.LEADER_3_N_LEADER_CIRCLE,
+                                Role.LEADER_4_N_LEADER_CIRCLE
+                        )))
                 .validate();
 
         return this.circleMemberPort.findByCircleId(circleId, status)
@@ -295,7 +303,7 @@ public class CircleService {
                 .consistOf(UserStateValidator.of(requestUser.getState()))
                 .consistOf(UserRoleIsNoneValidator.of(requestUser.getRole()))
                 .consistOf(ConstraintValidator.of(circleDomainModel, this.validator))
-                .consistOf(UserRoleValidator.of(requestUser.getRole(), List.of(Role.PRESIDENT)))
+                .consistOf(UserRoleValidator.of(requestUser.getRole(), List.of()))
                 .consistOf(GrantableRoleValidator.of(requestUser.getRole(), Role.LEADER_CIRCLE, leader.getRole()))
                 .validate();
 
@@ -314,7 +322,9 @@ public class CircleService {
         BoardDomainModel noticeBoard = BoardDomainModel.of(
                 "공지 게시판",
                 newCircle.getName() + " 공지 게시판",
-                Stream.of(Role.ADMIN, Role.PRESIDENT, Role.LEADER_CIRCLE)
+                Stream.of(Role.ADMIN, Role.PRESIDENT, Role.LEADER_CIRCLE, Role.LEADER_1_N_LEADER_CIRCLE, Role.LEADER_2_N_LEADER_CIRCLE,
+                                Role.LEADER_3_N_LEADER_CIRCLE, Role.LEADER_4_N_LEADER_CIRCLE, Role.PRESIDENT_N_LEADER_CIRCLE,
+                                Role.COUNCIL_N_LEADER_CIRCLE, Role.VICE_PRESIDENT_N_LEADER_CIRCLE)
                         .map(Role::getValue)
                         .collect(Collectors.toList()),
                 "공지 게시판",
@@ -381,10 +391,17 @@ public class CircleService {
                 .consistOf(ConstraintValidator.of(circle, this.validator))
                 .consistOf(UserRoleValidator.of(
                         user.getRole(),
-                        List.of(Role.PRESIDENT, Role.LEADER_CIRCLE)
+                        List.of(Role.LEADER_CIRCLE,
+                                Role.VICE_PRESIDENT_N_LEADER_CIRCLE,
+                                Role.COUNCIL_N_LEADER_CIRCLE,
+                                Role.LEADER_1_N_LEADER_CIRCLE,
+                                Role.LEADER_2_N_LEADER_CIRCLE,
+                                Role.LEADER_3_N_LEADER_CIRCLE,
+                                Role.LEADER_4_N_LEADER_CIRCLE
+                        )
                 ));
 
-        if (user.getRole().equals(Role.LEADER_CIRCLE)) {
+        if (user.getRole().getValue().contains("LEADER_CIRCLE")) {
             validatorBucket
                     .consistOf(UserEqualValidator.of(
                             circle.getLeader().map(UserDomainModel::getId).orElseThrow(
@@ -435,10 +452,17 @@ public class CircleService {
                 .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
                 .consistOf(UserRoleValidator.of(
                         user.getRole(),
-                        List.of(Role.PRESIDENT, Role.LEADER_CIRCLE)
+                        List.of(Role.LEADER_CIRCLE,
+                                Role.VICE_PRESIDENT_N_LEADER_CIRCLE,
+                                Role.COUNCIL_N_LEADER_CIRCLE,
+                                Role.LEADER_1_N_LEADER_CIRCLE,
+                                Role.LEADER_2_N_LEADER_CIRCLE,
+                                Role.LEADER_3_N_LEADER_CIRCLE,
+                                Role.LEADER_4_N_LEADER_CIRCLE
+                        )
                 ));
 
-        if (user.getRole().equals(Role.LEADER_CIRCLE)) {
+        if (user.getRole().getValue().contains("LEADER_CIRCLE")) {
             validatorBucket
                     .consistOf(UserEqualValidator.of(
                             circle.getLeader().map(UserDomainModel::getId).orElseThrow(
@@ -616,9 +640,17 @@ public class CircleService {
                 .consistOf(UserStateValidator.of(requestUser.getState()))
                 .consistOf(UserRoleIsNoneValidator.of(requestUser.getRole()))
                 .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
-                .consistOf(UserRoleValidator.of(requestUser.getRole(), List.of(Role.LEADER_CIRCLE)));
+                .consistOf(UserRoleValidator.of(requestUser.getRole(),
+                        List.of(Role.LEADER_CIRCLE,
+                                Role.VICE_PRESIDENT_N_LEADER_CIRCLE,
+                                Role.COUNCIL_N_LEADER_CIRCLE,
+                                Role.LEADER_1_N_LEADER_CIRCLE,
+                                Role.LEADER_2_N_LEADER_CIRCLE,
+                                Role.LEADER_3_N_LEADER_CIRCLE,
+                                Role.LEADER_4_N_LEADER_CIRCLE
+                        )));
 
-        if (requestUser.getRole().equals(Role.LEADER_CIRCLE)) {
+        if (requestUser.getRole().getValue().contains("LEADER_CIRCLE")) {
             validatorBucket
                     .consistOf(UserEqualValidator.of(
                             circle.getLeader().map(UserDomainModel::getId).orElseThrow(
@@ -704,9 +736,17 @@ public class CircleService {
                 .consistOf(UserStateValidator.of(requestUser.getState()))
                 .consistOf(UserRoleIsNoneValidator.of(requestUser.getRole()))
                 .consistOf(TargetIsDeletedValidator.of(circleMember.getCircle().getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
-                .consistOf(UserRoleValidator.of(requestUser.getRole(), List.of(Role.LEADER_CIRCLE)));
+                .consistOf(UserRoleValidator.of(requestUser.getRole(),
+                        List.of(Role.LEADER_CIRCLE,
+                                Role.VICE_PRESIDENT_N_LEADER_CIRCLE,
+                                Role.COUNCIL_N_LEADER_CIRCLE,
+                                Role.LEADER_1_N_LEADER_CIRCLE,
+                                Role.LEADER_2_N_LEADER_CIRCLE,
+                                Role.LEADER_3_N_LEADER_CIRCLE,
+                                Role.LEADER_4_N_LEADER_CIRCLE
+                        )));
 
-        if (requestUser.getRole().equals(Role.LEADER_CIRCLE)) {
+        if (requestUser.getRole().getValue().contains("LEADER_CIRCLE")) {
             validatorBucket
                     .consistOf(UserEqualValidator.of(
                             circleMember.getCircle().getLeader().map(UserDomainModel::getId).orElseThrow(

--- a/src/main/java/net/causw/application/comment/ChildCommentService.java
+++ b/src/main/java/net/causw/application/comment/ChildCommentService.java
@@ -121,7 +121,7 @@ public class ChildCommentService {
         );
 
         postDomainModel.getBoard().getCircle()
-                .filter(circleDomainModel -> !creatorDomainModel.getRole().equals(Role.ADMIN))
+                .filter(circleDomainModel -> !creatorDomainModel.getRole().equals(Role.ADMIN) && !creatorDomainModel.getRole().getValue().contains("PRESIDENT"))
                 .ifPresent(
                         circleDomainModel -> {
                             CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
@@ -185,7 +185,7 @@ public class ChildCommentService {
                 .consistOf(TargetIsDeletedValidator.of(postDomainModel.getIsDeleted(), StaticValue.DOMAIN_POST));
 
         postDomainModel.getBoard().getCircle()
-                .filter(circleDomainModel -> !userDomainModel.getRole().equals(Role.ADMIN))
+                .filter(circleDomainModel -> !userDomainModel.getRole().equals(Role.ADMIN) && !userDomainModel.getRole().getValue().contains("PRESIDENT"))
                 .ifPresent(
                         circleDomainModel -> {
                             CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
@@ -276,7 +276,7 @@ public class ChildCommentService {
                 ));
 
         postDomainModel.getBoard().getCircle()
-                .filter(circleDomainModel -> !updater.getRole().equals(Role.ADMIN))
+                .filter(circleDomainModel -> !updater.getRole().equals(Role.ADMIN) && !updater.getRole().getValue().contains("PRESIDENT"))
                 .ifPresent(
                         circleDomainModel -> {
                             CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
@@ -344,7 +344,7 @@ public class ChildCommentService {
                 .consistOf(TargetIsDeletedValidator.of(childCommentDomainModel.getIsDeleted(), StaticValue.DOMAIN_CHILD_COMMENT));
 
         postDomainModel.getBoard().getCircle()
-                .filter(circleDomainModel -> !deleterDomainModel.getRole().equals(Role.ADMIN))
+                .filter(circleDomainModel -> !deleterDomainModel.getRole().equals(Role.ADMIN) && !deleterDomainModel.getRole().getValue().contains("PRESIDENT"))
                 .ifPresentOrElse(
                         circleDomainModel -> {
                             CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
@@ -367,10 +367,17 @@ public class ChildCommentService {
                                             deleterDomainModel.getRole(),
                                             deleterId,
                                             childCommentDomainModel.getWriter().getId(),
-                                            List.of(Role.LEADER_CIRCLE)
+                                            List.of(Role.LEADER_CIRCLE,
+                                                    Role.VICE_PRESIDENT_N_LEADER_CIRCLE,
+                                                    Role.COUNCIL_N_LEADER_CIRCLE,
+                                                    Role.LEADER_1_N_LEADER_CIRCLE,
+                                                    Role.LEADER_2_N_LEADER_CIRCLE,
+                                                    Role.LEADER_3_N_LEADER_CIRCLE,
+                                                    Role.LEADER_4_N_LEADER_CIRCLE
+                                            )
                                     ));
 
-                            if (deleterDomainModel.getRole().equals(Role.LEADER_CIRCLE)) {
+                            if (deleterDomainModel.getRole().getValue().contains("LEADER_CIRCLE")) {
                                 validatorBucket
                                         .consistOf(UserEqualValidator.of(
                                                 circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
@@ -388,7 +395,7 @@ public class ChildCommentService {
                                         deleterDomainModel.getRole(),
                                         deleterId,
                                         childCommentDomainModel.getWriter().getId(),
-                                        List.of(Role.PRESIDENT)
+                                        List.of()
                                 ))
 
                 );

--- a/src/main/java/net/causw/application/comment/CommentService.java
+++ b/src/main/java/net/causw/application/comment/CommentService.java
@@ -94,7 +94,7 @@ public class CommentService {
                 .consistOf(ConstraintValidator.of(commentDomainModel, this.validator));
 
         postDomainModel.getBoard().getCircle()
-                .filter(circleDomainModel -> !creatorDomainModel.getRole().equals(Role.ADMIN))
+                .filter(circleDomainModel -> !creatorDomainModel.getRole().equals(Role.ADMIN) && !creatorDomainModel.getRole().getValue().contains("PRESIDENT"))
                 .ifPresent(
                         circleDomainModel -> {
                             CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
@@ -151,7 +151,7 @@ public class CommentService {
                 .consistOf(TargetIsDeletedValidator.of(postDomainModel.getIsDeleted(), StaticValue.DOMAIN_POST));
 
         postDomainModel.getBoard().getCircle()
-                .filter(circleDomainModel -> !userDomainModel.getRole().equals(Role.ADMIN))
+                .filter(circleDomainModel -> !userDomainModel.getRole().equals(Role.ADMIN) && !userDomainModel.getRole().getValue().contains("PRESIDENT"))
                 .ifPresent(
                         circleDomainModel -> {
                             CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
@@ -235,7 +235,7 @@ public class CommentService {
                 ));
 
         postDomainModel.getBoard().getCircle()
-                .filter(circleDomainModel -> !requestUser.getRole().equals(Role.ADMIN))
+                .filter(circleDomainModel -> !requestUser.getRole().equals(Role.ADMIN) && !requestUser.getRole().getValue().contains("PRESIDENT"))
                 .ifPresent(
                         circleDomainModel -> {
                             CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
@@ -304,7 +304,7 @@ public class CommentService {
                 .consistOf(TargetIsDeletedValidator.of(commentDomainModel.getIsDeleted(), StaticValue.DOMAIN_COMMENT));
 
         postDomainModel.getBoard().getCircle()
-                .filter(circleDomainModel -> !deleterDomainModel.getRole().equals(Role.ADMIN))
+                .filter(circleDomainModel -> !deleterDomainModel.getRole().equals(Role.ADMIN) && !deleterDomainModel.getRole().getValue().contains("PRESIDENT"))
                 .ifPresentOrElse(
                         circleDomainModel -> {
                             CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
@@ -327,10 +327,17 @@ public class CommentService {
                                             deleterDomainModel.getRole(),
                                             loginUserId,
                                             commentDomainModel.getWriter().getId(),
-                                            List.of(Role.LEADER_CIRCLE)
+                                            List.of(Role.LEADER_CIRCLE,
+                                                    Role.VICE_PRESIDENT_N_LEADER_CIRCLE,
+                                                    Role.COUNCIL_N_LEADER_CIRCLE,
+                                                    Role.LEADER_1_N_LEADER_CIRCLE,
+                                                    Role.LEADER_2_N_LEADER_CIRCLE,
+                                                    Role.LEADER_3_N_LEADER_CIRCLE,
+                                                    Role.LEADER_4_N_LEADER_CIRCLE
+                                            )
                                     ));
 
-                            if (deleterDomainModel.getRole().equals(Role.LEADER_CIRCLE)) {
+                            if (deleterDomainModel.getRole().getValue().contains("LEADER_CIRCLE")) {
                                 validatorBucket
                                         .consistOf(UserEqualValidator.of(
                                                 circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
@@ -348,7 +355,7 @@ public class CommentService {
                                         deleterDomainModel.getRole(),
                                         loginUserId,
                                         commentDomainModel.getWriter().getId(),
-                                        List.of(Role.PRESIDENT)
+                                        List.of()
                                 ))
                 );
 

--- a/src/main/java/net/causw/application/delegation/DelegationPresident.java
+++ b/src/main/java/net/causw/application/delegation/DelegationPresident.java
@@ -23,14 +23,14 @@ public class DelegationPresident implements Delegation {
 
     @Override
     public void delegate(String currentId, String targetId) {
-        List<UserDomainModel> councilList = this.userPort.findByRole(Role.COUNCIL);
+        List<UserDomainModel> councilList = this.userPort.findByRole("COUNCIL");
         if (councilList != null) {
             councilList.forEach(
                     user -> this.userPort.updateRole(user.getId(), Role.COMMON)
             );
         }
 
-        List<UserDomainModel> vicePresident = this.userPort.findByRole(Role.VICE_PRESIDENT);
+        List<UserDomainModel> vicePresident = this.userPort.findByRole("VICE_PRESIDENT");
         if (vicePresident != null) {
             vicePresident.forEach(
                     user -> this.userPort.updateRole(user.getId(), Role.COMMON)

--- a/src/main/java/net/causw/application/post/PostService.java
+++ b/src/main/java/net/causw/application/post/PostService.java
@@ -97,7 +97,7 @@ public class PostService {
                 .consistOf(UserRoleIsNoneValidator.of(userDomainModel.getRole()));
 
         postDomainModel.getBoard().getCircle()
-                .filter(circleDomainModel -> !userDomainModel.getRole().equals(Role.ADMIN) && !userDomainModel.getRole().equals(Role.PRESIDENT))
+                .filter(circleDomainModel -> !userDomainModel.getRole().equals(Role.ADMIN) && !userDomainModel.getRole().getValue().contains("PRESIDENT"))
                 .ifPresent(
                         circleDomainModel -> {
                             CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
@@ -165,7 +165,7 @@ public class PostService {
         );
 
         boardDomainModel.getCircle()
-                .filter(circleDomainModel -> !userDomainModel.getRole().equals(Role.ADMIN) && !userDomainModel.getRole().equals(Role.PRESIDENT))
+                .filter(circleDomainModel -> !userDomainModel.getRole().equals(Role.ADMIN) && !userDomainModel.getRole().getValue().contains("PRESIDENT"))
                 .ifPresent(
                         circleDomainModel -> {
                             CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
@@ -190,12 +190,12 @@ public class PostService {
         validatorBucket.validate();
 
         boolean isCircleLeader = false;
-        if(userDomainModel.getRole().equals(Role.LEADER_CIRCLE)){
+        if(userDomainModel.getRole().getValue().contains("LEADER_CIRCLE")){
             isCircleLeader = boardDomainModel.getCircle().get()
                 .getLeader().map(UserDomainModel::getId).orElse("").equals(loginUserId);
         }
 
-        if (isCircleLeader || userDomainModel.getRole().equals(Role.ADMIN) || userDomainModel.getRole().equals(Role.PRESIDENT)) {
+        if (isCircleLeader || userDomainModel.getRole().equals(Role.ADMIN) || userDomainModel.getRole().getValue().contains("PRESIDENT")) {
             return BoardPostsResponseDto.from(
                     boardDomainModel,
                     userDomainModel.getRole(),
@@ -283,12 +283,12 @@ public class PostService {
 
 
         boolean isCircleLeader = false;
-        if(userDomainModel.getRole().equals(Role.LEADER_CIRCLE)){
+        if(userDomainModel.getRole().getValue().contains("LEADER_CIRCLE")){
             isCircleLeader = boardDomainModel.getCircle().get()
                     .getLeader().map(UserDomainModel::getId).orElse("").equals(loginUserId);
         }
 
-        if (isCircleLeader || userDomainModel.getRole().equals(Role.ADMIN) || userDomainModel.getRole().equals(Role.PRESIDENT)) {
+        if (isCircleLeader || userDomainModel.getRole().equals(Role.ADMIN) || userDomainModel.getRole().getValue().contains("PRESIDENT")) {
             return BoardPostsResponseDto.from(
                     boardDomainModel,
                     userDomainModel.getRole(),
@@ -390,7 +390,7 @@ public class PostService {
                 ));
 
         boardDomainModel.getCircle()
-                .filter(circleDomainModel -> !creatorDomainModel.getRole().equals(Role.ADMIN) && !creatorDomainModel.getRole().equals(Role.PRESIDENT))
+                .filter(circleDomainModel -> !creatorDomainModel.getRole().equals(Role.ADMIN) && !creatorDomainModel.getRole().getValue().contains("PRESIDENT"))
                 .ifPresent(
                         circleDomainModel -> {
                             CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
@@ -410,7 +410,7 @@ public class PostService {
                                             List.of(CircleMemberStatus.MEMBER)
                                     ));
 
-                            if (creatorDomainModel.getRole().equals(Role.LEADER_CIRCLE) && !boardDomainModel.getCreateRoleList().contains("COMMON")) {
+                            if (creatorDomainModel.getRole().getValue().contains("LEADER_CIRCLE") && !boardDomainModel.getCreateRoleList().contains("COMMON")) {
                                 validatorBucket
                                         .consistOf(UserEqualValidator.of(
                                                 circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
@@ -475,7 +475,7 @@ public class PostService {
                 .consistOf(TargetIsDeletedValidator.of(postDomainModel.getIsDeleted(), StaticValue.DOMAIN_POST));
 
         postDomainModel.getBoard().getCircle()
-                .filter(circleDomainModel -> !deleterDomainModel.getRole().equals(Role.ADMIN) && !deleterDomainModel.getRole().equals(Role.PRESIDENT))
+                .filter(circleDomainModel -> !deleterDomainModel.getRole().equals(Role.ADMIN) && !deleterDomainModel.getRole().getValue().contains("PRESIDENT"))
                 .ifPresent(
                         circleDomainModel -> {
                             CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
@@ -495,7 +495,7 @@ public class PostService {
                                             List.of(CircleMemberStatus.MEMBER)
                                     ));
 
-                            if (deleterDomainModel.getRole().equals(Role.LEADER_CIRCLE) && !postDomainModel.getWriter().getId().equals(loginUserId)) {
+                            if (deleterDomainModel.getRole().getValue().contains("LEADER_CIRCLE") && !postDomainModel.getWriter().getId().equals(loginUserId)) {
                                 validatorBucket
                                         .consistOf(UserEqualValidator.of(
                                                 circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
@@ -515,8 +515,15 @@ public class PostService {
                         deleterDomainModel.getRole(),
                         loginUserId,
                         postDomainModel.getWriter().getId(),
-                        List.of(Role.PRESIDENT, Role.LEADER_CIRCLE)
-                ))
+                        List.of(Role.LEADER_CIRCLE,
+                                Role.VICE_PRESIDENT_N_LEADER_CIRCLE,
+                                Role.COUNCIL_N_LEADER_CIRCLE,
+                                Role.LEADER_1_N_LEADER_CIRCLE,
+                                Role.LEADER_2_N_LEADER_CIRCLE,
+                                Role.LEADER_3_N_LEADER_CIRCLE,
+                                Role.LEADER_4_N_LEADER_CIRCLE
+                        ))
+                )
                 .validate();
 
         return PostResponseDto.from(
@@ -568,7 +575,7 @@ public class PostService {
                 .consistOf(TargetIsDeletedValidator.of(postDomainModel.getIsDeleted(), StaticValue.DOMAIN_POST));
 
         postDomainModel.getBoard().getCircle()
-                .filter(circleDomainModel -> !updaterDomainModel.getRole().equals(Role.ADMIN) && !updaterDomainModel.getRole().equals(Role.PRESIDENT))
+                .filter(circleDomainModel -> !updaterDomainModel.getRole().equals(Role.ADMIN) && !updaterDomainModel.getRole().getValue().contains("PRESIDENT"))
                 .ifPresent(
                         circleDomainModel -> {
                             CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
@@ -588,7 +595,7 @@ public class PostService {
                                             List.of(CircleMemberStatus.MEMBER)
                                     ));
 
-                            if (updaterDomainModel.getRole().equals(Role.LEADER_CIRCLE) && !postDomainModel.getWriter().getId().equals(loginUserId)) {
+                            if (updaterDomainModel.getRole().getValue().contains("LEADER_CIRCLE") && !postDomainModel.getWriter().getId().equals(loginUserId)) {
                                 validatorBucket
                                         .consistOf(UserEqualValidator.of(
                                                 circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
@@ -614,7 +621,14 @@ public class PostService {
                         updaterDomainModel.getRole(),
                         loginUserId,
                         postDomainModel.getWriter().getId(),
-                        List.of(Role.PRESIDENT, Role.LEADER_CIRCLE)
+                        List.of(Role.LEADER_CIRCLE,
+                                Role.VICE_PRESIDENT_N_LEADER_CIRCLE,
+                                Role.COUNCIL_N_LEADER_CIRCLE,
+                                Role.LEADER_1_N_LEADER_CIRCLE,
+                                Role.LEADER_2_N_LEADER_CIRCLE,
+                                Role.LEADER_3_N_LEADER_CIRCLE,
+                                Role.LEADER_4_N_LEADER_CIRCLE
+                        )
                 ))
                 .consistOf(ConstraintValidator.of(postDomainModel, this.validator))
                 .validate();
@@ -673,7 +687,7 @@ public class PostService {
                 .consistOf(TargetIsNotDeletedValidator.of(postDomainModel.getIsDeleted(), StaticValue.DOMAIN_POST));
 
         postDomainModel.getBoard().getCircle()
-                .filter(circleDomainModel -> !restorerDomainModel.getRole().equals(Role.ADMIN) && !restorerDomainModel.getRole().equals(Role.PRESIDENT))
+                .filter(circleDomainModel -> !restorerDomainModel.getRole().equals(Role.ADMIN) && !restorerDomainModel.getRole().getValue().contains("PRESIDENT"))
                 .ifPresent(
                         circleDomainModel -> {
                             CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
@@ -693,7 +707,7 @@ public class PostService {
                                             List.of(CircleMemberStatus.MEMBER)
                                     ));
 
-                            if (restorerDomainModel.getRole().equals(Role.LEADER_CIRCLE) && !postDomainModel.getWriter().getId().equals(loginUserId)) {
+                            if (restorerDomainModel.getRole().getValue().contains("LEADER_CIRCLE") && !postDomainModel.getWriter().getId().equals(loginUserId)) {
                                 validatorBucket
                                         .consistOf(UserEqualValidator.of(
                                                 circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
@@ -713,7 +727,14 @@ public class PostService {
                         restorerDomainModel.getRole(),
                         loginUserId,
                         postDomainModel.getWriter().getId(),
-                        List.of(Role.PRESIDENT, Role.LEADER_CIRCLE)
+                        List.of(Role.LEADER_CIRCLE,
+                                Role.VICE_PRESIDENT_N_LEADER_CIRCLE,
+                                Role.COUNCIL_N_LEADER_CIRCLE,
+                                Role.LEADER_1_N_LEADER_CIRCLE,
+                                Role.LEADER_2_N_LEADER_CIRCLE,
+                                Role.LEADER_3_N_LEADER_CIRCLE,
+                                Role.LEADER_4_N_LEADER_CIRCLE
+                        )
                 ))
                 .validate();
 

--- a/src/main/java/net/causw/application/spi/UserPort.java
+++ b/src/main/java/net/causw/application/spi/UserPort.java
@@ -24,7 +24,7 @@ public interface UserPort {
 
     Optional<UserDomainModel> updateRole(String id, Role role);
 
-    List<UserDomainModel> findByRole(Role role);
+    List<UserDomainModel> findByRole(String role);
 
     Page<UserDomainModel> findByState(UserState state, Integer pageNum);
 

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -171,9 +171,7 @@ public class UserService {
                 .consistOf(UserRoleIsNoneValidator.of(requestUser.getRole()))
                 .consistOf(UserStateValidator.of(requestUser.getState()))
                 .consistOf(UserRoleValidator.of(requestUser.getRole(),
-                        List.of(Role.PRESIDENT,
-                                Role.LEADER_CIRCLE,
-                                Role.PRESIDENT_N_LEADER_CIRCLE,
+                        List.of(Role.LEADER_CIRCLE,
                                 Role.VICE_PRESIDENT_N_LEADER_CIRCLE,
                                 Role.COUNCIL_N_LEADER_CIRCLE,
                                 Role.LEADER_1_N_LEADER_CIRCLE,
@@ -320,15 +318,14 @@ public class UserService {
                 .consistOf(UserStateValidator.of(user.getState()))
                 .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
                 .consistOf(UserRoleValidator.of(user.getRole(),
-                        List.of(Role.PRESIDENT,
-                                Role.LEADER_CIRCLE,
-                                Role.PRESIDENT_N_LEADER_CIRCLE,
+                        List.of(Role.LEADER_CIRCLE,
                                 Role.VICE_PRESIDENT_N_LEADER_CIRCLE,
                                 Role.COUNCIL_N_LEADER_CIRCLE,
                                 Role.LEADER_1_N_LEADER_CIRCLE,
                                 Role.LEADER_2_N_LEADER_CIRCLE,
                                 Role.LEADER_3_N_LEADER_CIRCLE,
-                                Role.LEADER_4_N_LEADER_CIRCLE)))
+                                Role.LEADER_4_N_LEADER_CIRCLE
+                        )))
                 .validate();
 
         if (user.getRole().getValue().contains("LEADER_CIRCLE")) {
@@ -376,31 +373,31 @@ public class UserService {
         ValidatorBucket.of()
                 .consistOf(UserStateValidator.of(user.getState()))
                 .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
-                .consistOf(UserRoleValidator.of(user.getRole(), List.of(Role.PRESIDENT)))
+                .consistOf(UserRoleValidator.of(user.getRole(), List.of()))
                 .validate();
 
         return UserPrivilegedResponseDto.from(
-                this.userPort.findByRole(Role.COUNCIL)
+                this.userPort.findByRole("COUNCIL")
                         .stream()
                         .map(UserResponseDto::from)
                         .collect(Collectors.toList()),
-                this.userPort.findByRole(Role.LEADER_1)
+                this.userPort.findByRole("LEADER_1")
                         .stream()
                         .map(UserResponseDto::from)
                         .collect(Collectors.toList()),
-                this.userPort.findByRole(Role.LEADER_2)
+                this.userPort.findByRole("LEADER_2")
                         .stream()
                         .map(UserResponseDto::from)
                         .collect(Collectors.toList()),
-                this.userPort.findByRole(Role.LEADER_3)
+                this.userPort.findByRole("LEADER_3")
                         .stream()
                         .map(UserResponseDto::from)
                         .collect(Collectors.toList()),
-                this.userPort.findByRole(Role.LEADER_4)
+                this.userPort.findByRole("LEADER_4")
                         .stream()
                         .map(UserResponseDto::from)
                         .collect(Collectors.toList()),
-                this.userPort.findByRole(Role.LEADER_CIRCLE)
+                this.userPort.findByRole("LEADER_CIRCLE")
                         .stream()
                         .map(userDomainModel -> {
                             List<CircleDomainModel> ownCircles = this.circlePort.findByLeaderId(loginUserId);
@@ -410,7 +407,6 @@ public class UserService {
                                         "해당 동아리장이 배정된 동아리가 없습니다."
                                 );
                             }
-
                             return UserResponseDto.from(
                                     userDomainModel,
                                     ownCircles.stream().map(CircleDomainModel::getId).collect(Collectors.toList()),
@@ -418,11 +414,11 @@ public class UserService {
                             );
                         })
                         .collect(Collectors.toList()),
-                this.userPort.findByRole(Role.LEADER_ALUMNI)
+                this.userPort.findByRole("LEADER_ALUMNI")
                         .stream()
                         .map(UserResponseDto::from)
                         .collect(Collectors.toList()),
-                this.userPort.findByRole(Role.VICE_PRESIDENT)
+                this.userPort.findByRole("VICE_PRESIDENT")
                         .stream()
                         .map(UserResponseDto::from)
                         .collect(Collectors.toList())
@@ -445,7 +441,7 @@ public class UserService {
         ValidatorBucket.of()
                 .consistOf(UserStateValidator.of(user.getState()))
                 .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
-                .consistOf(UserRoleValidator.of(user.getRole(), List.of(Role.PRESIDENT)))
+                .consistOf(UserRoleValidator.of(user.getRole(), List.of()))
                 .validate();
 
         return this.userPort.findByState(UserState.of(state), pageNum)
@@ -753,7 +749,7 @@ public class UserService {
         else if ((grantor.getRole().equals(Role.PRESIDENT) || grantor.getRole().equals(Role.ADMIN))
                 && userUpdateRoleRequestDto.getRole().equals(Role.LEADER_ALUMNI)
         ) {
-            UserDomainModel previousLeaderAlumni = this.userPort.findByRole(Role.LEADER_ALUMNI)
+            UserDomainModel previousLeaderAlumni = this.userPort.findByRole("LEADER_ALUMNI")
                     .stream().findFirst()
                     .orElseThrow(
                             () -> new InternalServerException(
@@ -886,7 +882,7 @@ public class UserService {
         ValidatorBucket.of()
                 .consistOf(UserStateValidator.of(requestUser.getState()))
                 .consistOf(UserRoleIsNoneValidator.of(requestUser.getRole()))
-                .consistOf(UserRoleValidator.of(requestUser.getRole(), List.of(Role.PRESIDENT)))
+                .consistOf(UserRoleValidator.of(requestUser.getRole(), List.of()))
                 .consistOf(UserRoleWithoutAdminValidator.of(droppedUser.getRole(), List.of(Role.COMMON, Role.PROFESSOR)))
                 .validate();
 
@@ -931,7 +927,7 @@ public class UserService {
         ValidatorBucket.of()
                 .consistOf(UserStateValidator.of(requestUser.getState()))
                 .consistOf(UserRoleIsNoneValidator.of(requestUser.getRole()))
-                .consistOf(UserRoleValidator.of(requestUser.getRole(), List.of(Role.PRESIDENT)))
+                .consistOf(UserRoleValidator.of(requestUser.getRole(), List.of()))
                 .validate();
 
         return UserAdmissionResponseDto.from(this.userAdmissionPort.findById(admissionId).orElseThrow(
@@ -957,7 +953,7 @@ public class UserService {
         ValidatorBucket.of()
                 .consistOf(UserStateValidator.of(requestUser.getState()))
                 .consistOf(UserRoleIsNoneValidator.of(requestUser.getRole()))
-                .consistOf(UserRoleValidator.of(requestUser.getRole(), List.of(Role.PRESIDENT)))
+                .consistOf(UserRoleValidator.of(requestUser.getRole(), List.of()))
                 .validate();
 
         return this.userAdmissionPort.findAll(UserState.AWAIT, pageNum)
@@ -1026,7 +1022,7 @@ public class UserService {
         ValidatorBucket.of()
                 .consistOf(UserStateValidator.of(requestUser.getState()))
                 .consistOf(UserRoleIsNoneValidator.of(requestUser.getRole()))
-                .consistOf(UserRoleValidator.of(requestUser.getRole(), List.of(Role.PRESIDENT)))
+                .consistOf(UserRoleValidator.of(requestUser.getRole(), List.of()))
                 .validate();
 
         // Update user role to COMMON
@@ -1084,7 +1080,7 @@ public class UserService {
         ValidatorBucket.of()
                 .consistOf(UserStateValidator.of(requestUser.getState()))
                 .consistOf(UserRoleIsNoneValidator.of(requestUser.getRole()))
-                .consistOf(UserRoleValidator.of(requestUser.getRole(), List.of(Role.PRESIDENT)))
+                .consistOf(UserRoleValidator.of(requestUser.getRole(), List.of()))
                 .validate();
 
         this.userAdmissionLogPort.create(
@@ -1166,7 +1162,7 @@ public class UserService {
         );
 
         ValidatorBucket.of()
-                .consistOf(UserRoleValidator.of(requestUser.getRole(), List.of(Role.PRESIDENT)))
+                .consistOf(UserRoleValidator.of(requestUser.getRole(), List.of()))
                 .consistOf(UserStateIsDropValidator.of(restoredUser.getState()))
                 .validate();
 

--- a/src/main/java/net/causw/domain/validation/ContentsAdminValidator.java
+++ b/src/main/java/net/causw/domain/validation/ContentsAdminValidator.java
@@ -4,6 +4,7 @@ import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.UnauthorizedException;
 import net.causw.domain.model.enums.Role;
 
+import java.util.EnumSet;
 import java.util.List;
 
 /**
@@ -53,7 +54,7 @@ public class ContentsAdminValidator extends AbstractValidator {
             return;
         }
 
-        if (this.requestUserRole.equals(Role.ADMIN)) {
+        if (EnumSet.of(Role.ADMIN, Role.PRESIDENT, Role.PRESIDENT_N_LEADER_CIRCLE).contains(this.requestUserRole)) {
             return;
         }
 

--- a/src/main/java/net/causw/domain/validation/UserRoleValidator.java
+++ b/src/main/java/net/causw/domain/validation/UserRoleValidator.java
@@ -4,6 +4,7 @@ import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.UnauthorizedException;
 import net.causw.domain.model.enums.Role;
 
+import java.util.EnumSet;
 import java.util.List;
 
 public class UserRoleValidator extends AbstractValidator {
@@ -23,7 +24,8 @@ public class UserRoleValidator extends AbstractValidator {
 
     @Override
     public void validate() {
-        if (this.requestUserRole.equals(Role.ADMIN)) {
+
+        if (EnumSet.of(Role.ADMIN, Role.PRESIDENT, Role.PRESIDENT_N_LEADER_CIRCLE).contains(this.requestUserRole)) {
             return;
         }
 


### PR DESCRIPTION
### 🚩 관련사항
#449 


### 📢 전달사항
enum 값들의 개수가 증가하면서 단순히 Role.LEADER_CIRCLE인지 확인하던 코드부분을 모두 LEADER_CIRCLE이라는 value를 포함하는지 확인하는 코드로 변경하였습니다. 
학생회장의 권한을 ADMIN과 동일하게 설정하는 바에 따라서 validator내부의 설정을 변경하여 학생회장의 권한을 수정하였습니다.
findByRole로 역할에 따라 유저를 검색하는 메서드의 인자를 기존 Role에서 String 타입으로 넘겨서 해당 문자열을 포함한 모든 역할을 검색할 수 있도록 변경하였습니다.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [x] 동아리장 역임 가능에 따른 권한 설정 변경 및 수정
- [ ] user API 검증


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 2일