### PR TITLE
feat : 홈페이지 화면에서 조회되는 게시판 및 게시글 조건 변경 및 common API 검증 완료

### DIFF
--- a/src/main/java/net/causw/adapter/web/CommonController.java
+++ b/src/main/java/net/causw/adapter/web/CommonController.java
@@ -1,10 +1,10 @@
 package net.causw.adapter.web;
 
+import io.swagger.annotations.ApiOperation;
 import net.causw.application.common.CommonService;
 import net.causw.application.homepage.HomePageService;
 import net.causw.application.dto.homepage.HomePageResponseDto;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,8 +34,11 @@ public class CommonController {
 
     @GetMapping("/api/v1/home")
     @ResponseStatus(value = HttpStatus.OK)
-    public List<HomePageResponseDto> getHomePage(@AuthenticationPrincipal String userId) {
-        return this.homePageService.getHomePage(userId);
+    @ApiOperation(value = "홈페이지 불러오기 API(완료)", notes = "동아리에 속하지 않고 삭제되지 않은 게시판과 해당 게시판의 최신 글 3개의 정보를 반환합니다. \n 개발 db상에는 동아리에 속하지 않은 많은 더미 데이터가 있지만 실제 운영될 때는 동아리에 속하지 않는 게시판은 학생회 공지게시판 뿐입니다.")
+    public List<HomePageResponseDto> getHomePage() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String loginUserId = ((String) principal);
+        return this.homePageService.getHomePage(loginUserId);
     }
 
     /*


### PR DESCRIPTION
### 🚩 관련사항
#448 

### 📢 전달사항
common API 검증 완료하였습니다.
홈페이지에서 조회되는 게시판의 조건을 즐겨찾기한 게시판 -> 동아리에 속하지 않은 게시판으로 변경하였습니다.
운영상으로 동아리에 속하지 않는 게시판은 학생회 게시판이기 때문에 조건을 변경하였고, 추후 학년별 게시판 생성을 염두에 두었습니다.
현재는 동아리에 속하지않는 게시판 더미데이터가 많아서 홈페이지에 다양한 게시판이 출력되지만 실제로는 그렇게 되지 않습니다.
게시판과 함께 조회되는 게시글은 최근 게시글 3개입니다.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 2시간