### PR TITLE
hotfix : 유저 관리에서 탈퇴 유저와 추방유저를 모두 복구 가능하도록 변경

### DIFF
--- a/src/main/java/net/causw/application/circle/CircleService.java
+++ b/src/main/java/net/causw/application/circle/CircleService.java
@@ -310,7 +310,7 @@ public class CircleService {
                 Stream.of(Role.ADMIN, Role.PRESIDENT, Role.VICE_PRESIDENT, Role.LEADER_CIRCLE)
                         .map(Role::getValue)
                         .collect(Collectors.toList()),
-                "공지 게시판",
+                "동아리 공지 게시판",
                 newCircle
         );
         this.boardPort.createBoard(noticeBoard);

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -42,7 +42,7 @@ import net.causw.domain.validation.TargetIsDeletedValidator;
 import net.causw.domain.validation.UserRoleIsNoneValidator;
 import net.causw.domain.validation.UserRoleValidator;
 import net.causw.domain.validation.UserRoleWithoutAdminValidator;
-import net.causw.domain.validation.UserStateIsDropValidator;
+import net.causw.domain.validation.UserStateIsDropOrIsInActiveValidator;
 import net.causw.domain.validation.UserStateIsNotDropAndActiveValidator;
 import net.causw.domain.validation.UserStateValidator;
 import net.causw.domain.validation.ValidatorBucket;
@@ -1148,7 +1148,7 @@ public class UserService {
 
         ValidatorBucket.of()
                 .consistOf(UserRoleValidator.of(requestUser.getRole(), List.of()))
-                .consistOf(UserStateIsDropValidator.of(restoredUser.getState()))
+                .consistOf(UserStateIsDropOrIsInActiveValidator.of(restoredUser.getState()))
                 .validate();
 
         this.userPort.updateRole(restoredUser.getId(), Role.COMMON).orElseThrow(

--- a/src/main/java/net/causw/domain/validation/UserStateIsDropOrIsInActiveValidator.java
+++ b/src/main/java/net/causw/domain/validation/UserStateIsDropOrIsInActiveValidator.java
@@ -1,0 +1,27 @@
+package net.causw.domain.validation;
+
+import net.causw.domain.exceptions.ErrorCode;
+import net.causw.domain.exceptions.UnauthorizedException;
+import net.causw.domain.model.enums.UserState;
+
+public class UserStateIsDropOrIsInActiveValidator extends AbstractValidator {
+    private final UserState userState;
+
+    private UserStateIsDropOrIsInActiveValidator(UserState userState) {
+        this.userState = userState;
+    }
+
+    public static UserStateIsDropOrIsInActiveValidator of(UserState userState) {
+        return new UserStateIsDropOrIsInActiveValidator(userState);
+    }
+
+    @Override
+    public void validate() {
+        if (!(this.userState.equals(UserState.DROP) || this.userState.equals(UserState.INACTIVE))) {
+            throw new UnauthorizedException(
+                    ErrorCode.BLOCKED_USER,
+                    "등록된 사용자가 아닙니다."
+            );
+        }
+    }
+}


### PR DESCRIPTION
### 🚩 관련사항
관련된 이슈번호 혹은 pr번호를 기록합니다.


### 📢 전달사항
유저 관리 시 추방과 탈퇴 유저를 모두 복구 가능하도록 validator를 생성하였습니다.
동아리 공지게시판이 생성될 때 별도로 카테고리를 분리하기 위해서 '동아리 공지 게시판'으로 변경하였습니다.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 