### PR TITLE
hotfix : findAllBoard 로직을 수정하여서 동아리장과 일반 유저의 경우 본인이 속한 동아리의 게시판과 일반 게시판을 확인하게 수정하였습니다.

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/port/board/BoardPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/board/BoardPortImpl.java
@@ -25,16 +25,14 @@ public class BoardPortImpl extends DomainModelMapper implements BoardPort {
         return this.boardRepository.findById(id).map(this::entityToDomainModel);
     }
 
-
     @Override
     public List<BoardDomainModel> findAllBoard(List<String> circleIdList) {
-        List<Board> boardsInCircle = this.boardRepository.findByCircle_IdOrderByCreatedAtAsc(circleIdList);
-        List<Board> boardsOutsideCircle = this.boardRepository.findByCircle_IdNotInAndIsDeletedIsFalseOrderByCreatedAtAsc(circleIdList);
-
+        List<Board> boardsInCircle = this.boardRepository.findByCircle_IdInAndIsDeletedFalseOrderByCreatedAtAsc(circleIdList);
+        List<Board> boardsOutsideCircle = this.boardRepository.findByCircle_IdIsNullAndIsDeletedOrderByCreatedAtAsc(false);
 
         List<Board> allBoards = new ArrayList<>();
-        allBoards.addAll(boardsInCircle);
         allBoards.addAll(boardsOutsideCircle);
+        allBoards.addAll(boardsInCircle);
 
         return allBoards.stream()
                 .map(this::entityToDomainModel)
@@ -49,7 +47,7 @@ public class BoardPortImpl extends DomainModelMapper implements BoardPort {
     }
     @Override
     public List<BoardDomainModel> findAllBoard(boolean isDeleted) {
-        return this.boardRepository.findByIsDeletedOrderByCreatedAtAsc(isDeleted)
+        return this.boardRepository.findByCircle_IdIsNullAndIsDeletedOrderByCreatedAtAsc(isDeleted)
                 .stream()
                 .map(this::entityToDomainModel)
                 .collect(Collectors.toList());
@@ -68,13 +66,6 @@ public class BoardPortImpl extends DomainModelMapper implements BoardPort {
                 .collect(Collectors.toList());
     }
 
-    @Override
-    public List<BoardDomainModel> findBasicBoards() {
-        return this.boardRepository.findBasicBoards()
-                .stream()
-                .map(this::entityToDomainModel)
-                .collect(Collectors.toList());
-    }
 
     @Override
     public BoardDomainModel createBoard(BoardDomainModel boardDomainModel) {

--- a/src/main/java/net/causw/adapter/persistence/repository/BoardRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/BoardRepository.java
@@ -13,20 +13,11 @@ import java.util.Optional;
 public interface BoardRepository extends JpaRepository<Board, String> {
     List<Board> findByCircle_IdAndIsDeletedIsFalseOrderByCreatedAtAsc(String circleId);
 
-    @Query(value = "SELECT * FROM tb_board AS b WHERE b.circle_id IN :circleIdList ORDER BY b.created_at ASC", nativeQuery = true)
-    List<Board> findByCircle_IdOrderByCreatedAtAsc(@Param("circleIdList") List<String> circleIdList);
+    List<Board> findByCircle_IdInAndIsDeletedFalseOrderByCreatedAtAsc(List<String> circleIdList);
 
-    @Query(value = "SELECT * FROM tb_board AS b WHERE (b.circle_id NOT IN :circleIdList OR b.circle_id IS NULL) AND b.is_deleted = false ORDER BY b.created_at ASC", nativeQuery = true)
-    List<Board> findByCircle_IdNotInAndIsDeletedIsFalseOrderByCreatedAtAsc(@Param("circleIdList") List<String> circleIdList);
+    List<Board> findByCircle_IdIsNullAndIsDeletedOrderByCreatedAtAsc(boolean isDeleted);
 
     List<Board> findByOrderByCreatedAtAsc();
-    List<Board> findByIsDeletedOrderByCreatedAtAsc(boolean IsDeleted);
-
-    @Query(value = "SELECT * FROM tb_board AS b " +
-            "WHERE b.name = '앱 공지사항' " +
-            "OR b.name = '학생회 공지게시판' " +
-            "OR b.name = '전체 자유게시판'", nativeQuery = true)
-    List<Board> findBasicBoards();
 
     @Query(value = "SELECT * FROM tb_board WHERE tb_board.category = 'APP_NOTICE'", nativeQuery = true)
     Optional<Board> findAppNotice();

--- a/src/main/java/net/causw/application/board/BoardService.java
+++ b/src/main/java/net/causw/application/board/BoardService.java
@@ -4,6 +4,7 @@ import net.causw.application.dto.board.BoardCreateRequestDto;
 import net.causw.application.dto.board.BoardResponseDto;
 import net.causw.application.dto.board.BoardUpdateRequestDto;
 import net.causw.application.spi.BoardPort;
+import net.causw.application.spi.CircleMemberPort;
 import net.causw.application.spi.CirclePort;
 import net.causw.application.spi.UserPort;
 import net.causw.domain.exceptions.BadRequestException;
@@ -36,17 +37,20 @@ public class BoardService {
     private final BoardPort boardPort;
     private final UserPort userPort;
     private final CirclePort circlePort;
+    private final CircleMemberPort circleMemberPort;
     private final Validator validator;
 
     public BoardService(
             BoardPort boardPort,
             UserPort userPort,
             CirclePort circlePort,
+            CircleMemberPort circleMemberPort,
             Validator validator
     ) {
         this.boardPort = boardPort;
         this.userPort = userPort;
         this.circlePort = circlePort;
+        this.circleMemberPort = circleMemberPort;
         this.validator = validator;
     }
 
@@ -64,32 +68,29 @@ public class BoardService {
                 .consistOf(UserRoleIsNoneValidator.of(userDomainModel.getRole()))
                 .validate();
 
-        if (userDomainModel.getRole().getValue().contains("LEADER_CIRCLE") && !userDomainModel.getRole().getValue().contains("PRESIDENT")) {
-            List<CircleDomainModel> ownCircles = this.circlePort.findByLeaderId(loginUserId);
-            if (ownCircles.isEmpty()) {
-                throw new InternalServerException(
-                        ErrorCode.INTERNAL_SERVER,
-                        "해당 동아리장이 배정된 동아리가 없습니다."
-                );
-            }else{
-                List<String> circleIdList = ownCircles.stream().map(CircleDomainModel::getId).collect(Collectors.toList());
-                return this.boardPort.findAllBoard(circleIdList)
-                        .stream()
-                        .map(boardDomainModel -> BoardResponseDto.from(boardDomainModel, userDomainModel.getRole()))
-                        .collect(Collectors.toList());
-            }
-        }
-        else if(userDomainModel.getRole().equals(Role.ADMIN) || userDomainModel.getRole().getValue().contains("PRESIDENT") ){
+        if(userDomainModel.getRole().equals(Role.ADMIN) || userDomainModel.getRole().getValue().contains("PRESIDENT") ){
             return this.boardPort.findAllBoard()
                     .stream()
                     .map(boardDomainModel -> BoardResponseDto.from(boardDomainModel, userDomainModel.getRole()))
                     .collect(Collectors.toList());
         }
-        else{ //admin,president, leader_circle 제외 일반 user들
-            return this.boardPort.findAllBoard(false)
-                    .stream()
-                    .map(boardDomainModel -> BoardResponseDto.from(boardDomainModel, userDomainModel.getRole()))
-                    .collect(Collectors.toList());
+        else  {
+            List<CircleDomainModel> joinCircles = this.circleMemberPort.getCircleListByUserId(loginUserId);
+            if (joinCircles.isEmpty()) {
+                return this.boardPort.findAllBoard(false)
+                        .stream()
+                        .map(boardDomainModel -> BoardResponseDto.from(boardDomainModel, userDomainModel.getRole()))
+                        .collect(Collectors.toList());
+            }else{
+                List<String> circleIdList = joinCircles.stream()
+                        .map(CircleDomainModel::getId)
+                        .collect(Collectors.toList());
+
+                return this.boardPort.findAllBoard(circleIdList)
+                        .stream()
+                        .map(boardDomainModel -> BoardResponseDto.from(boardDomainModel, userDomainModel.getRole()))
+                        .collect(Collectors.toList());
+            }
         }
 
     }

--- a/src/main/java/net/causw/application/homepage/HomePageService.java
+++ b/src/main/java/net/causw/application/homepage/HomePageService.java
@@ -66,7 +66,6 @@ public class HomePageService {
         }
         return boardDomainModelList
                 .stream()
-                .filter(board -> board.getCircle().isEmpty())
                 .map(boardDomainModel -> HomePageResponseDto.from(
                         BoardResponseDto.from(boardDomainModel, userDomainModel.getRole()),
                         this.postPort.findAllPost(

--- a/src/main/java/net/causw/application/post/PostService.java
+++ b/src/main/java/net/causw/application/post/PostService.java
@@ -285,8 +285,9 @@ public class PostService {
 
         boolean isCircleLeader = false;
         if(userDomainModel.getRole().getValue().contains("LEADER_CIRCLE")){
-            isCircleLeader = boardDomainModel.getCircle().get()
-                    .getLeader().map(UserDomainModel::getId).orElse("").equals(loginUserId);
+            isCircleLeader = boardDomainModel.getCircle()
+                    .map(circle -> circle.getLeader().map(UserDomainModel::getId).orElse("").equals(loginUserId))
+                    .orElse(false);
         }
 
         if (isCircleLeader || userDomainModel.getRole().equals(Role.ADMIN) || userDomainModel.getRole().getValue().contains("PRESIDENT")) {

--- a/src/main/java/net/causw/application/spi/BoardPort.java
+++ b/src/main/java/net/causw/application/spi/BoardPort.java
@@ -12,12 +12,10 @@ public interface BoardPort {
     List<BoardDomainModel> findAllBoard();
     List<BoardDomainModel> findAllBoard(boolean isDeleted);
 
-
     Optional<BoardDomainModel> findAppNotice();
 
     List<BoardDomainModel> findByCircleId(String circleId);
 
-    List<BoardDomainModel> findBasicBoards();
 
     BoardDomainModel createBoard(BoardDomainModel boardDomainModel);
 


### PR DESCRIPTION
### 🚩 관련사항
#487 

### 📢 전달사항
#487 과 동일하게 isCircleLeader의 로직에 동아리가 존재하지 않을 경우의 예외처리를 추가하였습니다.
findAllBoard의 로직을 수정하여서 동아리장과 일반 유저의 경우 본인이 속한 동아리의 게시판과 일반게시판을 확인할 수 있게 변경하였습니다. 삭제된 게시판의 경우 추후 별도의 관리 페이지가 만들어졌을때 별도로 동아리장이 본인의 동아리의 것들만 관리할 수 있게 생성할 예정입니다.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 