### PR TITLE
hotfix : circle update 메서드 수정

### DIFF
--- a/src/main/java/net/causw/application/circle/CircleService.java
+++ b/src/main/java/net/causw/application/circle/CircleService.java
@@ -355,9 +355,13 @@ public class CircleService {
             );
         }
 
+        String mainImage = circleUpdateRequestDto.getMainImage();
+        if (mainImage.isEmpty()) {
+            mainImage = circle.getMainImage();
+        }
         circle.update(
                 circleUpdateRequestDto.getName(),
-                circleUpdateRequestDto.getMainImage(),
+                mainImage,
                 circleUpdateRequestDto.getDescription()
         );
 


### PR DESCRIPTION
### 🚩 관련사항
#503 


### 📢 전달사항
동아리 정보 업데이트 시 사진이 있을 경우 제대로 불러 와지지 않아 수정 페이지가 제대로 안 뜨는 문제 수정
동아리 업데이트 DTO에서 사진이 빈 칸이거나 null일 시 기존 사진 url 데이터를 그대로 유지 시키는 방식으로 수정


### 📸 스크린샷


### 📃 진행사항
- [x] Circle Service update 메서드 수정

### ⚙️ 기타사항

개발기간: 1시간