### PR TITLE
hotfix : 게시글 조회 시 동아리에 속하지 않는 경우에 대한 예외처리, _N_조건을 위한 rolevalidator 변경, 동아리 게시판 이름 및 카테고리 규칙 수정

### DIFF
--- a/src/main/java/net/causw/application/circle/CircleService.java
+++ b/src/main/java/net/causw/application/circle/CircleService.java
@@ -320,7 +320,7 @@ public class CircleService {
 
         // Create boards of circle
         BoardDomainModel noticeBoard = BoardDomainModel.of(
-                "공지 게시판",
+                newCircle.getName() + "공지 게시판",
                 newCircle.getName() + " 공지 게시판",
                 Stream.of(Role.ADMIN, Role.PRESIDENT, Role.LEADER_CIRCLE, Role.LEADER_1_N_LEADER_CIRCLE, Role.LEADER_2_N_LEADER_CIRCLE,
                                 Role.LEADER_3_N_LEADER_CIRCLE, Role.LEADER_4_N_LEADER_CIRCLE, Role.PRESIDENT_N_LEADER_CIRCLE,

--- a/src/main/java/net/causw/application/post/PostService.java
+++ b/src/main/java/net/causw/application/post/PostService.java
@@ -191,8 +191,9 @@ public class PostService {
 
         boolean isCircleLeader = false;
         if(userDomainModel.getRole().getValue().contains("LEADER_CIRCLE")){
-            isCircleLeader = boardDomainModel.getCircle().get()
-                .getLeader().map(UserDomainModel::getId).orElse("").equals(loginUserId);
+            isCircleLeader = boardDomainModel.getCircle()
+                    .map(circle -> circle.getLeader().map(UserDomainModel::getId).orElse("").equals(loginUserId))
+                    .orElse(false);
         }
 
         if (isCircleLeader || userDomainModel.getRole().equals(Role.ADMIN) || userDomainModel.getRole().getValue().contains("PRESIDENT")) {

--- a/src/main/java/net/causw/domain/validation/UserRoleValidator.java
+++ b/src/main/java/net/causw/domain/validation/UserRoleValidator.java
@@ -30,7 +30,7 @@ public class UserRoleValidator extends AbstractValidator {
         }
 
         for (Role targetRole : this.targetRoleList) {
-            if (this.requestUserRole.equals(targetRole)) {
+            if (this.requestUserRole.getValue().contains(targetRole.getValue())) {
                 return;
             }
         }


### PR DESCRIPTION
### 🚩 관련사항

### 📢 전달사항
동아리장이 게시글을 조회할 때 해당 게시글의 게시판이 동아리에 속하지 않을 경우 필터링하는 과정에서 null 값에 대한 예외처리를 해주지 않아서 수정하였습니다.
_N_ 조건을 고려하여 rolevalidator를 수정하였습니다.
동아리 게시판이 자동 생성될 때 게시판명에 해당 동아리의 이름이 포함되도록 수정하였습니다.

### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 