### PR TITLE
hotfix : 유저 상태별로 검색하는 과정에서 비활성 사용자의 경우 동아리를 체크하지 않도록 하였고, 테이블명을 변경하였습니다.

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/user/UserAdmission.java
+++ b/src/main/java/net/causw/adapter/persistence/user/UserAdmission.java
@@ -14,7 +14,7 @@ import javax.persistence.Table;
 @Getter
 @Entity
 @NoArgsConstructor
-@Table(name = "TB_USER_ADMISSION")
+@Table(name = "tb_user_admission")
 public class UserAdmission extends BaseEntity {
     @OneToOne
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/net/causw/adapter/persistence/user/UserAdmissionLog.java
+++ b/src/main/java/net/causw/adapter/persistence/user/UserAdmissionLog.java
@@ -14,7 +14,7 @@ import javax.persistence.Table;
 @Getter
 @Entity
 @NoArgsConstructor
-@Table(name = "TB_USER_ADMISSION_LOG")
+@Table(name = "tb_user_admission_log")
 public class UserAdmissionLog extends BaseEntity {
     @Column(name = "user_email", nullable = false)
     private String userEmail;

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -451,8 +451,8 @@ public class UserService {
 
         return this.userPort.findByState(UserState.of(state), pageNum)
                 .map(userDomainModel -> {
-                    if (userDomainModel.getRole().getValue().contains("LEADER_CIRCLE")) {
-                        List<CircleDomainModel> ownCircles = this.circlePort.findByLeaderId(loginUserId);
+                    if (userDomainModel.getRole().getValue().contains("LEADER_CIRCLE") && !state.equals("INACTIVE")) {
+                        List<CircleDomainModel> ownCircles = this.circlePort.findByLeaderId(userDomainModel.getId());
                         if (ownCircles.isEmpty()) {
                             throw new InternalServerException(
                                     ErrorCode.INTERNAL_SERVER,


### PR DESCRIPTION

### 🚩 관련사항


### 📢 전달사항
유저를 상태로 분류하여 검색하는 과정에서 sql오류가 발생하여 테이블 명을 소문자로 변경하여서 해결하였습니다. 
비활성 사용자의 경우 동아리를 확인하지 않도록 변경하였습니다.

### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 