### PR TITLE
fix : refreshToken 로직 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ dependencies {
 
     // S3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 test {

--- a/src/main/java/net/causw/adapter/persistence/repository/UserRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/UserRepository.java
@@ -21,7 +21,7 @@ public interface UserRepository extends JpaRepository<User, String> {
 
     Optional<User> findByEmail(String email);
 
-    Optional<User> findByRefreshToken(String refreshToken);
+    Optional<User> findById(String id);
 
     List<User> findByName(String name);
 

--- a/src/main/java/net/causw/application/locker/LockerActionRegister.java
+++ b/src/main/java/net/causw/application/locker/LockerActionRegister.java
@@ -15,7 +15,7 @@ import net.causw.domain.model.user.UserDomainModel;
 import net.causw.domain.validation.LockerAccessValidator;
 import net.causw.domain.validation.LockerInUseValidator;
 import net.causw.domain.validation.LockerIsDeactivatedValidator;
-import net.causw.domain.validation.TimePassedValidator;
+import net.causw.domain.validation.LockerTimePassedValidator;
 import net.causw.domain.validation.ValidatorBucket;
 
 import java.time.LocalDateTime;
@@ -47,7 +47,7 @@ public class LockerActionRegister implements LockerAction {
             //이미 등록 시 하루 제한
             lockerLogPort.whenRegister(updaterDomainModel).ifPresent(
                     createdAt -> ValidatorBucket.of()
-                            .consistOf(TimePassedValidator.of(createdAt))
+                            .consistOf(LockerTimePassedValidator.of(createdAt))
                             .validate()
             );
 

--- a/src/main/java/net/causw/application/spi/UserPort.java
+++ b/src/main/java/net/causw/application/spi/UserPort.java
@@ -36,5 +36,5 @@ public interface UserPort {
 
     Optional<UserDomainModel> updateState(String id, UserState state);
 
-    Optional<UserDomainModel> updateRefreshToken(String id, String refreshToken);
+    void updateRefreshToken(String id, String refreshToken);
 }

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -512,7 +512,7 @@ public class UserService {
                 .consistOf(UserStateValidator.of(userDomainModel.getState()))
                 .validate();
 
-        // refreshToken은 user DB에 보관 (추후 redis로 옮기면 좋을듯)
+        // refreshToken은 redis에 보관
         String refreshToken = jwtTokenProvider.createRefreshToken();
         this.userPort.updateRefreshToken(userDomainModel.getId(), refreshToken);
 
@@ -1159,18 +1159,13 @@ public class UserService {
         UserDomainModel user = this.userPort.findByRefreshToken(refreshToken).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        "RefreshToken 유효성 검증 실패"
                 )
         );
-
         // STEP3 : 새로운 accessToken 제공
         String newAccessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getRole(), user.getState());
-        String newRefreshToken = jwtTokenProvider.createRefreshToken();
-        this.userPort.updateRefreshToken(user.getId(), newRefreshToken);
-
         return UserSignInResponseDto.builder()
                 .accessToken(newAccessToken)
-                .refreshToken(newRefreshToken)
                 .build();
     }
 }

--- a/src/main/java/net/causw/config/redis/RedisConfig.java
+++ b/src/main/java/net/causw/config/redis/RedisConfig.java
@@ -1,0 +1,32 @@
+package net.causw.config.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/net/causw/domain/model/util/RedisUtils.java
+++ b/src/main/java/net/causw/domain/model/util/RedisUtils.java
@@ -1,0 +1,28 @@
+package net.causw.domain.model.util;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class RedisUtils {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public RedisUtils(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void setData(String key, String value,Long expiredTime){
+        redisTemplate.opsForValue().set(key, value, expiredTime, TimeUnit.MILLISECONDS);
+    }
+
+    public String getData(String key){
+        return (String) redisTemplate.opsForValue().get(key);
+    }
+
+    public void deleteData(String key){
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/net/causw/domain/validation/LockerTimePassedValidator.java
+++ b/src/main/java/net/causw/domain/validation/LockerTimePassedValidator.java
@@ -7,15 +7,15 @@ import net.causw.domain.model.util.StaticValue;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
-public class TimePassedValidator extends AbstractValidator {
+public class LockerTimePassedValidator extends AbstractValidator {
     private final LocalDateTime updatedAt;
 
-    private TimePassedValidator(LocalDateTime updatedAt) {
+    private LockerTimePassedValidator(LocalDateTime updatedAt) {
         this.updatedAt = updatedAt;
     }
 
-    public static TimePassedValidator of(LocalDateTime updatedAt) {
-        return new TimePassedValidator(updatedAt);
+    public static LockerTimePassedValidator of(LocalDateTime updatedAt) {
+        return new LockerTimePassedValidator(updatedAt);
     }
 
     @Override
@@ -26,7 +26,8 @@ public class TimePassedValidator extends AbstractValidator {
             LocalDateTime allowedTime = this.updatedAt.plusSeconds(StaticValue.JWT_ACCESS_THRESHOLD);
 
             String message =
-                            allowedTime.getYear() + "-" +
+                    "24시간 이내에 사물함 신청 내역이 있습니다." +
+                    allowedTime.getYear() + "-" +
                             allowedTime.getMonthValue() + "-" +
                             allowedTime.getDayOfMonth() + " " +
                             allowedTime.getHour() + ":" +


### PR DESCRIPTION
### 🚩 관련사항
#502 


### 📢 전달사항
refreshToken을 DB에 저장하는 방식에서 Redis를 도입하여 Redis에 저장하는 방식으로 바꿨습니다.
아직 User Entity에 있는 RefreshToken 변수와 DB의 RefreshToken column은 지우지 않았습니다. 
서비스가 안정되면 그 때 지우도록 하겠습니다.
application.yml 노션에 업데이트 하겠습니다. (redis 관련 변수)


### 📃 진행사항
- [ ] Redis 도입
- [ ] RefreshToken Redis에 저장
- [ ] 사물함 신청 제한 메시지 변경


### ⚙️ 기타사항
개발기간: 6시간