### PR TITLE
refac : 권한 중첩 시 검증 로직 수정 및 추가

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/port/user/UserPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/user/UserPortImpl.java
@@ -74,11 +74,39 @@ public class UserPortImpl extends DomainModelMapper implements UserPort {
     }
 
     @Override
-    public Optional<UserDomainModel> updateRole(String id, Role role) {
+    public Optional<UserDomainModel> updateRole(String id, Role newRole) {
         return this.userRepository.findById(id).map(
                 srcUser -> {
-                    srcUser.setRole(role);
-
+                    if (newRole.equals(Role.LEADER_CIRCLE)) {
+                        if(!srcUser.getRole().getValue().contains("LEADER_CIRCLE")){
+                            String combinedRoleValue = srcUser.getRole().getValue() + "_N_" + "LEADER_CIRCLE";
+                            Role combinedRole = Role.of(combinedRoleValue.toUpperCase());
+                            srcUser.setRole(combinedRole);
+                        } else {
+                            srcUser.setRole(srcUser.getRole());
+                        }
+                    } else if(srcUser.getRole().equals(Role.LEADER_CIRCLE)){
+                        String combinedRoleValue = newRole.getValue() + "_N_" + "LEADER_CIRCLE";
+                        Role combinedRole = Role.of(combinedRoleValue.toUpperCase());
+                        srcUser.setRole(combinedRole);
+                    }
+                    else {
+                        srcUser.setRole(newRole);
+                    }
+                    return this.entityToDomainModel(this.userRepository.save(srcUser));
+                }
+        );
+    }
+    @Override
+    public Optional<UserDomainModel> removeRole(String id, Role targetRole) {
+        return this.userRepository.findById(id).map(
+                srcUser -> {
+                    if(srcUser.getRole().equals(targetRole)){
+                        srcUser.setRole(Role.COMMON);
+                    } else if (srcUser.getRole().getValue().contains(targetRole.getValue())) {
+                        String updatedRoleValue = srcUser.getRole().getValue().replace(targetRole.getValue(), "").replace("_N_","");
+                        srcUser.setRole(Role.of(updatedRoleValue));
+                    }
                     return this.entityToDomainModel(this.userRepository.save(srcUser));
                 }
         );

--- a/src/main/java/net/causw/adapter/web/UserController.java
+++ b/src/main/java/net/causw/adapter/web/UserController.java
@@ -228,7 +228,7 @@ public class UserController {
      */
     @PutMapping(value = "/{granteeId}/role")
     @ResponseStatus(value = HttpStatus.OK)
-    @ApiOperation(value = "역할 업데이트 API", notes = "grantorId 에는 관리자의 고유 id값, granteeId 에는 권한이 업데이트될 사용자의 고유 id 값을 넣어주세요")
+    @ApiOperation(value = "역할 업데이트 API(완료)", notes = "grantorId 에는 관리자의 고유 id값, granteeId 에는 권한이 업데이트될 사용자의 고유 id 값을 넣어주세요")
     @ApiResponses({
             @ApiResponse(code = 200, message = "OK", response = String.class),
             @ApiResponse(code = 4000, message = "로그인된 사용자를 찾을 수 없습니다.", response = BadRequestException.class),

--- a/src/main/java/net/causw/adapter/web/UserController.java
+++ b/src/main/java/net/causw/adapter/web/UserController.java
@@ -90,7 +90,7 @@ public class UserController {
     public UserResponseDto findCurrentUser() {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         String loginUserId = ((String) principal);
-        return this.userService.findByUserId(loginUserId);
+        return this.userService.findCurrentUser(loginUserId);
     }
 
     @GetMapping(value = "/posts")

--- a/src/main/java/net/causw/application/board/BoardService.java
+++ b/src/main/java/net/causw/application/board/BoardService.java
@@ -64,7 +64,7 @@ public class BoardService {
                 .consistOf(UserRoleIsNoneValidator.of(userDomainModel.getRole()))
                 .validate();
 
-        if (userDomainModel.getRole().getValue().contains("LEADER_CIRCLE")) {
+        if (userDomainModel.getRole().getValue().contains("LEADER_CIRCLE") && !userDomainModel.getRole().getValue().contains("PRESIDENT")) {
             List<CircleDomainModel> ownCircles = this.circlePort.findByLeaderId(loginUserId);
             if (ownCircles.isEmpty()) {
                 throw new InternalServerException(
@@ -130,7 +130,7 @@ public class BoardService {
                                             Role.LEADER_4_N_LEADER_CIRCLE
                                     )));
 
-                    if (creatorDomainModel.getRole().getValue().contains("LEADER_CIRCLE")) {
+                    if (creatorDomainModel.getRole().getValue().contains("LEADER_CIRCLE") && !creatorDomainModel.getRole().getValue().contains("PRESIDENT")) {
                         validatorBucket
                                 .consistOf(UserEqualValidator.of(
                                         circle.getLeader().map(UserDomainModel::getId).orElseThrow(
@@ -210,7 +210,7 @@ public class BoardService {
                                             Role.LEADER_4_N_LEADER_CIRCLE
                                     )));
 
-                    if (updaterDomainModel.getRole().getValue().contains("LEADER_CIRCLE")) {
+                    if (updaterDomainModel.getRole().getValue().contains("LEADER_CIRCLE") && !updaterDomainModel.getRole().getValue().contains("PRESIDENT")) {
                         validatorBucket
                                 .consistOf(UserEqualValidator.of(
                                         circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
@@ -297,7 +297,7 @@ public class BoardService {
                                             Role.LEADER_4_N_LEADER_CIRCLE
                                     )));
 
-                    if (deleterDomainModel.getRole().getValue().contains("LEADER_CIRCLE")) {
+                    if (deleterDomainModel.getRole().getValue().contains("LEADER_CIRCLE") && !deleterDomainModel.getRole().getValue().contains("PRESIDENT")) {
                         validatorBucket
                                 .consistOf(UserEqualValidator.of(
                                         circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(

--- a/src/main/java/net/causw/application/delegation/DelegationLeaderCircle.java
+++ b/src/main/java/net/causw/application/delegation/DelegationLeaderCircle.java
@@ -66,6 +66,8 @@ public class DelegationLeaderCircle implements Delegation {
                 )
         );
 
+        boolean isCircleLeader = circle.getLeader().map(UserDomainModel::getId).orElse("").equals(currentId);
+
         ValidatorBucket.of()
                 .consistOf(CircleMemberStatusValidator.of(
                         circleMember.getStatus(),
@@ -80,11 +82,15 @@ public class DelegationLeaderCircle implements Delegation {
                 )
         );
 
-        this.userPort.updateRole(currentId, Role.COMMON).orElseThrow(
-                () -> new InternalServerException(
-                        ErrorCode.INTERNAL_SERVER,
-                        "User id checked, but exception occurred"
-                )
-        );
+        List<CircleDomainModel> ownCircles = this.circlePort.findByLeaderId(currentId);
+        if(isCircleLeader && ownCircles.size() == 1){
+            this.userPort.removeRole(currentId, Role.LEADER_CIRCLE).orElseThrow(
+                    () -> new InternalServerException(
+                            ErrorCode.INTERNAL_SERVER,
+                            "User id checked, but exception occurred"
+                    )
+            );
+        }
+
     }
 }

--- a/src/main/java/net/causw/application/delegation/DelegationPresident.java
+++ b/src/main/java/net/causw/application/delegation/DelegationPresident.java
@@ -26,18 +26,18 @@ public class DelegationPresident implements Delegation {
         List<UserDomainModel> councilList = this.userPort.findByRole("COUNCIL");
         if (councilList != null) {
             councilList.forEach(
-                    user -> this.userPort.updateRole(user.getId(), Role.COMMON)
+                    user -> this.userPort.removeRole(user.getId(), Role.COUNCIL)
             );
         }
 
         List<UserDomainModel> vicePresident = this.userPort.findByRole("VICE_PRESIDENT");
         if (vicePresident != null) {
             vicePresident.forEach(
-                    user -> this.userPort.updateRole(user.getId(), Role.COMMON)
+                    user -> this.userPort.removeRole(user.getId(), Role.VICE_PRESIDENT)
             );
         }
 
-        this.userPort.updateRole(currentId, Role.COMMON).orElseThrow(
+        this.userPort.removeRole(currentId, Role.PRESIDENT).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
                         "User id checked, but exception occurred"

--- a/src/main/java/net/causw/application/dto/user/UserResponseDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserResponseDto.java
@@ -35,10 +35,10 @@ public class UserResponseDto {
     @ApiModelProperty(value = "상태", example = "AWAIT")
     private UserState state;
 
-    @ApiModelProperty(value = "리더일 경우, 동아리 고유 id값", example = "uuid 형식의 String 값입니다.")
+    @ApiModelProperty(value = "리더일 경우, 동아리 고유 id값", example = "['uuid 형식의 String 값입니다.', ...]")
     private List<String> circleIdIfLeader;
 
-    @ApiModelProperty(value = "리더일 경우, 동아리 이름", example = "개발 동아리")
+    @ApiModelProperty(value = "리더일 경우, 동아리 이름", example = "[개발 동아리, 퍼주마,..]")
     private List<String> circleNameIfLeader;
 
 

--- a/src/main/java/net/causw/application/post/PostService.java
+++ b/src/main/java/net/causw/application/post/PostService.java
@@ -254,7 +254,7 @@ public class PostService {
         );
 
         boardDomainModel.getCircle()
-                .filter(circleDomainModel -> !userDomainModel.getRole().equals(Role.ADMIN))
+                .filter(circleDomainModel -> !userDomainModel.getRole().equals(Role.ADMIN) && !userDomainModel.getRole().getValue().contains("PRESIDENT"))
                 .ifPresent(
                         circleDomainModel -> {
                             CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(

--- a/src/main/java/net/causw/application/spi/UserPort.java
+++ b/src/main/java/net/causw/application/spi/UserPort.java
@@ -24,6 +24,8 @@ public interface UserPort {
 
     Optional<UserDomainModel> updateRole(String id, Role role);
 
+    Optional<UserDomainModel> removeRole(String id, Role role);
+
     List<UserDomainModel> findByRole(String role);
 
     Page<UserDomainModel> findByState(UserState state, Integer pageNum);

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -208,7 +208,7 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public UserResponseDto findByUserId(String loginUserId) {
+    public UserResponseDto findCurrentUser(String loginUserId) {
         UserDomainModel requestUser = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -181,7 +181,7 @@ public class UserService {
                         )))
                 .validate();
 
-        if (requestUser.getRole().getValue().contains("LEADER_CIRCLE")) {
+        if (requestUser.getRole().getValue().contains("LEADER_CIRCLE") && !requestUser.getRole().getValue().contains("PRESIDENT")) {
             List<CircleDomainModel> ownCircles = this.circlePort.findByLeaderId(loginUserId);
             if (ownCircles.isEmpty()) {
                 throw new InternalServerException(
@@ -328,7 +328,7 @@ public class UserService {
                         )))
                 .validate();
 
-        if (user.getRole().getValue().contains("LEADER_CIRCLE")) {
+        if (user.getRole().getValue().contains("LEADER_CIRCLE") && !user.getRole().getValue().contains("PRESIDENT")) {
             List<CircleDomainModel> ownCircles = this.circlePort.findByLeaderId(loginUserId);
             if (ownCircles.isEmpty()) {
                 throw new InternalServerException(

--- a/src/main/java/net/causw/domain/validation/GrantableRoleValidator.java
+++ b/src/main/java/net/causw/domain/validation/GrantableRoleValidator.java
@@ -31,11 +31,13 @@ public class GrantableRoleValidator extends AbstractValidator {
          *   => They will automatically granted while other granting process since the roles has unique user
          */
         if (this.grantorRole == Role.ADMIN) {
-            if (this.grantedRole != Role.ADMIN
-                    && this.granteeRole != Role.ADMIN
-                    && (this.granteeRole != Role.LEADER_CIRCLE && this.granteeRole != Role.LEADER_ALUMNI)
-                    && (this.grantedRole != this.granteeRole)) {
-                return;
+            if (this.granteeRole != Role.ADMIN
+                    && (this.granteeRole != Role.LEADER_ALUMNI && this.granteeRole != Role.PROFESSOR)) {
+                if(this.grantedRole.equals(Role.LEADER_CIRCLE)){
+                    return;
+                } else if(this.granteeRole != this.grantedRole){
+                    return;
+                }
             }
         }
         /* When role of grantor is President
@@ -44,20 +46,25 @@ public class GrantableRoleValidator extends AbstractValidator {
          * Grantee role should not be Leader Circle or Leader Alumni
          *   => They will automatically granted while other granting process since the roles has unique user
          */
-        if (this.grantorRole == Role.PRESIDENT) {
+        if (this.grantorRole.getValue().contains("PRESIDENT")) {
             if (this.grantedRole != Role.ADMIN
                     && (this.granteeRole != Role.ADMIN && this.granteeRole != Role.PRESIDENT)
-                    && (this.granteeRole != Role.LEADER_CIRCLE && this.granteeRole != Role.LEADER_ALUMNI)
-                    && (this.grantedRole != this.granteeRole)) {
-                return;
+                    && (this.granteeRole != Role.LEADER_ALUMNI && this.granteeRole != Role.PROFESSOR)) {
+                if(this.grantedRole.equals(Role.LEADER_CIRCLE)){
+                    return;
+                } else if(this.granteeRole != this.grantedRole){
+                    return;
+                }
             }
         }
         /* When role of grantor is Leader_Circle
          * Granted role should be Leader_Circle, and Grantee role should be Common
          */
-        if (this.grantorRole == Role.LEADER_CIRCLE) {
-            if (this.grantedRole == Role.LEADER_CIRCLE && this.granteeRole == Role.COMMON) {
-                return;
+        if (this.grantorRole.getValue().contains("LEADER_CIRCLE")) {
+            if(this.grantedRole.equals(Role.LEADER_CIRCLE)){
+                if(this.granteeRole != Role.ADMIN && this.granteeRole != Role.LEADER_ALUMNI && this.granteeRole != Role.PROFESSOR){
+                    return;
+                }
             }
         }
         /* When role of grantor is Leader_Alumni


### PR DESCRIPTION
### 🚩 관련사항
#450 

### 📢 전달사항
동아리장과 학생회장을 겸직할시에는 관리자 권한을 가진 학생회장의 권한으로 역할을 수행할 수 있도록 조건을 추가하였습니다.
권한을 위임해줄 시에 위임자의 권한 겸직과 피위임자의 권한 겸직을 모두 고려하여 기존 updateRole 로만 수행하던 것을 removeRole을 추가로 생성하여 위임자의 권한 변경을 별도로 처리하였습니다.
또한 동아리장을 역임하는 경우도 고려하여서 해당 id로 검색되는 동아리가 한개일 경우에만 removeRole을 통해 동아리장 권한을 박탈하도록 하였습니다.(2개 이상일 시에는 해당 동아리의 동아리장 정보는 바뀌나 위임자는 타 동아리의 동아리장이므로 enum 값 leader_circle 유지)

현재 접속한 사용자 본인의 정보 조회 메서드 명이 findbyuserid로 다른 유저 정보를 조회하는 메서드와 혼동이 생길것 같아 findcurrentuser로 변경하였습니다.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [x] 권한 겸직 문제 해결


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 4일