### PR TITLE
hotfix : 권한 관리 시 학생회장 권한인 사용자 확인 가능하게 dto 변경 / 특별한 권한을 가진 사용자 확인 시 활성화 사용자만 가능하게 변경

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/port/user/UserPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/user/UserPortImpl.java
@@ -127,7 +127,7 @@ public class UserPortImpl extends DomainModelMapper implements UserPort {
 
         return Arrays.stream(Role.values())
                 .filter(enumRole -> enumRole.getValue().contains(role))
-                .flatMap(enumRole -> this.userRepository.findByRole(enumRole).stream())
+                .flatMap(enumRole -> this.userRepository.findByRoleAndState(enumRole, UserState.ACTIVE).stream())
                 .map(this::entityToDomainModel)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/net/causw/adapter/persistence/repository/UserRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/UserRepository.java
@@ -25,7 +25,7 @@ public interface UserRepository extends JpaRepository<User, String> {
 
     List<User> findByName(String name);
 
-    List<User> findByRole(Role role);
+    List<User> findByRoleAndState(Role role, UserState state);
 
     Page<User> findByStateOrderByCreatedAtAsc(UserState state, Pageable pageable);
 }

--- a/src/main/java/net/causw/application/dto/user/UserPrivilegedResponseDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserPrivilegedResponseDto.java
@@ -9,17 +9,20 @@ import java.util.List;
 @Getter
 @Setter
 public class UserPrivilegedResponseDto {
+    private UserResponseDto presidentUsers;
     private List<UserResponseDto> councilUsers;
     private List<UserResponseDto> leaderGradeUsers;
     private List<UserResponseDto> leaderCircleUsers;
     private UserResponseDto leaderAlumni;
 
     private UserPrivilegedResponseDto(
+            UserResponseDto presidentUsers,
             List<UserResponseDto> councilUsers,
             List<UserResponseDto> leaderGradeUsers,
             List<UserResponseDto> leaderCircleUsers,
             UserResponseDto leaderAlumni
     ) {
+        this.presidentUsers = presidentUsers;
         this.councilUsers = councilUsers;
         this.leaderGradeUsers = leaderGradeUsers;
         this.leaderCircleUsers = leaderCircleUsers;
@@ -27,6 +30,7 @@ public class UserPrivilegedResponseDto {
     }
 
     public static UserPrivilegedResponseDto from(
+            List<UserResponseDto> presidentUsers,
             List<UserResponseDto> councilUsers,
             List<UserResponseDto> leaderGrade1,
             List<UserResponseDto> leaderGrade2,
@@ -44,6 +48,9 @@ public class UserPrivilegedResponseDto {
         councilUsers.addAll(vicePresidentUser);
 
         return new UserPrivilegedResponseDto(
+                presidentUsers.stream()
+                        .findFirst()
+                        .orElse(null),
                 councilUsers,
                 leaderGradeUsers,
                 leaderCircleUsers,

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -378,6 +378,10 @@ public class UserService {
                 .validate();
 
         return UserPrivilegedResponseDto.from(
+                this.userPort.findByRole("PRESIDENT")
+                        .stream()
+                        .map(UserResponseDto::from)
+                        .collect(Collectors.toList()),
                 this.userPort.findByRole("COUNCIL")
                         .stream()
                         .map(UserResponseDto::from)
@@ -401,7 +405,7 @@ public class UserService {
                 this.userPort.findByRole("LEADER_CIRCLE")
                         .stream()
                         .map(userDomainModel -> {
-                            List<CircleDomainModel> ownCircles = this.circlePort.findByLeaderId(loginUserId);
+                            List<CircleDomainModel> ownCircles = this.circlePort.findByLeaderId(userDomainModel.getId());
                             if (ownCircles.isEmpty()) {
                                 throw new InternalServerException(
                                         ErrorCode.INTERNAL_SERVER,


### PR DESCRIPTION
### 🚩 관련사항


### 📢 전달사항
권한 관리 관련 오류 사항입니다.
leader_circle 역할을 가진 사용자의 동아리를 찾을 때로 변경하였고, 특별한 권한을 가진 사용자 확인 시 활성화 사용자만 가능하게 변경하였습니다.
특별한 권한을 가진 사용자 중 학생회장도 확인할 수 있도록 변경하였습니다. 

### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 