### PR TITLE
feat: 토큰 로직 구현

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/port/mapper/DomainModelMapper.java
+++ b/src/main/java/net/causw/adapter/persistence/port/mapper/DomainModelMapper.java
@@ -42,6 +42,7 @@ public abstract class DomainModelMapper {
                 user.getAdmissionYear(),
                 user.getRole(),
                 user.getProfileImage(),
+                user.getRefreshToken(),
                 user.getState()
         );
     }

--- a/src/main/java/net/causw/adapter/persistence/port/user/UserPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/user/UserPortImpl.java
@@ -54,6 +54,11 @@ public class UserPortImpl extends DomainModelMapper implements UserPort {
     }
 
     @Override
+    public Optional<UserDomainModel> findByRefreshToken(String refreshToken) {
+        return this.userRepository.findByRefreshToken(refreshToken).map(this::entityToDomainModel);
+    }
+
+    @Override
     public UserDomainModel create(UserDomainModel userDomainModel) {
         return this.entityToDomainModel(this.userRepository.save(User.from(userDomainModel)));
     }

--- a/src/main/java/net/causw/adapter/persistence/port/user/UserPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/user/UserPortImpl.java
@@ -125,4 +125,14 @@ public class UserPortImpl extends DomainModelMapper implements UserPort {
                 }
         );
     }
+
+    @Override
+    public Optional<UserDomainModel> updateRefreshToken(String id, String refreshToken) {
+        return this.userRepository.findById(id).map(
+            srcUser -> {
+                srcUser.setRefreshToken(refreshToken);
+                return this.entityToDomainModel(this.userRepository.save(srcUser));
+            }
+        );
+    }
 }

--- a/src/main/java/net/causw/adapter/persistence/repository/UserRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/UserRepository.java
@@ -21,6 +21,8 @@ public interface UserRepository extends JpaRepository<User, String> {
 
     Optional<User> findByEmail(String email);
 
+    Optional<User> findByRefreshToken(String refreshToken);
+
     List<User> findByName(String name);
 
     List<User> findByRole(Role role);

--- a/src/main/java/net/causw/adapter/persistence/user/User.java
+++ b/src/main/java/net/causw/adapter/persistence/user/User.java
@@ -48,6 +48,9 @@ public class User extends BaseEntity {
     @Column(name = "profile_image", length = 500, nullable = true)
     private String profileImage;
 
+    @Column(name = "refresh_token", nullable = true)
+    private String refreshToken;
+
     @Column(name = "state", nullable = false)
     @Enumerated(EnumType.STRING)
     private UserState state;

--- a/src/main/java/net/causw/adapter/web/UserController.java
+++ b/src/main/java/net/causw/adapter/web/UserController.java
@@ -4,10 +4,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import net.causw.application.user.UserService;
-import net.causw.application.dto.duplicate.DuplicatedCheckResponseDto;
-import net.causw.application.dto.board.BoardResponseDto;
-import net.causw.application.dto.circle.CircleResponseDto;
 import net.causw.application.dto.user.UserAdmissionCreateRequestDto;
 import net.causw.application.dto.user.UserAdmissionResponseDto;
 import net.causw.application.dto.user.UserAdmissionsResponseDto;
@@ -17,9 +13,14 @@ import net.causw.application.dto.user.UserPostsResponseDto;
 import net.causw.application.dto.user.UserPrivilegedResponseDto;
 import net.causw.application.dto.user.UserResponseDto;
 import net.causw.application.dto.user.UserSignInRequestDto;
+import net.causw.application.dto.user.UserSignInResponseDto;
 import net.causw.application.dto.user.UserUpdatePasswordRequestDto;
 import net.causw.application.dto.user.UserUpdateRequestDto;
 import net.causw.application.dto.user.UserUpdateRoleRequestDto;
+import net.causw.application.user.UserService;
+import net.causw.application.dto.duplicate.DuplicatedCheckResponseDto;
+import net.causw.application.dto.board.BoardResponseDto;
+import net.causw.application.dto.circle.CircleResponseDto;
 import net.causw.domain.exceptions.BadRequestException;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -174,7 +175,7 @@ public class UserController {
             @ApiResponse(code = 4104, message = "대기 중인 사용자 입니다.", response = BadRequestException.class),
             @ApiResponse(code = 4109, message = "가입이 거절된 사용자 입니다.", response = BadRequestException.class)
     })
-    public String signIn(@RequestBody UserSignInRequestDto userSignInRequestDto) {
+    public UserSignInResponseDto signIn(@RequestBody UserSignInRequestDto userSignInRequestDto) {
         return this.userService.signIn(userSignInRequestDto);
     }
 

--- a/src/main/java/net/causw/adapter/web/UserController.java
+++ b/src/main/java/net/causw/adapter/web/UserController.java
@@ -17,6 +17,7 @@ import net.causw.application.dto.user.UserSignInResponseDto;
 import net.causw.application.dto.user.UserUpdatePasswordRequestDto;
 import net.causw.application.dto.user.UserUpdateRequestDto;
 import net.causw.application.dto.user.UserUpdateRoleRequestDto;
+import net.causw.application.dto.user.UserUpdateTokenRequestDto;
 import net.causw.application.user.UserService;
 import net.causw.application.dto.duplicate.DuplicatedCheckResponseDto;
 import net.causw.application.dto.board.BoardResponseDto;
@@ -166,7 +167,7 @@ public class UserController {
     @ResponseStatus(value = HttpStatus.OK)
     @ApiOperation(value = "로그인 API (완료)")
     @ApiResponses({
-            @ApiResponse(code = 200, message = "OK", response = String.class),
+            @ApiResponse(code = 200, message = "OK", response = UserSignInResponseDto.class),
             @ApiResponse(code = 4101, message = "잘못된 이메일 입니다.", response = BadRequestException.class),
             @ApiResponse(code = 4101, message = "비밀번호를 잘못 입력했습니다.", response = BadRequestException.class),
             @ApiResponse(code = 4011, message = "신청서를 작성하지 않았습니다.", response = BadRequestException.class),
@@ -413,5 +414,16 @@ public class UserController {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         String loginUserId = ((String) principal);
         return this.userService.restore(loginUserId, id);
+    }
+
+    @PutMapping(value = "/token/update")
+    @ResponseStatus(value = HttpStatus.OK)
+    @ApiOperation(value = "토큰 재발급 API", notes = "refreshToken을 넣어주세요.")
+    @ApiResponses({
+        @ApiResponse(code = 200, message = "OK", response = UserSignInResponseDto.class),
+        @ApiResponse(code = 4000, message = "로그인된 사용자를 찾을 수 없습니다.", response = BadRequestException.class)
+    })
+    public UserSignInResponseDto updateToken(@RequestBody UserUpdateTokenRequestDto userUpdateTokenRequestDto) {
+        return this.userService.updateToken(userUpdateTokenRequestDto.getRefreshToken());
     }
 }

--- a/src/main/java/net/causw/application/dto/user/UserSignInResponseDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserSignInResponseDto.java
@@ -1,0 +1,11 @@
+package net.causw.application.dto.user;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserSignInResponseDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/net/causw/application/dto/user/UserUpdateTokenRequestDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserUpdateTokenRequestDto.java
@@ -1,0 +1,8 @@
+package net.causw.application.dto.user;
+
+import lombok.Getter;
+
+@Getter
+public class UserUpdateTokenRequestDto {
+    private String refreshToken;
+}

--- a/src/main/java/net/causw/application/spi/UserPort.java
+++ b/src/main/java/net/causw/application/spi/UserPort.java
@@ -18,6 +18,8 @@ public interface UserPort {
 
     Optional<UserDomainModel> findByEmail(String email);
 
+    Optional<UserDomainModel> findByRefreshToken(String refreshToken);
+
     UserDomainModel create(UserDomainModel userDomainModel);
 
     Optional<UserDomainModel> update(String id, UserDomainModel userDomainModel);

--- a/src/main/java/net/causw/application/spi/UserPort.java
+++ b/src/main/java/net/causw/application/spi/UserPort.java
@@ -31,4 +31,6 @@ public interface UserPort {
     Optional<UserDomainModel> updatePassword(String id, String password);
 
     Optional<UserDomainModel> updateState(String id, UserState state);
+
+    Optional<UserDomainModel> updateRefreshToken(String id, String refreshToken);
 }

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -15,6 +15,7 @@ import net.causw.application.dto.user.UserPostsResponseDto;
 import net.causw.application.dto.user.UserPrivilegedResponseDto;
 import net.causw.application.dto.user.UserResponseDto;
 import net.causw.application.dto.user.UserSignInRequestDto;
+import net.causw.application.dto.user.UserSignInResponseDto;
 import net.causw.application.dto.user.UserUpdatePasswordRequestDto;
 import net.causw.application.dto.user.UserUpdateRequestDto;
 import net.causw.application.dto.user.UserUpdateRoleRequestDto;
@@ -531,7 +532,8 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public String signIn(UserSignInRequestDto userSignInRequestDto) {
+    //TODO : 기태 작업중
+    public UserSignInResponseDto signIn(UserSignInRequestDto userSignInRequestDto) {
         UserDomainModel userDomainModel = this.userPort.findByEmail(userSignInRequestDto.getEmail()).orElseThrow(
                 () -> new UnauthorizedException(
                         ErrorCode.INVALID_SIGNIN,
@@ -562,11 +564,11 @@ public class UserService {
                 .consistOf(UserStateValidator.of(userDomainModel.getState()))
                 .validate();
 
-        return this.jwtTokenProvider.createToken(
-                userDomainModel.getId(),
-                userDomainModel.getRole(),
-                userDomainModel.getState()
-        );
+        //TODO
+        return UserSignInResponseDto.builder()
+                .accessToken(jwtTokenProvider.createAccessToken(userDomainModel.getId(), userDomainModel.getRole(), userDomainModel.getState()))
+                .refreshToken(jwtTokenProvider.createRefreshToken())
+                .build();
     }
 
     /**

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -531,8 +531,7 @@ public class UserService {
         return UserResponseDto.from(this.userPort.create(userDomainModel));
     }
 
-    @Transactional(readOnly = true)
-    //TODO : 기태 작업중
+    @Transactional
     public UserSignInResponseDto signIn(UserSignInRequestDto userSignInRequestDto) {
         UserDomainModel userDomainModel = this.userPort.findByEmail(userSignInRequestDto.getEmail()).orElseThrow(
                 () -> new UnauthorizedException(
@@ -564,7 +563,10 @@ public class UserService {
                 .consistOf(UserStateValidator.of(userDomainModel.getState()))
                 .validate();
 
-        //TODO
+        // refreshToken은 user DB에 보관 (추후 redis로 옮기면 좋을듯)
+        String refreshToken = jwtTokenProvider.createRefreshToken();
+        this.userPort.updateRefreshToken(userDomainModel.getId(), refreshToken);
+
         return UserSignInResponseDto.builder()
                 .accessToken(jwtTokenProvider.createAccessToken(userDomainModel.getId(), userDomainModel.getRole(), userDomainModel.getState()))
                 .refreshToken(jwtTokenProvider.createRefreshToken())

--- a/src/main/java/net/causw/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/net/causw/config/security/JwtAuthenticationFilter.java
@@ -22,7 +22,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         String token = this.jwtTokenProvider.resolveToken((HttpServletRequest) request);
-        if (token != null && this.jwtTokenProvider.validateToken(token, (HttpServletRequest) request)) {
+        if (token != null && this.jwtTokenProvider.validateToken(token)) {
             Authentication auth = this.jwtTokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(auth);
         }

--- a/src/main/java/net/causw/config/security/JwtTokenProvider.java
+++ b/src/main/java/net/causw/config/security/JwtTokenProvider.java
@@ -65,12 +65,12 @@ public class JwtTokenProvider {
         return request.getHeader("Authorization");
     }
 
-    public boolean validateToken(String jwtToken, HttpServletRequest request) {
+    public boolean validateToken(String jwtToken) {
         try {
             Jws<Claims> claims = Jwts.parser().setSigningKey(this.secretKey).parseClaimsJws(jwtToken);
 
             if (claims.getBody().getExpiration().before(new Date())) {
-                throw new UnauthorizedException(ErrorCode.INVALID_JWT, "만료된 access 토큰입니다.");
+                throw new UnauthorizedException(ErrorCode.INVALID_JWT, "만료된 토큰입니다.");
             }
 
             if (claims.getBody().get("role").equals(Role.NONE.getValue()) ||

--- a/src/main/java/net/causw/config/security/JwtTokenProvider.java
+++ b/src/main/java/net/causw/config/security/JwtTokenProvider.java
@@ -5,7 +5,9 @@ import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.RequiredArgsConstructor;
+import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
+import net.causw.domain.exceptions.UnauthorizedException;
 import net.causw.domain.model.enums.Role;
 import net.causw.domain.model.util.StaticValue;
 import net.causw.domain.model.enums.UserState;
@@ -27,21 +29,29 @@ public class JwtTokenProvider {
     @Value("${spring.jwt.secret}")
     private String secretKey;
 
+    Date now = new Date();
+
     @PostConstruct
     protected void init() {
         this.secretKey = Base64.getEncoder().encodeToString(this.secretKey.getBytes());
     }
 
-    public String createToken(String userPk, Role role, UserState userState) {
+    public String createAccessToken(String userPk, Role role, UserState userState) {
         Claims claims = Jwts.claims().setSubject(userPk);
         claims.put("role", role.getValue());
         claims.put("state", userState.getValue());
 
-        Date now = new Date();
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + StaticValue.JWT_TOKEN_VALID_TIME))
+                .setExpiration(new Date(now.getTime() + StaticValue.JWT_ACCESS_TOKEN_VALID_TIME))
+                .signWith(SignatureAlgorithm.HS256, this.secretKey)
+                .compact();
+    }
+
+    public String createRefreshToken() {
+        return Jwts.builder()
+                .setExpiration(new Date(now.getTime() + StaticValue.JWT_REFRESH_TOKEN_VALID_TIME))
                 .signWith(SignatureAlgorithm.HS256, this.secretKey)
                 .compact();
     }
@@ -60,17 +70,15 @@ public class JwtTokenProvider {
             Jws<Claims> claims = Jwts.parser().setSigningKey(this.secretKey).parseClaimsJws(jwtToken);
 
             if (claims.getBody().getExpiration().before(new Date())) {
-                request.setAttribute("exception", ErrorCode.INVALID_JWT);
-                return false;
+                throw new UnauthorizedException(ErrorCode.INVALID_JWT, "만료된 access 토큰입니다.");
             }
 
             if (claims.getBody().get("role").equals(Role.NONE.getValue()) ||
                     !claims.getBody().get("state").equals(UserState.ACTIVE.getValue())) {
-                request.setAttribute("exception", ErrorCode.NEED_SIGN_IN);
-                return false;
+                throw new BadRequestException(ErrorCode.NEED_SIGN_IN, "다시 로그인 하세요.");
             }
-
             return true;
+
         } catch (Exception e) {
             return false;
         }

--- a/src/main/java/net/causw/config/security/WebSecurityConfig.java
+++ b/src/main/java/net/causw/config/security/WebSecurityConfig.java
@@ -65,7 +65,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                         "/api/**/users/admissions/apply",
                         "/api/**/users/**/is-duplicated",
                         "/api/**/users/email",
-                        "/api/**/users/password"
+                        "/api/**/users/password",
+                        "/api/**/users/token/update"
                 )
                 .permitAll()
                 .anyRequest().authenticated()

--- a/src/main/java/net/causw/domain/model/user/UserDomainModel.java
+++ b/src/main/java/net/causw/domain/model/user/UserDomainModel.java
@@ -15,6 +15,7 @@ public class UserDomainModel {
     private String id;
     private String studentId;
     private String profileImage;
+    private String refreshToken;
 
     @NotBlank(message = "사용자 이름이 입력되지 않았습니다.")
     private String name;
@@ -44,6 +45,7 @@ public class UserDomainModel {
             Integer admissionYear,
             Role role,
             String profileImage,
+            String refreshToken,
             UserState state
     ) {
         this.id = id;
@@ -54,6 +56,7 @@ public class UserDomainModel {
         this.admissionYear = admissionYear;
         this.role = role;
         this.profileImage = profileImage;
+        this.refreshToken = refreshToken;
         this.state = state;
     }
 
@@ -66,6 +69,7 @@ public class UserDomainModel {
             Integer admissionYear,
             Role role,
             String profileImage,
+            String refreshToken,
             UserState state
     ) {
         return new UserDomainModel(
@@ -77,6 +81,7 @@ public class UserDomainModel {
                 admissionYear,
                 role,
                 profileImage,
+                refreshToken,
                 state
         );
     }
@@ -98,6 +103,7 @@ public class UserDomainModel {
                 admissionYear,
                 Role.NONE,
                 profileImage,
+                null,
                 UserState.AWAIT
         );
     }

--- a/src/main/java/net/causw/domain/model/util/StaticValue.java
+++ b/src/main/java/net/causw/domain/model/util/StaticValue.java
@@ -17,7 +17,8 @@ public class StaticValue {
     public final static Integer USER_LIST_PAGE_SIZE = 30;
 
     // JWT Token
-    public static final Long JWT_TOKEN_VALID_TIME = 1000L * 60 * 60 * 24 * 7;
+    public static final Long JWT_ACCESS_TOKEN_VALID_TIME = 1000L * 60 * 30;    // 30min
+    public static final Long JWT_REFRESH_TOKEN_VALID_TIME = 1000L * 60 * 60 * 24 * 7;   // 7day
     public static final Integer JWT_ACCESS_THRESHOLD = 60 * 60 * 24;  // 1 day
 
     // Swagger configuration


### PR DESCRIPTION
### 📃 진행사항
- [x] 로그인 성공 시, accessToken, refreshToken 모두 반환하도록 변경
- [x] accessToken, refreshToken 유효시간 재정의
- [x] 로그인 유지를 위한 토큰 업데이트 로직 구현
- [x] 토큰 업데이트 로직에 따른 User Entity 컬럼 추가(refreshToken)