### PR TITLE
hotfix : 추방 및 탈퇴 유저를 관리할 때 이름이 들어가지 않을 경우 오류가 발생하는 현상을 수정하였습니다.

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/port/user/UserPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/user/UserPortImpl.java
@@ -155,7 +155,7 @@ public class UserPortImpl extends DomainModelMapper implements UserPort {
     public Page<UserDomainModel> findByStateAndName(String state, String name, Integer pageNum) {
 
         if(state.equals("INACTIVE_N_DROP")){
-            List<UserState> statesToSearch = Arrays.asList(UserState.INACTIVE, UserState.DROP);
+            List<String> statesToSearch = Arrays.asList("INACTIVE", "DROP");
             return this.userRepository.findByStateInAndNameContaining(
                     statesToSearch,
                     name,

--- a/src/main/java/net/causw/adapter/persistence/repository/UserRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/UserRepository.java
@@ -32,7 +32,10 @@ public interface UserRepository extends JpaRepository<User, String> {
             "WHERE u.state = :state AND (:name IS NULL OR u.name LIKE %:name%) ORDER BY u.created_at DESC" , nativeQuery = true)
     Page<User> findByStateAndName(@Param("state") String state, @Param("name") String name, Pageable pageable);
 
-    Page<User> findByStateInAndNameContaining(List<UserState> states, String name, Pageable pageable);
+    @Query(value = "SELECT * "  +
+            "FROM tb_user AS u " +
+            "WHERE u.state IN :state AND (COALESCE(:name, '') = '' OR u.name LIKE CONCAT('%', :name, '%')) ORDER BY u.created_at DESC" , nativeQuery = true)
+    Page<User> findByStateInAndNameContaining(@Param("state")List<String> states, @Param("name")String name, Pageable pageable);
 }
 
 


### PR DESCRIPTION
### 🚩 관련사항
#529 


### 📢 전달사항
여러개의 상태를 한번에 반환하게 쿼리를 짜는 과정에서 name이 들어가지 않을 경우 오류가 발생했습니다.
기존 jpa 자동생성 쿼리로 수정하려고 하였으나 findbystateandname의 native 쿼리를 수정하여서 적용하여 에러를 수정하였습니다.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.
개발기간: 20분