### PR TITLE
Refactor: 하드코딩된 문자열 제거

### DIFF
--- a/src/main/java/net/causw/application/board/BoardService.java
+++ b/src/main/java/net/causw/application/board/BoardService.java
@@ -167,7 +167,7 @@ public class BoardService {
         BoardDomainModel boardDomainModel = this.boardPort.findById(boardId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "수정할 게시판을 찾을 수 없습니다."
+                        MessageUtil.BOARD_NOT_FOUND
                 )
         );
 
@@ -215,7 +215,7 @@ public class BoardService {
                 this.boardPort.updateBoard(boardId, boardDomainModel).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                MessageUtil.exceptionOccur("Board")
+                                MessageUtil.INTERNAL_SERVER_ERROR
                         )
                 ),
                 updaterDomainModel.getRole()
@@ -239,7 +239,7 @@ public class BoardService {
         BoardDomainModel boardDomainModel = this.boardPort.findById(boardId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "삭제할 게시판을 찾을 수 없습니다."
+                        MessageUtil.BOARD_NOT_FOUND
                 )
         );
 
@@ -287,7 +287,7 @@ public class BoardService {
                 this.boardPort.deleteBoard(boardId).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                MessageUtil.exceptionOccur("Board")
+                                MessageUtil.INTERNAL_SERVER_ERROR
                         )
                 ),
                 deleterDomainModel.getRole()
@@ -311,7 +311,7 @@ public class BoardService {
         BoardDomainModel boardDomainModel = this.boardPort.findById(boardId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "복구할 게시판을 찾을 수 없습니다."
+                        MessageUtil.BOARD_NOT_FOUND
                 )
         );
 
@@ -359,7 +359,7 @@ public class BoardService {
                 this.boardPort.restoreBoard(boardId).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                MessageUtil.exceptionOccur("Board")
+                                MessageUtil.INTERNAL_SERVER_ERROR
                         )
                 ),
                 restorerDomainModel.getRole()

--- a/src/main/java/net/causw/application/board/BoardService.java
+++ b/src/main/java/net/causw/application/board/BoardService.java
@@ -101,7 +101,7 @@ public class BoardService {
                     CircleDomainModel circle = this.circlePort.findById(circleId).orElseThrow(
                             () -> new BadRequestException(
                                     ErrorCode.ROW_DOES_NOT_EXIST,
-                                    MessageUtil.CIRCLE_NOT_FOUND
+                                    MessageUtil.SMALL_CLUB_NOT_FOUND
                             )
                     );
 
@@ -167,7 +167,7 @@ public class BoardService {
         BoardDomainModel boardDomainModel = this.boardPort.findById(boardId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.UPDATE_BOARD_NOT_FOUND
+                        "수정할 게시판을 찾을 수 없습니다."
                 )
         );
 
@@ -239,7 +239,7 @@ public class BoardService {
         BoardDomainModel boardDomainModel = this.boardPort.findById(boardId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.DELETE_BOARD_NOT_FOUND
+                        "삭제할 게시판을 찾을 수 없습니다."
                 )
         );
 
@@ -311,7 +311,7 @@ public class BoardService {
         BoardDomainModel boardDomainModel = this.boardPort.findById(boardId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.RESTORE_BOARD_NOT_FOUND
+                        "복구할 게시판을 찾을 수 없습니다."
                 )
         );
 

--- a/src/main/java/net/causw/application/circle/CircleService.java
+++ b/src/main/java/net/causw/application/circle/CircleService.java
@@ -220,7 +220,7 @@ public class CircleService {
         UserDomainModel circleLeader = circle.getLeader().orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "해당 동아리의 동아리장을 찾을 수 없습니다."
+                        MessageUtil.CIRCLE_LEADER_NOR_FOUND
                 )
         );
 
@@ -239,7 +239,7 @@ public class CircleService {
                     UserDomainModel member = this.userPort.findById(circleMember.getUserId()).orElseThrow(
                             () -> new BadRequestException(
                                     ErrorCode.ROW_DOES_NOT_EXIST,
-                                    "소모임원을 찾을 수 없습니다."
+                                    MessageUtil.CIRCLE_MEMBER_NOT_FOUND
                             )
                     );
 
@@ -260,7 +260,7 @@ public class CircleService {
         UserDomainModel leader = this.userPort.findById(circleCreateRequestDto.getLeaderId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "등록할 소모임장을 다시 확인해주세요."
+                        MessageUtil.USER_NOT_FOUND
                 )
         );
 
@@ -297,7 +297,7 @@ public class CircleService {
         leader = this.userPort.updateRole(circleCreateRequestDto.getLeaderId(), Role.LEADER_CIRCLE).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.INTERNAL_SERVER,
-                        "Leader id checked, but exception occurred"
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         );
 
@@ -322,7 +322,7 @@ public class CircleService {
         this.circleMemberPort.updateStatus(circleMemberDomainModel.getId(), CircleMemberStatus.MEMBER).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "Circle id immediately can be used, but exception occurred"
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         );
 
@@ -340,7 +340,7 @@ public class CircleService {
         CircleDomainModel circle = this.circlePort.findById(circleId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "수정할 소모임을 찾을 수 없습니다."
+                        MessageUtil.SMALL_CLUB_NOT_FOUND
                 )
         );
 
@@ -388,7 +388,7 @@ public class CircleService {
                             circle.getLeader().map(UserDomainModel::getId).orElseThrow(
                                     () -> new InternalServerException(
                                             ErrorCode.INTERNAL_SERVER,
-                                            "This circle has not circle leader"
+                                            MessageUtil.CIRCLE_WITHOUT_LEADER
                                     )
                             ),
                             userId
@@ -401,7 +401,7 @@ public class CircleService {
         return CircleResponseDto.from(this.circlePort.update(circleId, circle).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "Circle id checked, but exception occurred"
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         ));
     }
@@ -416,7 +416,7 @@ public class CircleService {
         CircleDomainModel circle = this.circlePort.findById(circleId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "삭제할 소모임을 찾을 수 없습니다."
+                        MessageUtil.SMALL_CLUB_NOT_FOUND
                 )
         );
 
@@ -442,7 +442,7 @@ public class CircleService {
                             circle.getLeader().map(UserDomainModel::getId).orElseThrow(
                                     () -> new InternalServerException(
                                             ErrorCode.INTERNAL_SERVER,
-                                            "This circle has not circle leader"
+                                            MessageUtil.CIRCLE_WITHOUT_LEADER
                                     )
                             ),
                             user.getId()
@@ -465,14 +465,14 @@ public class CircleService {
             this.userPort.removeRole(leaderId, Role.LEADER_CIRCLE).orElseThrow(
                     () -> new InternalServerException(
                             ErrorCode.INTERNAL_SERVER,
-                            "Leader id checked, but exception occurred"
+                            MessageUtil.INTERNAL_SERVER_ERROR
                     )
             );
         }
         CircleResponseDto circleResponseDto = CircleResponseDto.from(this.circlePort.delete(circleId).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "Circle id checked, but exception occurred"
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         ));
         boardPort.deleteAllCircleBoard(circleId);
@@ -484,7 +484,7 @@ public class CircleService {
         CircleDomainModel circle = this.circlePort.findById(circleId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "신청할 소모임을 찾을 수 없습니다."
+                        MessageUtil.SMALL_CLUB_NOT_FOUND
                 )
         );
 
@@ -516,7 +516,7 @@ public class CircleService {
                             return this.circleMemberPort.updateStatus(circleMember.getId(), CircleMemberStatus.AWAIT).orElseThrow(
                                     () -> new InternalServerException(
                                             ErrorCode.INTERNAL_SERVER,
-                                            "Application id checked, but exception occurred"
+                                            MessageUtil.INTERNAL_SERVER_ERROR
                                     )
                             );
                         })
@@ -541,14 +541,14 @@ public class CircleService {
         CircleDomainModel circle = this.circlePort.findById(circleId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "탈퇴할 소모임을 찾을 수 없습니다."
+                        MessageUtil.SMALL_CLUB_NOT_FOUND
                 )
         );
 
         CircleMemberDomainModel circleMember = this.circleMemberPort.findByUserIdAndCircleId(user.getId(), circle.getId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "가입 신청한 소모임이 아닙니다."
+                        MessageUtil.CIRCLE_APPLY_INVALID
                 )
         );
 
@@ -564,7 +564,7 @@ public class CircleService {
                         circle.getLeader().map(UserDomainModel::getId).orElseThrow(
                                 () -> new InternalServerException(
                                         ErrorCode.INTERNAL_SERVER,
-                                        "This circle has not circle leader"
+                                        MessageUtil.CIRCLE_WITHOUT_LEADER
                                 )
                         ),
                         userId))
@@ -573,7 +573,7 @@ public class CircleService {
         return CircleMemberResponseDto.from(user, this.circleMemberPort.updateStatus(circleMember.getId(), CircleMemberStatus.LEAVE).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "Application id checked, but exception occurred"
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         ));
     }
@@ -596,7 +596,7 @@ public class CircleService {
         UserDomainModel user = this.userPort.findById(userId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "추방할 사용자를 찾을 수 없습니다."
+                        MessageUtil.USER_NOT_FOUND
                 )
         );
 
@@ -610,7 +610,7 @@ public class CircleService {
         CircleMemberDomainModel circleMember = this.circleMemberPort.findByUserIdAndCircleId(userId, circleId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "추방시킬 사용자가 가입 신청한 소모임이 아닙니다."
+                        MessageUtil.CIRCLE_APPLY_INVALID
                 )
         );
 
@@ -627,7 +627,7 @@ public class CircleService {
                             circle.getLeader().map(UserDomainModel::getId).orElseThrow(
                                     () -> new InternalServerException(
                                             ErrorCode.INTERNAL_SERVER,
-                                            "This circle has not circle leader"
+                                            MessageUtil.CIRCLE_WITHOUT_LEADER
                                     )
                             ),
                             requestUserId
@@ -643,7 +643,7 @@ public class CircleService {
                         circle.getLeader().map(UserDomainModel::getId).orElseThrow(
                                 () -> new InternalServerException(
                                         ErrorCode.INTERNAL_SERVER,
-                                        "This circle has not circle leader"
+                                        MessageUtil.CIRCLE_WITHOUT_LEADER
                                 )
                         ),
                         userId))
@@ -652,7 +652,7 @@ public class CircleService {
         return CircleMemberResponseDto.from(user, this.circleMemberPort.updateStatus(circleMember.getId(), CircleMemberStatus.DROP).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "Application id checked, but exception occurred"
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         ));
     }
@@ -692,14 +692,14 @@ public class CircleService {
         CircleMemberDomainModel circleMember = this.circleMemberPort.findById(applicationId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "소모임 가입 신청을 찾을 수 없습니다."
+                        MessageUtil.USER_APPLY_NOT_FOUND
                 )
         );
 
         UserDomainModel user = this.userPort.findById(circleMember.getUserId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "가입 요청한 사용자를 찾을 수 없습니다."
+                        MessageUtil.USER_NOT_FOUND
                 )
         );
 
@@ -716,7 +716,7 @@ public class CircleService {
                             circleMember.getCircle().getLeader().map(UserDomainModel::getId).orElseThrow(
                                     () -> new InternalServerException(
                                             ErrorCode.INTERNAL_SERVER,
-                                            "This circle has not circle leader"
+                                            MessageUtil.CIRCLE_WITHOUT_LEADER
                                     )
                             ),
                             requestUserId));
@@ -732,7 +732,7 @@ public class CircleService {
         return CircleMemberResponseDto.from(user, this.circleMemberPort.updateStatus(applicationId, targetStatus).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "Application id checked, but exception occurred"
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         ));
     }
@@ -750,21 +750,21 @@ public class CircleService {
         UserDomainModel targetUser = this.userPort.findById(targetUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "추방된 사용자를 찾을 수 없습니다."
+                        MessageUtil.USER_NOT_FOUND
                 )
         );
 
         CircleDomainModel circle = this.circlePort.findById(circleId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "소모임을 찾을 수 없습니다."
+                        MessageUtil.SMALL_CLUB_NOT_FOUND
                 )
         );
 
         CircleMemberDomainModel restoreTargetMember = this.circleMemberPort.findByUserIdAndCircleId(targetUserId, circleId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "추방시킬 사용자가 가입 신청한 소모임이 아닙니다."
+                        MessageUtil.CIRCLE_APPLY_INVALID
                 )
         );
 
@@ -777,7 +777,7 @@ public class CircleService {
                 .consistOf(UserEqualValidator.of(loginUserId,circle.getLeader().map(UserDomainModel::getId).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                "The board has circle without circle leader"
+                                MessageUtil.CIRCLE_WITHOUT_LEADER
                         )
                 )));
         validatorBucket
@@ -789,7 +789,7 @@ public class CircleService {
         return CircleMemberResponseDto.from(targetUser, this.circleMemberPort.updateStatus(restoreTargetMember.getId(), CircleMemberStatus.MEMBER).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "Application id checked, but exception occurred"
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         ));
     }

--- a/src/main/java/net/causw/application/circle/CircleService.java
+++ b/src/main/java/net/causw/application/circle/CircleService.java
@@ -23,6 +23,7 @@ import net.causw.domain.model.circle.CircleDomainModel;
 import net.causw.domain.model.circle.CircleMemberDomainModel;
 import net.causw.domain.model.enums.CircleMemberStatus;
 import net.causw.domain.model.enums.Role;
+import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
 import net.causw.domain.model.user.UserDomainModel;
 import net.causw.domain.validation.CircleMemberStatusValidator;
@@ -63,7 +64,7 @@ public class CircleService {
         CircleDomainModel circle = this.circlePort.findById(circleId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "소모임을 찾을 수 없습니다."
+                        MessageUtil.SMALL_CLUB_NOT_FOUND
                 )
         );
 
@@ -82,7 +83,7 @@ public class CircleService {
         UserDomainModel userDomainModel = this.userPort.findById(currentUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -127,14 +128,14 @@ public class CircleService {
         CircleDomainModel circleDomainModel = this.circlePort.findById(circleId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "소모임을 찾을 수 없습니다."
+                        MessageUtil.SMALL_CLUB_NOT_FOUND
                 )
         );
 
         UserDomainModel userDomainModel = this.userPort.findById(currentUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -148,7 +149,7 @@ public class CircleService {
             CircleMemberDomainModel circleMember = this.circleMemberPort.findByUserIdAndCircleId(currentUserId, circleDomainModel.getId()).orElseThrow(
                     () -> new BadRequestException(
                             ErrorCode.NOT_MEMBER,
-                            "로그인된 사용자가 가입 신청한 소모임이 아닙니다."
+                            MessageUtil.CIRCLE_APPLY_INVALID
                     )
             );
 
@@ -189,7 +190,7 @@ public class CircleService {
         this.circlePort.findById(id).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "소모임을 찾을 수 없습니다."
+                        MessageUtil.SMALL_CLUB_NOT_FOUND
                 )
         );
 
@@ -205,14 +206,14 @@ public class CircleService {
         UserDomainModel user = this.userPort.findById(currentUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         CircleDomainModel circle = this.circlePort.findById(circleId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "소모임을 찾을 수 없습니다."
+                        MessageUtil.SMALL_CLUB_NOT_FOUND
                 )
         );
 
@@ -252,7 +253,7 @@ public class CircleService {
         UserDomainModel requestUser = this.userPort.findById(userId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -277,7 +278,7 @@ public class CircleService {
                 name -> {
                     throw new BadRequestException(
                             ErrorCode.ROW_ALREADY_EXIST,
-                            "중복된 소모임 이름입니다."
+                            MessageUtil.CIRCLE_DUPLICATE_NAME
                     );
                 }
         );
@@ -346,7 +347,7 @@ public class CircleService {
         UserDomainModel user = this.userPort.findById(userId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -355,7 +356,7 @@ public class CircleService {
                     name -> {
                         throw new BadRequestException(
                                 ErrorCode.ROW_ALREADY_EXIST,
-                                "중복된 소모임 이름입니다."
+                                MessageUtil.CIRCLE_DUPLICATE_NAME
                         );
                     }
             );
@@ -422,7 +423,7 @@ public class CircleService {
         UserDomainModel user = this.userPort.findById(requestUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -490,7 +491,7 @@ public class CircleService {
         UserDomainModel user = this.userPort.findById(userId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -533,7 +534,7 @@ public class CircleService {
         UserDomainModel user = this.userPort.findById(userId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -588,7 +589,7 @@ public class CircleService {
         UserDomainModel requestUser = this.userPort.findById(requestUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -602,7 +603,7 @@ public class CircleService {
         CircleDomainModel circle = this.circlePort.findById(circleId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "소모임을 찾을 수 없습니다."
+                       MessageUtil.SMALL_CLUB_NOT_FOUND
                 )
         );
 
@@ -684,7 +685,7 @@ public class CircleService {
         UserDomainModel requestUser = this.userPort.findById(requestUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -743,7 +744,7 @@ public class CircleService {
         UserDomainModel loginUser = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
         UserDomainModel targetUser = this.userPort.findById(targetUserId).orElseThrow(

--- a/src/main/java/net/causw/application/comment/ChildCommentService.java
+++ b/src/main/java/net/causw/application/comment/ChildCommentService.java
@@ -69,7 +69,7 @@ public class ChildCommentService {
                 refChildCommentId -> this.childCommentPort.findById(refChildCommentId).orElseThrow(
                         () -> new BadRequestException(
                                 ErrorCode.ROW_DOES_NOT_EXIST,
-                                "답할 답글을 찾을 수 없습니다."
+                                MessageUtil.COMMENT_NOT_FOUND
                         )
                 )
         );
@@ -77,7 +77,7 @@ public class ChildCommentService {
         CommentDomainModel parentCommentDomainModel = this.commentPort.findById(childCommentCreateRequestDto.getParentCommentId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "상위 댓글을 찾을 수 없습니다."
+                        MessageUtil.COMMENT_NOT_FOUND
                 )
         );
 
@@ -155,7 +155,7 @@ public class ChildCommentService {
         CommentDomainModel parentCommentDomainModel = this.commentPort.findById(parentCommentId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "상위 댓글을 찾을 수 없습니다."
+                        MessageUtil.COMMENT_NOT_FOUND
                 )
         );
 
@@ -234,7 +234,7 @@ public class ChildCommentService {
         ChildCommentDomainModel childCommentDomainModel = this.childCommentPort.findById(childCommentId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "수정할 답글을 찾을 수 없습니다."
+                        MessageUtil.COMMENT_NOT_FOUND
                 )
         );
 
@@ -293,7 +293,7 @@ public class ChildCommentService {
                 this.childCommentPort.update(childCommentId, childCommentDomainModel).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                MessageUtil.exceptionOccur("Comment")
+                                MessageUtil.INTERNAL_SERVER_ERROR
                         )
                 ),
                 updater,
@@ -315,7 +315,7 @@ public class ChildCommentService {
         ChildCommentDomainModel childCommentDomainModel = this.childCommentPort.findById(childCommentId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "삭제할 답글을 찾을 수 없습니다."
+                        MessageUtil.COMMENT_NOT_FOUND
                 )
         );
 
@@ -388,7 +388,7 @@ public class ChildCommentService {
                 this.childCommentPort.delete(childCommentId).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                MessageUtil.exceptionOccur("Comment")
+                                MessageUtil.INTERNAL_SERVER_ERROR
                         )
                 ),
                 deleterDomainModel,

--- a/src/main/java/net/causw/application/comment/ChildCommentService.java
+++ b/src/main/java/net/causw/application/comment/ChildCommentService.java
@@ -21,6 +21,7 @@ import net.causw.domain.model.enums.CircleMemberStatus;
 import net.causw.domain.model.comment.CommentDomainModel;
 import net.causw.domain.model.post.PostDomainModel;
 import net.causw.domain.model.enums.Role;
+import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
 import net.causw.domain.model.user.UserDomainModel;
 import net.causw.domain.validation.CircleMemberStatusValidator;
@@ -56,7 +57,7 @@ public class ChildCommentService {
         UserDomainModel creatorDomainModel = this.userPort.findById(creatorId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -83,7 +84,7 @@ public class ChildCommentService {
         PostDomainModel postDomainModel = this.postPort.findPostById(parentCommentDomainModel.getPostId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "게시글을 찾을 수 없습니다."
+                        MessageUtil.POST_NOT_FOUND
                 )
         );
 
@@ -117,7 +118,7 @@ public class ChildCommentService {
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
-                                            "로그인된 사용자가 가입 신청한 소모임이 아닙니다."
+                                            MessageUtil.CIRCLE_APPLY_INVALID
                                     )
                             );
 
@@ -147,7 +148,7 @@ public class ChildCommentService {
         UserDomainModel userDomainModel = this.userPort.findById(userId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -161,7 +162,7 @@ public class ChildCommentService {
         PostDomainModel postDomainModel = this.postPort.findPostById(parentCommentDomainModel.getPostId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "게시글을 찾을 수 없습니다."
+                        MessageUtil.POST_NOT_FOUND
                 )
         );
 
@@ -181,7 +182,7 @@ public class ChildCommentService {
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
-                                            "로그인된 사용자가 가입 신청한 소모임이 아닙니다."
+                                            MessageUtil.CIRCLE_APPLY_INVALID
                                     )
                             );
 
@@ -226,7 +227,7 @@ public class ChildCommentService {
         UserDomainModel updater = this.userPort.findById(updaterId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -240,7 +241,7 @@ public class ChildCommentService {
         PostDomainModel postDomainModel = this.postPort.findPostById(childCommentDomainModel.getParentComment().getPostId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "게시글을 찾을 수 없습니다."
+                        MessageUtil.POST_NOT_FOUND
                 )
         );
 
@@ -272,7 +273,7 @@ public class ChildCommentService {
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
-                                            "사용자가 가입 신청한 소모임이 아닙니다."
+                                            MessageUtil.CIRCLE_APPLY_INVALID
                                     )
                             );
 
@@ -292,7 +293,7 @@ public class ChildCommentService {
                 this.childCommentPort.update(childCommentId, childCommentDomainModel).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                "Comment id checked, but exception occurred"
+                                MessageUtil.exceptionOccur("Comment")
                         )
                 ),
                 updater,
@@ -307,7 +308,7 @@ public class ChildCommentService {
         UserDomainModel deleterDomainModel = this.userPort.findById(deleterId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -321,7 +322,7 @@ public class ChildCommentService {
         PostDomainModel postDomainModel = this.postPort.findPostById(childCommentDomainModel.getParentComment().getPostId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "게시글을 찾을 수 없습니다."
+                        MessageUtil.POST_NOT_FOUND
                 )
         );
 
@@ -340,7 +341,7 @@ public class ChildCommentService {
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
-                                            "로그인된 사용자가 가입 신청한 소모임이 아닙니다."
+                                            MessageUtil.CIRCLE_APPLY_INVALID
                                     )
                             );
 
@@ -363,7 +364,7 @@ public class ChildCommentService {
                                                 circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
                                                         () -> new InternalServerException(
                                                                 ErrorCode.INTERNAL_SERVER,
-                                                                "The board has circle without circle leader"
+                                                                MessageUtil.CIRCLE_WITHOUT_LEADER
                                                         )
                                                 ),
                                                 deleterId
@@ -387,7 +388,7 @@ public class ChildCommentService {
                 this.childCommentPort.delete(childCommentId).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                "Comment id checked, but exception occurred"
+                                MessageUtil.exceptionOccur("Comment")
                         )
                 ),
                 deleterDomainModel,

--- a/src/main/java/net/causw/application/comment/ChildCommentService.java
+++ b/src/main/java/net/causw/application/comment/ChildCommentService.java
@@ -19,6 +19,7 @@ import net.causw.domain.model.enums.CircleMemberStatus;
 import net.causw.domain.model.comment.CommentDomainModel;
 import net.causw.domain.model.post.PostDomainModel;
 import net.causw.domain.model.enums.Role;
+import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
 import net.causw.domain.model.user.UserDomainModel;
 import net.causw.domain.validation.CircleMemberStatusValidator;
@@ -54,7 +55,7 @@ public class ChildCommentService {
         UserDomainModel creatorDomainModel = this.userPort.findById(creatorId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -66,7 +67,7 @@ public class ChildCommentService {
                 refChildCommentId -> this.childCommentPort.findById(refChildCommentId).orElseThrow(
                         () -> new BadRequestException(
                                 ErrorCode.ROW_DOES_NOT_EXIST,
-                                "답할 답글을 찾을 수 없습니다."
+                                MessageUtil.COMMENT_NOT_FOUND
                         )
                 )
         );
@@ -74,14 +75,14 @@ public class ChildCommentService {
         CommentDomainModel parentCommentDomainModel = this.commentPort.findById(childCommentCreateRequestDto.getParentCommentId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "상위 댓글을 찾을 수 없습니다."
+                        MessageUtil.COMMENT_NOT_FOUND
                 )
         );
 
         PostDomainModel postDomainModel = this.postPort.findPostById(parentCommentDomainModel.getPostId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "게시글을 찾을 수 없습니다."
+                        MessageUtil.POST_NOT_FOUND
                 )
         );
 
@@ -115,7 +116,7 @@ public class ChildCommentService {
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
-                                            "로그인된 사용자가 가입 신청한 소모임이 아닙니다."
+                                            MessageUtil.CIRCLE_APPLY_INVALID
                                     )
                             );
 
@@ -149,21 +150,21 @@ public class ChildCommentService {
         UserDomainModel updater = this.userPort.findById(updaterId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         ChildCommentDomainModel childCommentDomainModel = this.childCommentPort.findById(childCommentId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "수정할 답글을 찾을 수 없습니다."
+                        MessageUtil.COMMENT_NOT_FOUND
                 )
         );
 
         PostDomainModel postDomainModel = this.postPort.findPostById(childCommentDomainModel.getParentComment().getPostId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "게시글을 찾을 수 없습니다."
+                        MessageUtil.POST_NOT_FOUND
                 )
         );
 
@@ -195,7 +196,7 @@ public class ChildCommentService {
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
-                                            "사용자가 가입 신청한 소모임이 아닙니다."
+                                            MessageUtil.CIRCLE_APPLY_INVALID
                                     )
                             );
 
@@ -215,7 +216,7 @@ public class ChildCommentService {
                 this.childCommentPort.update(childCommentId, childCommentDomainModel).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                "Comment id checked, but exception occurred"
+                                MessageUtil.INTERNAL_SERVER_ERROR
                         )
                 ),
                 updater,
@@ -230,21 +231,21 @@ public class ChildCommentService {
         UserDomainModel deleterDomainModel = this.userPort.findById(deleterId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         ChildCommentDomainModel childCommentDomainModel = this.childCommentPort.findById(childCommentId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "삭제할 답글을 찾을 수 없습니다."
+                        MessageUtil.COMMENT_NOT_FOUND
                 )
         );
 
         PostDomainModel postDomainModel = this.postPort.findPostById(childCommentDomainModel.getParentComment().getPostId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "게시글을 찾을 수 없습니다."
+                        MessageUtil.POST_NOT_FOUND
                 )
         );
 
@@ -263,7 +264,7 @@ public class ChildCommentService {
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
-                                            "로그인된 사용자가 가입 신청한 소모임이 아닙니다."
+                                            MessageUtil.CIRCLE_APPLY_INVALID
                                     )
                             );
 
@@ -286,7 +287,7 @@ public class ChildCommentService {
                                                 circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
                                                         () -> new InternalServerException(
                                                                 ErrorCode.INTERNAL_SERVER,
-                                                                "The board has circle without circle leader"
+                                                                MessageUtil.CIRCLE_WITHOUT_LEADER
                                                         )
                                                 ),
                                                 deleterId
@@ -310,7 +311,7 @@ public class ChildCommentService {
                 this.childCommentPort.delete(childCommentId).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                "Comment id checked, but exception occurred"
+                                MessageUtil.INTERNAL_SERVER_ERROR
                         )
                 ),
                 deleterDomainModel,

--- a/src/main/java/net/causw/application/comment/CommentService.java
+++ b/src/main/java/net/causw/application/comment/CommentService.java
@@ -191,7 +191,7 @@ public class CommentService {
         CommentDomainModel commentDomainModel = this.commentPort.findById(commentId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "수정할 댓글을 찾을 수 없습니다."
+                        MessageUtil.COMMENT_NOT_FOUND
                 )
         );
 
@@ -250,7 +250,7 @@ public class CommentService {
                 this.commentPort.update(commentId, commentDomainModel).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                MessageUtil.exceptionOccur("Comment")
+                                MessageUtil.INTERNAL_SERVER_ERROR
                         )
                 ),
                 requestUser,
@@ -273,7 +273,7 @@ public class CommentService {
         CommentDomainModel commentDomainModel = this.commentPort.findById(commentId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "삭제할 댓글을 찾을 수 없습니다."
+                        MessageUtil.COMMENT_NOT_FOUND
                 )
         );
 
@@ -345,7 +345,7 @@ public class CommentService {
                 this.commentPort.delete(commentId).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                MessageUtil.exceptionOccur("Comment")
+                                MessageUtil.INTERNAL_SERVER_ERROR
                         )
                 ),
                 deleterDomainModel,

--- a/src/main/java/net/causw/application/comment/CommentService.java
+++ b/src/main/java/net/causw/application/comment/CommentService.java
@@ -18,6 +18,7 @@ import net.causw.domain.model.enums.CircleMemberStatus;
 import net.causw.domain.model.comment.CommentDomainModel;
 import net.causw.domain.model.post.PostDomainModel;
 import net.causw.domain.model.enums.Role;
+import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
 import net.causw.domain.model.user.UserDomainModel;
 import net.causw.domain.validation.CircleMemberStatusValidator;
@@ -52,7 +53,7 @@ public class CommentService {
         UserDomainModel creatorDomainModel = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -63,7 +64,7 @@ public class CommentService {
         PostDomainModel postDomainModel = this.postPort.findPostById(commentCreateDto.getPostId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "게시글을 찾을 수 없습니다."
+                        MessageUtil.POST_NOT_FOUND
                 )
         );
 
@@ -88,7 +89,7 @@ public class CommentService {
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
-                                            "로그인된 사용자가 가입 신청한 소모임이 아닙니다."
+                                            MessageUtil.CIRCLE_APPLY_INVALID
                                     )
                             );
                             validatorBucket
@@ -118,14 +119,14 @@ public class CommentService {
         UserDomainModel userDomainModel = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         PostDomainModel postDomainModel = this.postPort.findPostById(postId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "게시글을 찾을 수 없습니다."
+                        MessageUtil.POST_NOT_FOUND
                 )
         );
 
@@ -145,7 +146,7 @@ public class CommentService {
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
-                                            "로그인된 사용자가 가입 신청한 소모임이 아닙니다."
+                                            MessageUtil.CIRCLE_APPLY_INVALID
                                     )
                             );
 
@@ -183,7 +184,7 @@ public class CommentService {
         UserDomainModel requestUser = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -197,7 +198,7 @@ public class CommentService {
         PostDomainModel postDomainModel = this.postPort.findPostById(commentDomainModel.getPostId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "게시글을 찾을 수 없습니다."
+                        MessageUtil.POST_NOT_FOUND
                 )
         );
 
@@ -229,7 +230,7 @@ public class CommentService {
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
-                                            "사용자가 가입 신청한 소모임이 아닙니다."
+                                            MessageUtil.CIRCLE_APPLY_INVALID
                                     )
                             );
 
@@ -249,7 +250,7 @@ public class CommentService {
                 this.commentPort.update(commentId, commentDomainModel).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                "Comment id checked, but exception occurred"
+                                MessageUtil.exceptionOccur("Comment")
                         )
                 ),
                 requestUser,
@@ -265,7 +266,7 @@ public class CommentService {
         UserDomainModel deleterDomainModel = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -279,7 +280,7 @@ public class CommentService {
         PostDomainModel postDomainModel = this.postPort.findPostById(commentDomainModel.getPostId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "게시글을 찾을 수 없습니다."
+                        MessageUtil.POST_NOT_FOUND
                 )
         );
 
@@ -298,7 +299,7 @@ public class CommentService {
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
-                                            "로그인된 사용자가 가입 신청한 소모임이 아닙니다."
+                                            MessageUtil.CIRCLE_APPLY_INVALID
                                     )
                             );
 
@@ -321,7 +322,7 @@ public class CommentService {
                                                 circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
                                                         () -> new InternalServerException(
                                                                 ErrorCode.INTERNAL_SERVER,
-                                                                "The board has circle without circle leader"
+                                                                MessageUtil.CIRCLE_WITHOUT_LEADER
                                                         )
                                                 ),
                                                 loginUserId
@@ -344,7 +345,7 @@ public class CommentService {
                 this.commentPort.delete(commentId).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                "Comment id checked, but exception occurred"
+                                MessageUtil.exceptionOccur("Comment")
                         )
                 ),
                 deleterDomainModel,

--- a/src/main/java/net/causw/application/common/CommonService.java
+++ b/src/main/java/net/causw/application/common/CommonService.java
@@ -43,7 +43,7 @@ public class CommonService {
                 flag -> {
                     throw new BadRequestException(
                             ErrorCode.ROW_ALREADY_EXIST,
-                            "이미 존재하는 플래그 입니다."
+                            MessageUtil.FLAG_ALREADY_EXIST
                     );
                 }
         );
@@ -71,7 +71,7 @@ public class CommonService {
         return this.flagPort.update(key, value).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "플래그를 업데이트 하지 못했습니다."
+                        MessageUtil.FLAG_UPDATE_FAILED
                 )
         );
     }

--- a/src/main/java/net/causw/application/common/CommonService.java
+++ b/src/main/java/net/causw/application/common/CommonService.java
@@ -8,6 +8,7 @@ import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
 import net.causw.domain.model.enums.Role;
 import net.causw.domain.model.user.UserDomainModel;
+import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.validation.UserRoleValidator;
 import net.causw.domain.validation.ValidatorBucket;
 import org.springframework.stereotype.Service;
@@ -30,7 +31,7 @@ public class CommonService {
         UserDomainModel userDomainModel = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -59,7 +60,7 @@ public class CommonService {
         UserDomainModel userDomainModel = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 

--- a/src/main/java/net/causw/application/delegation/DelegationLeaderAlumni.java
+++ b/src/main/java/net/causw/application/delegation/DelegationLeaderAlumni.java
@@ -23,7 +23,7 @@ public class DelegationLeaderAlumni implements Delegation {
         this.userPort.updateRole(currentId, Role.COMMON).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        MessageUtil.exceptionOccur("User")
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         );
     }

--- a/src/main/java/net/causw/application/delegation/DelegationLeaderAlumni.java
+++ b/src/main/java/net/causw/application/delegation/DelegationLeaderAlumni.java
@@ -4,6 +4,7 @@ import net.causw.application.spi.UserPort;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
 import net.causw.domain.model.enums.Role;
+import net.causw.domain.model.util.MessageUtil;
 
 /**
  * The delegation process for the leader of the alumni.
@@ -22,7 +23,7 @@ public class DelegationLeaderAlumni implements Delegation {
         this.userPort.updateRole(currentId, Role.COMMON).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "User id checked, but exception occurred"
+                        MessageUtil.exceptionOccur("User")
                 )
         );
     }

--- a/src/main/java/net/causw/application/delegation/DelegationLeaderCircle.java
+++ b/src/main/java/net/causw/application/delegation/DelegationLeaderCircle.java
@@ -12,6 +12,7 @@ import net.causw.domain.model.circle.CircleMemberDomainModel;
 import net.causw.domain.model.enums.CircleMemberStatus;
 import net.causw.domain.model.enums.Role;
 import net.causw.domain.model.user.UserDomainModel;
+import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.validation.CircleMemberStatusValidator;
 import net.causw.domain.validation.ValidatorBucket;
 
@@ -81,7 +82,7 @@ public class DelegationLeaderCircle implements Delegation {
             this.userPort.removeRole(currentId, Role.LEADER_CIRCLE).orElseThrow(
                     () -> new InternalServerException(
                             ErrorCode.INTERNAL_SERVER,
-                            "User id checked, but exception occurred"
+                            MessageUtil.exceptionOccur("User")
                     )
             );
         }
@@ -89,7 +90,7 @@ public class DelegationLeaderCircle implements Delegation {
         this.circlePort.updateLeader(circle.getId(), newLeader).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "Circle id and Leader id checked, but exception occurred"
+                        "Circle id and" + MessageUtil.exceptionOccur("Leader")
                 )
         );
     }

--- a/src/main/java/net/causw/application/delegation/DelegationLeaderCircle.java
+++ b/src/main/java/net/causw/application/delegation/DelegationLeaderCircle.java
@@ -49,21 +49,21 @@ public class DelegationLeaderCircle implements Delegation {
         CircleDomainModel circle = this.circlePort.findById(this.circleId).orElseThrow(
                 () -> new UnauthorizedException(
                         ErrorCode.API_NOT_ALLOWED,
-                        "권한을 위임할 소모임장의 소모임을 찾을 수 없습니다."
+                        MessageUtil.SMALL_CLUB_NOT_FOUND
                 )
         );
 
         UserDomainModel newLeader = this.userPort.findById(targetId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "피위임자를 찾을 수 없습니다."
+                        MessageUtil.USER_NOT_FOUND
                 )
         );
 
         CircleMemberDomainModel circleMember = this.circleMemberPort.findByUserIdAndCircleId(targetId, circle.getId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "피위임자가 가입 신청한 소모임이 아닙니다."
+                        MessageUtil.CIRCLE_MEMBER_NOT_FOUND
                 )
         );
 
@@ -82,7 +82,7 @@ public class DelegationLeaderCircle implements Delegation {
             this.userPort.removeRole(currentId, Role.LEADER_CIRCLE).orElseThrow(
                     () -> new InternalServerException(
                             ErrorCode.INTERNAL_SERVER,
-                            MessageUtil.exceptionOccur("User")
+                            MessageUtil.INTERNAL_SERVER_ERROR
                     )
             );
         }
@@ -90,7 +90,7 @@ public class DelegationLeaderCircle implements Delegation {
         this.circlePort.updateLeader(circle.getId(), newLeader).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "Circle id and" + MessageUtil.exceptionOccur("Leader")
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         );
     }

--- a/src/main/java/net/causw/application/delegation/DelegationPresident.java
+++ b/src/main/java/net/causw/application/delegation/DelegationPresident.java
@@ -5,6 +5,7 @@ import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
 import net.causw.domain.model.enums.Role;
 import net.causw.domain.model.user.UserDomainModel;
+import net.causw.domain.model.util.MessageUtil;
 
 import java.util.List;
 
@@ -40,7 +41,7 @@ public class DelegationPresident implements Delegation {
         this.userPort.removeRole(currentId, Role.PRESIDENT).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "User id checked, but exception occurred"
+                        MessageUtil.exceptionOccur("User")
                 )
         );
     }

--- a/src/main/java/net/causw/application/delegation/DelegationPresident.java
+++ b/src/main/java/net/causw/application/delegation/DelegationPresident.java
@@ -41,7 +41,7 @@ public class DelegationPresident implements Delegation {
         this.userPort.removeRole(currentId, Role.PRESIDENT).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        MessageUtil.exceptionOccur("User")
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         );
     }

--- a/src/main/java/net/causw/application/homepage/HomePageService.java
+++ b/src/main/java/net/causw/application/homepage/HomePageService.java
@@ -12,6 +12,7 @@ import net.causw.application.spi.UserPort;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.model.board.BoardDomainModel;
+import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
 import net.causw.domain.model.user.UserDomainModel;
 import net.causw.domain.validation.UserRoleIsNoneValidator;
@@ -30,11 +31,12 @@ public class HomePageService {
     private final BoardPort boardPort;
     private final PostPort postPort;
     private final CommentPort commentPort;
+
     public List<HomePageResponseDto> getHomePage(String userId) {
         UserDomainModel userDomainModel = this.userPort.findById(userId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -48,7 +50,7 @@ public class HomePageService {
         if(boardDomainModelList.isEmpty()){
             throw new BadRequestException(
                     ErrorCode.ROW_DOES_NOT_EXIST,
-                    "게시판을 찾을 수 없습니다."
+                    MessageUtil.BOARD_NOT_FOUND
             );
         }
         return boardDomainModelList

--- a/src/main/java/net/causw/application/inquiry/InquiryService.java
+++ b/src/main/java/net/causw/application/inquiry/InquiryService.java
@@ -8,6 +8,7 @@ import net.causw.application.spi.UserPort;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.model.inquiry.InquiryDomainModel;
+import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
 import net.causw.domain.model.user.UserDomainModel;
 import net.causw.domain.validation.ValidatorBucket;
@@ -38,14 +39,14 @@ public class InquiryService {
         UserDomainModel userDomainModel = this.userPort.findById(requestUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         InquiryDomainModel inquiryDomainModel = this.inquiryPort.findById(inquiryId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "문의글을 찾을 수 없습니다."
+                        MessageUtil.INQUIRY_NOT_FOUND
                 )
         );
 
@@ -70,7 +71,7 @@ public class InquiryService {
         UserDomainModel creatorDomainModel = this.userPort.findById(requestUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 

--- a/src/main/java/net/causw/application/locker/LockerActionExtend.java
+++ b/src/main/java/net/causw/application/locker/LockerActionExtend.java
@@ -10,6 +10,7 @@ import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
 import net.causw.domain.model.locker.LockerDomainModel;
 import net.causw.domain.model.enums.Role;
+import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
 import net.causw.domain.model.user.UserDomainModel;
 import net.causw.domain.validation.ExtendLockerExpiredAtValidator;
@@ -35,7 +36,7 @@ public class LockerActionExtend implements LockerAction {
         if (lockerDomainModel.getUser().isEmpty()) {
             throw new BadRequestException(
                     ErrorCode.CANNOT_PERFORMED,
-                    "사용 중인 사물함이 아닙니다."
+                    MessageUtil.LOCKER_UNUSED
             );
         }
 
@@ -47,7 +48,7 @@ public class LockerActionExtend implements LockerAction {
         LocalDateTime expiredAtToExtend = LocalDateTime.parse(textFieldPort.findByKey(StaticValue.EXPIRED_AT).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "사물함 반납 기한을 설정하지 않았습니다."
+                        MessageUtil.LOCKER_RETURN_TIME_NOT_SET
                 )
         ), DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"));
 

--- a/src/main/java/net/causw/application/locker/LockerActionFactory.java
+++ b/src/main/java/net/causw/application/locker/LockerActionFactory.java
@@ -3,6 +3,7 @@ package net.causw.application.locker;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.model.enums.LockerLogAction;
+import net.causw.domain.model.util.MessageUtil;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
@@ -28,7 +29,7 @@ public class LockerActionFactory {
         if(updateAction == null) {
             throw new BadRequestException(
                     ErrorCode.INVALID_PARAMETER,
-                    "Invalid action parameter"
+                    MessageUtil.INVALID_PARAMETER
             );
         }
         return updateAction.get();

--- a/src/main/java/net/causw/application/locker/LockerActionRegister.java
+++ b/src/main/java/net/causw/application/locker/LockerActionRegister.java
@@ -10,6 +10,7 @@ import net.causw.domain.exceptions.InternalServerException;
 import net.causw.domain.model.locker.LockerDomainModel;
 import net.causw.domain.model.enums.LockerLogAction;
 import net.causw.domain.model.enums.Role;
+import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
 import net.causw.domain.model.user.UserDomainModel;
 import net.causw.domain.validation.LockerAccessValidator;
@@ -75,7 +76,7 @@ public class LockerActionRegister implements LockerAction {
                 LocalDateTime.parse(textFieldPort.findByKey(StaticValue.EXPIRED_AT).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                "사물함 반납 기한을 설정하지 않았습니다."
+                                MessageUtil.LOCKER_RETURN_TIME_NOT_SET
                         )
                 ), DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"))
         );

--- a/src/main/java/net/causw/application/locker/LockerActionReturn.java
+++ b/src/main/java/net/causw/application/locker/LockerActionReturn.java
@@ -10,6 +10,7 @@ import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.model.locker.LockerDomainModel;
 import net.causw.domain.model.enums.Role;
 import net.causw.domain.model.user.UserDomainModel;
+import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.validation.UserRoleValidator;
 import net.causw.domain.validation.ValidatorBucket;
 
@@ -30,7 +31,7 @@ public class LockerActionReturn implements LockerAction {
         if (lockerDomainModel.getUser().isEmpty()) {
             throw new BadRequestException(
                     ErrorCode.CANNOT_PERFORMED,
-                    "사용 중인 사물함이 아닙니다."
+                    MessageUtil.LOCKER_UNUSED
             );
         }
 

--- a/src/main/java/net/causw/application/locker/LockerService.java
+++ b/src/main/java/net/causw/application/locker/LockerService.java
@@ -131,7 +131,7 @@ public class LockerService {
                 })
                 .orElseThrow(() -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "Exception occurred when creating locker"
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 ));
     }
 
@@ -182,7 +182,7 @@ public class LockerService {
                 })
                 .orElseThrow(() -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "Locker id checked, but exception occurred"
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 ));
     }
 
@@ -225,7 +225,7 @@ public class LockerService {
         return LockerResponseDto.from(this.lockerPort.updateLocation(lockerId, lockerDomainModel).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                "Locker id checked, but exception occurred"
+                                MessageUtil.INTERNAL_SERVER_ERROR
                         )),
                 updaterDomainModel
         );
@@ -261,7 +261,7 @@ public class LockerService {
                 lockerDomainModel.getLockerLocation().getName(),
                 deleterDomainModel,
                 LockerLogAction.DISABLE,
-                "사물함 삭제"
+                MessageUtil.LOCKER_DELETED
         );
 
         return LockerResponseDto.from(lockerDomainModel, deleterDomainModel);
@@ -405,7 +405,7 @@ public class LockerService {
                 this.lockerLocationPort.update(locationId, lockerLocationDomainModel).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                "Locker location id checked, but exception occurred"
+                                MessageUtil.INTERNAL_SERVER_ERROR
                         )
                 ),
                 this.lockerPort.countEnableLockerByLocation(lockerLocationDomainModel.getId()),

--- a/src/main/java/net/causw/application/locker/LockerService.java
+++ b/src/main/java/net/causw/application/locker/LockerService.java
@@ -25,6 +25,7 @@ import net.causw.domain.model.locker.LockerDomainModel;
 import net.causw.domain.model.locker.LockerLocationDomainModel;
 import net.causw.domain.model.enums.LockerLogAction;
 import net.causw.domain.model.enums.Role;
+import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
 import net.causw.domain.model.user.UserDomainModel;
 import net.causw.domain.validation.ConstraintValidator;
@@ -61,14 +62,14 @@ public class LockerService {
         UserDomainModel userDomainModel = this.userPort.findById(userId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         return LockerResponseDto.from(this.lockerPort.findByIdForRead(id).orElseThrow(
                         () -> new BadRequestException(
                                 ErrorCode.ROW_DOES_NOT_EXIST,
-                                "사물함을 찾을 수 없습니다."
+                                MessageUtil.LOCKER_NOT_FOUND
                         )),
                 userDomainModel
         );
@@ -84,7 +85,7 @@ public class LockerService {
         UserDomainModel creatorDomainModel = this.userPort.findById(creatorId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -93,14 +94,14 @@ public class LockerService {
                 .orElseThrow(
                         () -> new BadRequestException(
                                 ErrorCode.ROW_DOES_NOT_EXIST,
-                                "등록된 사물함 위치가 아닙니다."
+                                MessageUtil.LOCKER_WRONG_POSITION
                         )
                 );
 
         if (this.lockerPort.findByLockerNumber(lockerCreateRequestDto.getLockerNumber()).isPresent()) {
             throw new BadRequestException(
                     ErrorCode.ROW_ALREADY_EXIST,
-                    "중복된 사물함 번호입니다."
+                    MessageUtil.LOCKER_DUPLICATE_NUMBER
             );
         }
 
@@ -124,7 +125,7 @@ public class LockerService {
                             lockerLocationDomainModel.getName(),
                             creatorDomainModel,
                             LockerLogAction.ENABLE,
-                            "사물함 최초 생성"
+                            MessageUtil.LOCKER_FIRST_CREATED
                     );
                     return LockerResponseDto.from(resLockerDomainModel, creatorDomainModel);
                 })
@@ -143,14 +144,14 @@ public class LockerService {
         UserDomainModel updaterDomainModel = this.userPort.findById(updaterId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         LockerDomainModel lockerDomainModel = this.lockerPort.findByIdForWrite(lockerId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "사물함을 찾을 수 없습니다."
+                        MessageUtil.LOCKER_NOT_FOUND
                 )
         );
 
@@ -194,21 +195,21 @@ public class LockerService {
         UserDomainModel updaterDomainModel = this.userPort.findById(updaterId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         LockerDomainModel lockerDomainModel = this.lockerPort.findByIdForWrite(lockerId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "사물함을 찾을 수 없습니다."
+                        MessageUtil.LOCKER_WRONG_POSITION
                 )
         );
 
         LockerLocationDomainModel lockerLocationDomainModel = this.lockerLocationPort.findById(lockerMoveRequestDto.getLocationId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "등록된 사물함 위치가 아닙니다."
+                        MessageUtil.LOCKER_WRONG_POSITION
                 )
         );
 
@@ -235,14 +236,14 @@ public class LockerService {
         UserDomainModel deleterDomainModel = this.userPort.findById(deleterId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         LockerDomainModel lockerDomainModel = this.lockerPort.findByIdForWrite(lockerId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "사물함을 찾을 수 없습니다."
+                        MessageUtil.LOCKER_NOT_FOUND
                 )
         );
 
@@ -271,14 +272,14 @@ public class LockerService {
         UserDomainModel userDomainModel = this.userPort.findById(userId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         LockerLocationDomainModel lockerLocation = this.lockerLocationPort.findById(locationId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "등록된 사물함 위치가 아닙니다."
+                        MessageUtil.LOCKER_WRONG_POSITION
                 )
         );
 
@@ -296,7 +297,7 @@ public class LockerService {
         UserDomainModel userDomainModel = this.userPort.findById(userId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -331,14 +332,14 @@ public class LockerService {
         UserDomainModel creatorDomainModel = this.userPort.findById(creatorId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         if (this.lockerLocationPort.findByName(lockerLocationCreateRequestDto.getName()).isPresent()) {
             throw new BadRequestException(
                     ErrorCode.ROW_ALREADY_EXIST,
-                    "이미 등록된 사물함 위치입니다."
+                    MessageUtil.LOCKER_ALREADY_REGISTERED
             );
         }
 
@@ -369,14 +370,14 @@ public class LockerService {
         UserDomainModel creatorDomainModel = this.userPort.findById(updaterId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         LockerLocationDomainModel lockerLocationDomainModel = this.lockerLocationPort.findById(locationId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "등록된 사물함 위치가 아닙니다."
+                        MessageUtil.LOCKER_WRONG_POSITION
                 )
         );
 
@@ -384,7 +385,7 @@ public class LockerService {
             if (this.lockerLocationPort.findByName(lockerLocationRequestDto.getName()).isPresent()) {
                 throw new BadRequestException(
                         ErrorCode.ROW_ALREADY_EXIST,
-                        "이미 등록된 사물함 위치 입니다."
+                        MessageUtil.LOCKER_ALREADY_REGISTERED
                 );
             }
         }
@@ -417,21 +418,21 @@ public class LockerService {
         UserDomainModel deleterDomainModel = this.userPort.findById(deleterId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         LockerLocationDomainModel lockerLocationDomainModel = this.lockerLocationPort.findById(lockerLocationId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "등록된 사물함 위치가 아닙니다."
+                        MessageUtil.LOCKER_WRONG_POSITION
                 )
         );
 
         if (this.lockerPort.countByLocation(lockerLocationDomainModel.getId()) != 0L) {
             throw new BadRequestException(
                     ErrorCode.CANNOT_PERFORMED,
-                    "사물함 위치에 사물함이 존재합니다."
+                    MessageUtil.LOCKER_ALREADY_EXIST
             );
         }
 
@@ -451,7 +452,7 @@ public class LockerService {
         LockerDomainModel locker = this.lockerPort.findByIdForRead(id).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "사물함을 찾을 수 없습니다."
+                        MessageUtil.LOCKER_NOT_FOUND
                 )
         );
 
@@ -466,7 +467,7 @@ public class LockerService {
         UserDomainModel userDomainModel = this.userPort.findById(requestUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -501,7 +502,7 @@ public class LockerService {
         UserDomainModel creatorDomainModel = this.userPort.findById(creatorId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -510,7 +511,7 @@ public class LockerService {
                 .orElseThrow(
                         () -> new BadRequestException(
                                 ErrorCode.ROW_DOES_NOT_EXIST,
-                                "등록된 사물함 위치가 아닙니다."
+                                MessageUtil.LOCKER_WRONG_POSITION
                         )
                 );
         LockerLocationDomainModel lockerLocationThirdFloorDomainModel = this.lockerLocationPort
@@ -518,7 +519,7 @@ public class LockerService {
                 .orElseThrow(
                         () -> new BadRequestException(
                                 ErrorCode.ROW_DOES_NOT_EXIST,
-                                "등록된 사물함 위치가 아닙니다."
+                                MessageUtil.LOCKER_WRONG_POSITION
                         )
                 );
         LockerLocationDomainModel lockerLocationFourthFloorDomainModel = this.lockerLocationPort
@@ -526,7 +527,7 @@ public class LockerService {
                 .orElseThrow(
                         () -> new BadRequestException(
                                 ErrorCode.ROW_DOES_NOT_EXIST,
-                                "등록된 사물함 위치가 아닙니다."
+                                MessageUtil.LOCKER_WRONG_POSITION
                         )
                 );
 
@@ -551,7 +552,7 @@ public class LockerService {
                     lockerLocationSecondFloorDomainModel.getName(),
                     creatorDomainModel,
                     LockerLogAction.ENABLE,
-                    "사물함 최초 생성"
+                    MessageUtil.LOCKER_FIRST_CREATED
             );
         }
         for (Long lockerNumber = 1L; lockerNumber <= 168; lockerNumber++) {
@@ -575,7 +576,7 @@ public class LockerService {
                     lockerLocationThirdFloorDomainModel.getName(),
                     creatorDomainModel,
                     LockerLogAction.ENABLE,
-                    "사물함 최초 생성"
+                    MessageUtil.LOCKER_FIRST_CREATED
             );
         }
         for (Long lockerNumber = 1L; lockerNumber <= 32; lockerNumber++) {
@@ -599,7 +600,7 @@ public class LockerService {
                     lockerLocationFourthFloorDomainModel.getName(),
                     creatorDomainModel,
                     LockerLogAction.ENABLE,
-                    "사물함 최초 생성"
+                    MessageUtil.LOCKER_FIRST_CREATED
             );
         }
     }

--- a/src/main/java/net/causw/application/post/PostService.java
+++ b/src/main/java/net/causw/application/post/PostService.java
@@ -23,6 +23,7 @@ import net.causw.domain.model.circle.CircleMemberDomainModel;
 import net.causw.domain.model.enums.CircleMemberStatus;
 import net.causw.domain.model.post.PostDomainModel;
 import net.causw.domain.model.enums.Role;
+import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
 import net.causw.domain.model.user.UserDomainModel;
 import net.causw.domain.validation.CircleMemberStatusValidator;
@@ -62,14 +63,14 @@ public class PostService {
         UserDomainModel userDomainModel = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         PostDomainModel postDomainModel = this.postPort.findPostById(postId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "게시글을 찾을 수 없습니다."
+                        MessageUtil.POST_NOT_FOUND
                 )
         );
 
@@ -87,7 +88,7 @@ public class PostService {
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
-                                            "로그인된 사용자가 동아리 멤버가 아닙니다."
+                                            MessageUtil.NOT_CIRCLE_MEMBER
                                     )
                             );
 
@@ -130,7 +131,7 @@ public class PostService {
         UserDomainModel userDomainModel = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -141,7 +142,7 @@ public class PostService {
         BoardDomainModel boardDomainModel = this.boardPort.findById(boardId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "게시판을 찾을 수 없습니다."
+                        MessageUtil.BOARD_NOT_FOUND
                 )
         );
 
@@ -155,7 +156,7 @@ public class PostService {
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
-                                            "로그인된 사용자가 동아리 멤버가 아닙니다."
+                                            MessageUtil.NOT_CIRCLE_MEMBER
                                     )
                             );
 
@@ -220,7 +221,7 @@ public class PostService {
         UserDomainModel userDomainModel = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -231,7 +232,7 @@ public class PostService {
         BoardDomainModel boardDomainModel = this.boardPort.findById(boardId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "게시판을 찾을 수 없습니다."
+                        MessageUtil.BOARD_NOT_FOUND
                 )
         );
 
@@ -246,7 +247,7 @@ public class PostService {
                                     .orElseThrow(
                                             () -> new UnauthorizedException(
                                                     ErrorCode.NOT_MEMBER,
-                                                    "로그인된 사용자가 동아리 멤버가 아닙니다."
+                                                    MessageUtil.NOT_CIRCLE_MEMBER
                                             )
                                     );
 
@@ -308,14 +309,14 @@ public class PostService {
         UserDomainModel userDomainModel = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         BoardDomainModel boardDomainModel = this.boardPort.findAppNotice().orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "앱 공지 게시판을 찾을 수 없습니다."
+                        MessageUtil.NOTICE_NOT_FOUND
                 )
         );
 
@@ -340,14 +341,14 @@ public class PostService {
         UserDomainModel creatorDomainModel = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         BoardDomainModel boardDomainModel = this.boardPort.findById(postCreateRequestDto.getBoardId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "게시판을 찾을 수 없습니다."
+                        MessageUtil.BOARD_NOT_FOUND
                 )
         );
 
@@ -382,7 +383,7 @@ public class PostService {
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
-                                            "로그인된 사용자가 동아리 멤버가 아닙니다."
+                                            MessageUtil.NOT_CIRCLE_MEMBER
                                     )
                             );
 
@@ -399,7 +400,7 @@ public class PostService {
                                                 circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
                                                         () -> new UnauthorizedException(
                                                                 ErrorCode.API_NOT_ALLOWED,
-                                                                "사용자가 해당 동아리의 동아리장이 아닙니다."
+                                                                MessageUtil.NOT_CIRCLE_LEADER
                                                         )
                                                 ),
                                                 loginUserId
@@ -433,14 +434,14 @@ public class PostService {
         UserDomainModel deleterDomainModel = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         PostDomainModel postDomainModel = this.postPort.findPostById(postId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "게시글을 찾을 수 없습니다."
+                        MessageUtil.POST_NOT_FOUND
                 )
         );
 
@@ -467,7 +468,7 @@ public class PostService {
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
-                                            "로그인된 사용자가 동아리 멤버가 아닙니다."
+                                            MessageUtil.NOT_CIRCLE_MEMBER
                                     )
                             );
 
@@ -489,7 +490,7 @@ public class PostService {
                                                 circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
                                                         () -> new UnauthorizedException(
                                                                 ErrorCode.API_NOT_ALLOWED,
-                                                                "사용자가 해당 동아리의 동아리장이 아닙니다."
+                                                                MessageUtil.NOT_CIRCLE_LEADER
                                                         )
                                                 ),
                                                 loginUserId
@@ -512,7 +513,7 @@ public class PostService {
                 this.postPort.deletePost(postId).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                "Post id checked, but exception occurred"
+                                MessageUtil.exceptionOccur("Post")
                         )
                 ),
                 deleterDomainModel
@@ -530,14 +531,14 @@ public class PostService {
         UserDomainModel updaterDomainModel = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         PostDomainModel postDomainModel = this.postPort.findPostById(postId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "게시글을 찾을 수 없습니다."
+                        MessageUtil.POST_NOT_FOUND
                 )
         );
 
@@ -572,7 +573,7 @@ public class PostService {
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
-                                            "로그인된 사용자가 동아리 멤버가 아닙니다."
+                                            MessageUtil.NOT_CIRCLE_MEMBER
                                     )
                             );
 
@@ -598,7 +599,7 @@ public class PostService {
         PostDomainModel updatedPostDomainModel = this.postPort.updatePost(postId, postDomainModel).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "Post id checked, but exception occurred"
+                        MessageUtil.exceptionOccur("Post")
                 )
         );
 
@@ -623,14 +624,14 @@ public class PostService {
         UserDomainModel restorerDomainModel = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         PostDomainModel postDomainModel = this.postPort.findPostById(postId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "게시글을 찾을 수 없습니다."
+                        MessageUtil.POST_NOT_FOUND
                 )
         );
 
@@ -658,7 +659,7 @@ public class PostService {
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
-                                            "로그인된 사용자가 동아리 멤버가 아닙니다."
+                                            MessageUtil.NOT_CIRCLE_MEMBER
                                     )
                             );
 
@@ -681,7 +682,7 @@ public class PostService {
                                                 circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
                                                         () -> new UnauthorizedException(
                                                                 ErrorCode.API_NOT_ALLOWED,
-                                                                "사용자가 해당 동아리의 동아리장이 아닙니다."
+                                                                MessageUtil.NOT_CIRCLE_LEADER
                                                         )
                                                 ),
                                                 loginUserId
@@ -709,7 +710,7 @@ public class PostService {
         PostDomainModel restoredPostDomainModel = this.postPort.restorePost(postId, postDomainModel).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "Post id checked, but exception occurred"
+                        MessageUtil.exceptionOccur("Post")
                 )
         );
 

--- a/src/main/java/net/causw/application/post/PostService.java
+++ b/src/main/java/net/causw/application/post/PostService.java
@@ -513,7 +513,7 @@ public class PostService {
                 this.postPort.deletePost(postId).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                MessageUtil.exceptionOccur("Post")
+                                MessageUtil.INTERNAL_SERVER_ERROR
                         )
                 ),
                 deleterDomainModel
@@ -599,7 +599,7 @@ public class PostService {
         PostDomainModel updatedPostDomainModel = this.postPort.updatePost(postId, postDomainModel).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        MessageUtil.exceptionOccur("Post")
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         );
 
@@ -710,7 +710,7 @@ public class PostService {
         PostDomainModel restoredPostDomainModel = this.postPort.restorePost(postId, postDomainModel).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        MessageUtil.exceptionOccur("Post")
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         );
 

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -95,7 +95,7 @@ public class UserService {
         this.userPort.updatePassword(requestUser.getId(), passwordEncoder.encode(newPassword)).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        MessageUtil.exceptionOccur("User")
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         );
         return UserResponseDto.from(requestUser);
@@ -133,7 +133,7 @@ public class UserService {
                                     .map(circleMemberDomainModel -> circleMemberDomainModel.getStatus() == CircleMemberStatus.MEMBER)
                                     .orElse(false));
             if (!isMemberOfAnyCircle) {
-                throw new BadRequestException(ErrorCode.NOT_MEMBER, "해당 유저는 동아리 회원이 아닙니다.");
+                throw new BadRequestException(ErrorCode.NOT_MEMBER, MessageUtil.CIRCLE_MEMBER_NOT_FOUND);
             }
         }
 
@@ -141,7 +141,7 @@ public class UserService {
                 .map(UserResponseDto::from)
                 .orElseThrow(() -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "해당 사용자를 찾을 수 없습니다."
+                        MessageUtil.USER_NOT_FOUND
                 ));
     }
 
@@ -226,7 +226,7 @@ public class UserService {
                     PostDomainModel post = this.postPort.findPostById(comment.getPostId()).orElseThrow(
                             () -> new BadRequestException(
                                     ErrorCode.ROW_DOES_NOT_EXIST,
-                                    "게시글을 찾을 수 없습니다."
+                                    MessageUtil.POST_NOT_FOUND
                             )
                     );
 
@@ -454,7 +454,7 @@ public class UserService {
                 email -> {
                     throw new BadRequestException(
                             ErrorCode.ROW_ALREADY_EXIST,
-                            "중복된 이메일 입니다."
+                            MessageUtil.EMAIL_ALREADY_EXIST
                     );
                 }
         );
@@ -474,7 +474,7 @@ public class UserService {
         UserDomainModel userDomainModel = this.userPort.findByEmail(userSignInRequestDto.getEmail()).orElseThrow(
                 () -> new UnauthorizedException(
                         ErrorCode.INVALID_SIGNIN,
-                        "잘못된 이메일 입니다."
+                        MessageUtil.EMAIL_INVALID
                 )
         );
 
@@ -492,7 +492,7 @@ public class UserService {
             this.userAdmissionPort.findByUserId(userDomainModel.getId()).orElseThrow(
                     () -> new BadRequestException(
                             ErrorCode.NO_APPLICATION,
-                            "신청서를 작성하지 않았습니다."
+                            MessageUtil.NO_APPLICATION
                     )
             );
         }
@@ -525,7 +525,7 @@ public class UserService {
             if (state.equals(UserState.INACTIVE) || state.equals(UserState.DROP)) {
                 throw new BadRequestException(
                         ErrorCode.ROW_ALREADY_EXIST,
-                        "탈퇴한 계정의 재가입은 관리자에게 문의해주세요."
+                        MessageUtil.USER_ALREADY_APPLY
                 );
             }
         }
@@ -557,7 +557,7 @@ public class UserService {
                     email -> {
                         throw new BadRequestException(
                                 ErrorCode.ROW_ALREADY_EXIST,
-                                "이미 사용중인 이메일입니다."
+                                MessageUtil.EMAIL_ALREADY_EXIST
                         );
                     }
             );
@@ -583,7 +583,7 @@ public class UserService {
         return UserResponseDto.from(this.userPort.update(loginUserId, userDomainModel).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        MessageUtil.exceptionOccur("user")
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         ));
     }
@@ -612,7 +612,7 @@ public class UserService {
         UserDomainModel grantee = this.userPort.findById(granteeId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "권한을 받을 사용자를 찾을 수 없습니다."
+                        MessageUtil.USER_NOT_FOUND
                 )
         );
 
@@ -662,7 +662,7 @@ public class UserService {
                         user -> this.userPort.removeRole(user.getId(), Role.VICE_PRESIDENT).orElseThrow(
                                 () -> new InternalServerException(
                                         ErrorCode.INTERNAL_SERVER,
-                                        MessageUtil.exceptionOccur("user")
+                                        MessageUtil.INTERNAL_SERVER_ERROR
                                 ))
                 );
             }
@@ -677,7 +677,9 @@ public class UserService {
                     ));
             if(grantee.getRole().equals(Role.VICE_PRESIDENT)){
                 throw new UnauthorizedException(
-                        ErrorCode.API_NOT_ALLOWED, "부회장은 동아리장 겸직이 불가합니다."
+                        ErrorCode.API_NOT_ALLOWED,
+                        MessageUtil.CONCURRENT_JOB_IMPOSSIBLE
+
                 );
             }
 
@@ -692,7 +694,7 @@ public class UserService {
                             () -> {
                                 throw new UnauthorizedException(
                                         ErrorCode.NOT_MEMBER,
-                                        MessageUtil.USER_NOT_APPLIED_FOR_CIRCLE
+                                        MessageUtil.CIRCLE_APPLY_INVALID
                                 );
                             });
 
@@ -726,7 +728,7 @@ public class UserService {
                 return UserResponseDto.from(this.userPort.removeRole(granteeId, Role.COMMON).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                MessageUtil.exceptionOccur("user")
+                                MessageUtil.INTERNAL_SERVER_ERROR
                         )
                 ));
             }
@@ -739,13 +741,13 @@ public class UserService {
                     .orElseThrow(
                             () -> new InternalServerException(
                                     ErrorCode.INTERNAL_SERVER,
-                                    "동문회장이 존재하지 않습니다."
+                                    MessageUtil.INTERNAL_SERVER_ERROR
                             ));
 
             this.userPort.removeRole(previousLeaderAlumni.getId(), Role.LEADER_ALUMNI).orElseThrow(
                     () -> new InternalServerException(
                             ErrorCode.INTERNAL_SERVER,
-                            MessageUtil.exceptionOccur("user")
+                            MessageUtil.INTERNAL_SERVER_ERROR
                     )
             );
         }
@@ -756,7 +758,7 @@ public class UserService {
         return UserResponseDto.from(this.userPort.updateRole(granteeId, userUpdateRoleRequestDto.getRole()).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        MessageUtil.exceptionOccur("user")
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         ));
     }
@@ -791,7 +793,7 @@ public class UserService {
                 .orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                MessageUtil.exceptionOccur("user")
+                                MessageUtil.INTERNAL_SERVER_ERROR
                         )
                 ));
     }
@@ -829,7 +831,7 @@ public class UserService {
         this.userPort.updateRole(loginUserId, Role.NONE).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        MessageUtil.exceptionOccur("user")
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         );
 
@@ -842,7 +844,7 @@ public class UserService {
         return UserResponseDto.from(this.userPort.updateState(loginUserId, UserState.INACTIVE).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        MessageUtil.exceptionOccur("user")
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         ));
     }
@@ -859,7 +861,7 @@ public class UserService {
         UserDomainModel droppedUser = this.userPort.findById(userId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "내보낼 사용자를 찾을 수 없습니다."
+                        MessageUtil.USER_NOT_FOUND
                 )
         );
 
@@ -887,14 +889,14 @@ public class UserService {
         this.userPort.updateRole(userId, Role.NONE).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        MessageUtil.exceptionOccur("user")
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         );
 
         return UserResponseDto.from(this.userPort.updateState(userId, UserState.DROP).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        MessageUtil.exceptionOccur("user")
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         ));
     }
@@ -950,14 +952,14 @@ public class UserService {
         UserDomainModel requestUser = this.userPort.findByEmail(userAdmissionCreateRequestDto.getEmail()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "회원가입된 사용자의 이메일이 아닙니다."
+                        MessageUtil.USER_NOT_FOUND
                 )
         );
 
         if (this.userAdmissionPort.existsByUserId(requestUser.getId())) {
             throw new BadRequestException(
                     ErrorCode.ROW_ALREADY_EXIST,
-                    "이미 신청한 사용자 입니다."
+                    MessageUtil.USER_ALREADY_APPLY
             );
         }
 
@@ -1143,7 +1145,7 @@ public class UserService {
         UserDomainModel restoredUser = this.userPort.findById(userId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "복구할 사용자를 찾을 수 없습니다."
+                        MessageUtil.USER_NOT_FOUND
                 )
         );
 
@@ -1155,14 +1157,14 @@ public class UserService {
         this.userPort.updateRole(restoredUser.getId(), Role.COMMON).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        MessageUtil.exceptionOccur("user")
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         );
 
         return UserResponseDto.from(this.userPort.updateState(restoredUser.getId(), UserState.ACTIVE).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        MessageUtil.exceptionOccur("user")
+                        MessageUtil.INTERNAL_SERVER_ERROR
                 )
         ));
     }
@@ -1173,7 +1175,7 @@ public class UserService {
         UserDomainModel user = this.userPort.findByRefreshToken(refreshToken).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "RefreshToken 유효성 검증 실패"
+                        MessageUtil.INVALID_TOKEN
                 )
         );
 

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -29,6 +29,7 @@ import net.causw.domain.model.circle.CircleDomainModel;
 import net.causw.domain.model.board.FavoriteBoardDomainModel;
 import net.causw.domain.model.enums.*;
 import net.causw.domain.model.post.PostDomainModel;
+import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
 import net.causw.domain.model.user.UserAdmissionDomainModel;
 import net.causw.domain.model.user.UserDomainModel;
@@ -86,7 +87,7 @@ public class UserService {
         UserDomainModel requestUser = this.userPort.findForPassword(userFindPasswordRequestDto.getEmail(), userFindPasswordRequestDto.getName(), userFindPasswordRequestDto.getStudentId()).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "해당 사용자를 찾을 수 없습니다."
+                        MessageUtil.USER_NOT_FOUND
                 )
         );
         String newPassword = requestUser.updatePassword(this.passwordGenerator.generate());
@@ -94,7 +95,7 @@ public class UserService {
         this.userPort.updatePassword(requestUser.getId(), passwordEncoder.encode(newPassword)).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "User id checked, but exception occurred"
+                        MessageUtil.exceptionOccur("User")
                 )
         );
         return UserResponseDto.from(requestUser);
@@ -106,7 +107,7 @@ public class UserService {
         UserDomainModel requestUser = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -123,7 +124,7 @@ public class UserService {
             if (ownCircles.isEmpty()) {
                 throw new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "해당 동아리장이 배정된 동아리가 없습니다."
+                        MessageUtil.NO_ASSIGNED_CIRCLE_FOR_LEADER
                 );
             }
             boolean isMemberOfAnyCircle = ownCircles.stream()
@@ -149,7 +150,7 @@ public class UserService {
         UserDomainModel requestUser = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -163,7 +164,7 @@ public class UserService {
             if (ownCircles.isEmpty()) {
                 throw new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "해당 동아리장이 배정된 동아리가 없습니다."
+                        MessageUtil.NO_ASSIGNED_CIRCLE_FOR_LEADER
                 );
             }
 
@@ -183,7 +184,7 @@ public class UserService {
         UserDomainModel requestUser = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -210,7 +211,7 @@ public class UserService {
         UserDomainModel requestUser = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -247,7 +248,7 @@ public class UserService {
         UserDomainModel user = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -264,7 +265,7 @@ public class UserService {
             if (ownCircles.isEmpty()) {
                 throw new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "해당 동아리장이 배정된 동아리가 없습니다."
+                        MessageUtil.NO_ASSIGNED_CIRCLE_FOR_LEADER
                 );
             }
 
@@ -297,7 +298,7 @@ public class UserService {
         UserDomainModel user = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -343,7 +344,7 @@ public class UserService {
                             if (ownCircles.isEmpty()) {
                                 throw new InternalServerException(
                                         ErrorCode.INTERNAL_SERVER,
-                                        "해당 동아리장이 배정된 동아리가 없습니다."
+                                        MessageUtil.NO_ASSIGNED_CIRCLE_FOR_LEADER
                                 );
                             }
                             return UserResponseDto.from(
@@ -370,7 +371,7 @@ public class UserService {
         UserDomainModel user = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -388,7 +389,7 @@ public class UserService {
                         if (ownCircles.isEmpty()) {
                             throw new InternalServerException(
                                     ErrorCode.INTERNAL_SERVER,
-                                    "해당 동아리장이 배정된 동아리가 없습니다."
+                                    MessageUtil.NO_ASSIGNED_CIRCLE_FOR_LEADER
                             );
                         }
 
@@ -408,7 +409,7 @@ public class UserService {
         UserDomainModel user = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -544,7 +545,7 @@ public class UserService {
         UserDomainModel userDomainModel = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -582,7 +583,7 @@ public class UserService {
         return UserResponseDto.from(this.userPort.update(loginUserId, userDomainModel).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "User id checked, but exception occurred"
+                        MessageUtil.exceptionOccur("user")
                 )
         ));
     }
@@ -605,7 +606,7 @@ public class UserService {
         UserDomainModel grantor = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
         UserDomainModel grantee = this.userPort.findById(granteeId).orElseThrow(
@@ -640,7 +641,7 @@ public class UserService {
                 circleId = userUpdateRoleRequestDto.getCircleId()
                         .orElseThrow(() -> new BadRequestException(
                                 ErrorCode.INVALID_PARAMETER,
-                                "소모임장을 위임할 소모임 입력이 필요합니다."
+                                MessageUtil.CIRCLE_ID_REQUIRED_FOR_LEADER_DELEGATION
                         ));
             }
             DelegationFactory
@@ -661,7 +662,7 @@ public class UserService {
                         user -> this.userPort.removeRole(user.getId(), Role.VICE_PRESIDENT).orElseThrow(
                                 () -> new InternalServerException(
                                         ErrorCode.INTERNAL_SERVER,
-                                        "User id checked, but exception occurred"
+                                        MessageUtil.exceptionOccur("user")
                                 ))
                 );
             }
@@ -672,7 +673,7 @@ public class UserService {
             String circleId = userUpdateRoleRequestDto.getCircleId()
                     .orElseThrow(() -> new BadRequestException(
                             ErrorCode.INVALID_PARAMETER,
-                            "소모임장을 위임할 소모임 입력이 필요합니다."
+                            MessageUtil.CIRCLE_ID_REQUIRED_FOR_LEADER_DELEGATION
                     ));
             if(grantee.getRole().equals(Role.VICE_PRESIDENT)){
                 throw new UnauthorizedException(
@@ -691,7 +692,7 @@ public class UserService {
                             () -> {
                                 throw new UnauthorizedException(
                                         ErrorCode.NOT_MEMBER,
-                                        "사용자가 가입 신청한 소모임이 아닙니다."
+                                        MessageUtil.USER_NOT_APPLIED_FOR_CIRCLE
                                 );
                             });
 
@@ -709,7 +710,7 @@ public class UserService {
                     }, () -> {
                         throw new BadRequestException(
                                 ErrorCode.ROW_DOES_NOT_EXIST,
-                                "소모임을 찾을 수 없습니다."
+                                MessageUtil.SMALL_CLUB_NOT_FOUND
                         );
                     });
 
@@ -725,7 +726,7 @@ public class UserService {
                 return UserResponseDto.from(this.userPort.removeRole(granteeId, Role.COMMON).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                "User id checked, but exception occurred"
+                                MessageUtil.exceptionOccur("user")
                         )
                 ));
             }
@@ -744,7 +745,7 @@ public class UserService {
             this.userPort.removeRole(previousLeaderAlumni.getId(), Role.LEADER_ALUMNI).orElseThrow(
                     () -> new InternalServerException(
                             ErrorCode.INTERNAL_SERVER,
-                            "User id checked, but exception occurred"
+                            MessageUtil.exceptionOccur("user")
                     )
             );
         }
@@ -755,7 +756,7 @@ public class UserService {
         return UserResponseDto.from(this.userPort.updateRole(granteeId, userUpdateRoleRequestDto.getRole()).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "User id checked, but exception occurred"
+                        MessageUtil.exceptionOccur("user")
                 )
         ));
     }
@@ -768,7 +769,7 @@ public class UserService {
         UserDomainModel user = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -790,7 +791,7 @@ public class UserService {
                 .orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                "User id checked, but exception occurred"
+                                MessageUtil.exceptionOccur("user")
                         )
                 ));
     }
@@ -800,7 +801,7 @@ public class UserService {
         UserDomainModel user = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -828,7 +829,7 @@ public class UserService {
         this.userPort.updateRole(loginUserId, Role.NONE).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "User id checked, but exception occurred"
+                        MessageUtil.exceptionOccur("user")
                 )
         );
 
@@ -841,7 +842,7 @@ public class UserService {
         return UserResponseDto.from(this.userPort.updateState(loginUserId, UserState.INACTIVE).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "User id checked, but exception occurred"
+                        MessageUtil.exceptionOccur("user")
                 )
         ));
     }
@@ -851,7 +852,7 @@ public class UserService {
         UserDomainModel requestUser = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -886,14 +887,14 @@ public class UserService {
         this.userPort.updateRole(userId, Role.NONE).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "User id checked, but exception occurred"
+                        MessageUtil.exceptionOccur("user")
                 )
         );
 
         return UserResponseDto.from(this.userPort.updateState(userId, UserState.DROP).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "User id checked, but exception occurred"
+                        MessageUtil.exceptionOccur("user")
                 )
         ));
     }
@@ -903,7 +904,7 @@ public class UserService {
         UserDomainModel requestUser = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -916,7 +917,7 @@ public class UserService {
         return UserAdmissionResponseDto.from(this.userAdmissionPort.findById(admissionId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "사용자의 가입 신청을 찾을 수 없습니다."
+                        MessageUtil.USER_APPLY_NOT_FOUND
                 )
         ));
     }
@@ -930,7 +931,7 @@ public class UserService {
         UserDomainModel requestUser = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -993,14 +994,14 @@ public class UserService {
         UserDomainModel requestUser = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         UserAdmissionDomainModel userAdmissionDomainModel = this.userAdmissionPort.findById(admissionId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "사용자의 가입 신청을 찾을 수 없습니다."
+                        MessageUtil.USER_APPLY_NOT_FOUND
                 )
         );
 
@@ -1014,7 +1015,7 @@ public class UserService {
         this.userPort.updateRole(userAdmissionDomainModel.getUser().getId(), Role.COMMON).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "User id of the admission checked, but exception occurred"
+                        MessageUtil.ADMISSION_EXCEPTION
                 )
         );
 
@@ -1037,7 +1038,7 @@ public class UserService {
                 this.userPort.updateState(userAdmissionDomainModel.getUser().getId(), UserState.ACTIVE).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                "User id of the admission checked, but exception occurred"
+                                MessageUtil.ADMISSION_EXCEPTION
                         )
                 )
         );
@@ -1051,14 +1052,14 @@ public class UserService {
         UserDomainModel requestUser = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         UserAdmissionDomainModel userAdmissionDomainModel = this.userAdmissionPort.findById(admissionId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "사용자의 가입 신청을 찾을 수 없습니다."
+                        MessageUtil.USER_APPLY_NOT_FOUND
                 )
         );
 
@@ -1085,7 +1086,7 @@ public class UserService {
                 this.userPort.updateState(userAdmissionDomainModel.getUser().getId(), UserState.REJECT).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
-                                "User id of the admission checked, but exception occurred"
+                                MessageUtil.ADMISSION_EXCEPTION
                         )
                 ));
     }
@@ -1098,14 +1099,14 @@ public class UserService {
         UserDomainModel user = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
         BoardDomainModel board = this.boardPort.findById(boardId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "게시판을 찾을 수 없습니다."
+                        MessageUtil.BOARD_NOT_FOUND
                 )
         );
 
@@ -1135,7 +1136,7 @@ public class UserService {
         UserDomainModel requestUser = this.userPort.findById(loginUserId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        "로그인된 사용자를 찾을 수 없습니다."
+                        MessageUtil.LOGIN_USER_NOT_FOUND
                 )
         );
 
@@ -1154,14 +1155,14 @@ public class UserService {
         this.userPort.updateRole(restoredUser.getId(), Role.COMMON).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "User id checked, but exception occurred"
+                        MessageUtil.exceptionOccur("user")
                 )
         );
 
         return UserResponseDto.from(this.userPort.updateState(restoredUser.getId(), UserState.ACTIVE).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
-                        "User id checked, but exception occurred"
+                        MessageUtil.exceptionOccur("user")
                 )
         ));
     }

--- a/src/main/java/net/causw/domain/model/util/MessageUtil.java
+++ b/src/main/java/net/causw/domain/model/util/MessageUtil.java
@@ -3,11 +3,13 @@ package net.causw.domain.model.util;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+// FIXME: 추후 MessageUtil에서 ResponseCode 형식으로 Code와 Message를 동시 관리하도록 수정해야 함
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MessageUtil {
 
     // 400
     public static final String INVALID_PARAMETER = "Invalid action parameter";
+    public static final String INVALID_TOKEN = "RefreshToken 유효성 검증 실패";
 
     // Circle & Post
     public static final String NOT_CIRCLE_LEADER = "사용자가 해당 동아리의 동아리장이 아닙니다.";
@@ -18,6 +20,7 @@ public class MessageUtil {
     public static final String CIRCLE_MEMBER_NOT_FOUND = "동아리를 찾을 수 없습니다.";
     public static final String INQUIRY_NOT_FOUND = "문의글을 찾을 수 없습니다.";
     public static final String POST_NOT_FOUND = "게시글을 찾을 수 없습니다.";
+    public static final String COMMENT_NOT_FOUND = "댓글을 찾을 수 없습니다.";
     public static final String NOTICE_NOT_FOUND = "앱 공지 게시판을 찾을 수 없습니다.";
     public static final String SMALL_CLUB_NOT_FOUND = "소모임을 찾을 수 없습니다.";
     public static final String USER_APPLY_NOT_FOUND = "사용자의 가입 신청을 찾을 수 없습니다.";
@@ -40,8 +43,12 @@ public class MessageUtil {
     public static final String USER_NOT_FOUND = "해당 사용자를 찾을 수 없습니다.";
     public static final String ADMISSION_EXCEPTION = "User id of the admission checked, but exception occurred";
     public static final String NO_ASSIGNED_CIRCLE_FOR_LEADER = "해당 동아리장이 배정된 동아리가 없습니다.";
-    public static final String NO_ASSIGNED_CIRCLE_FOR_MEMBER = "해당 동아리원이 배정된 동아리가 없습니다.";
     public static final String CIRCLE_ID_REQUIRED_FOR_LEADER_DELEGATION = "소모임장을 위임할 소모임 입력이 필요합니다.";
+    public static final String EMAIL_ALREADY_EXIST = "이미 존재하는 이메일입니다.";
+    public static final String EMAIL_INVALID = "잘못된 이메일입니다.";
+    public static final String USER_ALREADY_APPLY = "이미 신청한 사용자 입니다.";
+    public static final String NO_APPLICATION = "신청서를 작성하지 않았습니다.";
+    public static final String CONCURRENT_JOB_IMPOSSIBLE = "부회장은 동아리장 겸직이 불가합니다.";
 
     // Flag
     public static final String FLAG_UPDATE_FAILED = "플래그 업데이트에 실패했습니다.";

--- a/src/main/java/net/causw/domain/model/util/MessageUtil.java
+++ b/src/main/java/net/causw/domain/model/util/MessageUtil.java
@@ -6,17 +6,34 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MessageUtil {
 
+    // Circle & Post
     public static final String NOT_CIRCLE_LEADER = "사용자가 해당 동아리의 동아리장이 아닙니다.";
     public static final String NOT_CIRCLE_MEMBER = "로그인된 사용자가 동아리 멤버가 아닙니다.";
     public static final String LOGIN_USER_NOT_FOUND = "로그인된 사용자를 찾을 수 없습니다.";
-    public static final String RESTORE_BOARD_NOT_FOUND = "복구할 게시판을 찾을 수 없습니다.";
-    public static final String DELETE_BOARD_NOT_FOUND = "삭제할 게시판을 찾을 수 없습니다.";
-    public static final String UPDATE_BOARD_NOT_FOUND = "수정할 게시판을 찾을 수 없습니다.";
     public static final String BOARD_NOT_FOUND = "게시판을 찾을 수 없습니다.";
-    public static final String CIRCLE_NOT_FOUND = "동아리를 찾을 수 없습니다.";
     public static final String INQUIRY_NOT_FOUND = "문의글을 찾을 수 없습니다.";
-    public static final String POST_NOT_FOUND = "게시판을 찾을 수 없습니다.";
+    public static final String POST_NOT_FOUND = "게시글을 찾을 수 없습니다.";
     public static final String NOTICE_NOT_FOUND = "앱 공지 게시판을 찾을 수 없습니다.";
+    public static final String SMALL_CLUB_NOT_FOUND = "소모임을 찾을 수 없습니다.";
+    public static final String USER_APPLY_NOT_FOUND = "사용자의 가입 신청을 찾을 수 없습니다.";
+    public static final String CIRCLE_WITHOUT_LEADER = "The board has circle without circle leader";
+    public static final String CIRCLE_APPLY_INVALID = "로그인된 사용자가 가입 신청한 소모임이 아닙니다.";
+    public static final String CIRCLE_DUPLICATE_NAME = "중복된 소모임 이름입니다.";
+
+    // Locker
+    public static final String LOCKER_WRONG_POSITION = "등록된 사물함 위치가 아닙니다.";
+    public static final String LOCKER_FIRST_CREATED = "사물함 최초 생성";
+    public static final String LOCKER_NOT_FOUND = "사물함을 찾을 수 없습니다.";
+    public static final String LOCKER_DUPLICATE_NUMBER = "중복된 사물함 번호입니다.";
+    public static final String LOCKER_ALREADY_REGISTERED = "이미 등록된 사물함 위치입니다.";
+    public static final String LOCKER_ALREADY_EXIST = "사물함 위치에 사물함이 존재합니다.";
+
+    // User
+    public static final String USER_NOT_FOUND = "해당 사용자를 찾을 수 없습니다.";
+    public static final String ADMISSION_EXCEPTION = "User id of the admission checked, but exception occurred";
+    public static final String NO_ASSIGNED_CIRCLE_FOR_LEADER = "해당 동아리장이 배정된 동아리가 없습니다.";
+    public static final String CIRCLE_ID_REQUIRED_FOR_LEADER_DELEGATION = "소모임장을 위임할 소모임 입력이 필요합니다.";
+    public static final String USER_NOT_APPLIED_FOR_CIRCLE = "사용자가 가입 신청한 소모임이 아닙니다.";
 
     public static String exceptionOccur(String target) {
         return target + " id checked, but exception occurred";

--- a/src/main/java/net/causw/domain/model/util/MessageUtil.java
+++ b/src/main/java/net/causw/domain/model/util/MessageUtil.java
@@ -1,0 +1,24 @@
+package net.causw.domain.model.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MessageUtil {
+
+    public static final String NOT_CIRCLE_LEADER = "사용자가 해당 동아리의 동아리장이 아닙니다.";
+    public static final String NOT_CIRCLE_MEMBER = "로그인된 사용자가 동아리 멤버가 아닙니다.";
+    public static final String LOGIN_USER_NOT_FOUND = "로그인된 사용자를 찾을 수 없습니다.";
+    public static final String RESTORE_BOARD_NOT_FOUND = "복구할 게시판을 찾을 수 없습니다.";
+    public static final String DELETE_BOARD_NOT_FOUND = "삭제할 게시판을 찾을 수 없습니다.";
+    public static final String UPDATE_BOARD_NOT_FOUND = "수정할 게시판을 찾을 수 없습니다.";
+    public static final String BOARD_NOT_FOUND = "게시판을 찾을 수 없습니다.";
+    public static final String CIRCLE_NOT_FOUND = "동아리를 찾을 수 없습니다.";
+    public static final String INQUIRY_NOT_FOUND = "문의글을 찾을 수 없습니다.";
+    public static final String POST_NOT_FOUND = "게시판을 찾을 수 없습니다.";
+    public static final String NOTICE_NOT_FOUND = "앱 공지 게시판을 찾을 수 없습니다.";
+
+    public static String exceptionOccur(String target) {
+        return target + " id checked, but exception occurred";
+    }
+}

--- a/src/main/java/net/causw/domain/model/util/MessageUtil.java
+++ b/src/main/java/net/causw/domain/model/util/MessageUtil.java
@@ -6,18 +6,23 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MessageUtil {
 
+    // 400
+    public static final String INVALID_PARAMETER = "Invalid action parameter";
+
     // Circle & Post
     public static final String NOT_CIRCLE_LEADER = "사용자가 해당 동아리의 동아리장이 아닙니다.";
     public static final String NOT_CIRCLE_MEMBER = "로그인된 사용자가 동아리 멤버가 아닙니다.";
     public static final String LOGIN_USER_NOT_FOUND = "로그인된 사용자를 찾을 수 없습니다.";
     public static final String BOARD_NOT_FOUND = "게시판을 찾을 수 없습니다.";
+    public static final String CIRCLE_LEADER_NOR_FOUND = "해당 동아리의 동아리장을 찾을 수 없습니다.";
+    public static final String CIRCLE_MEMBER_NOT_FOUND = "동아리를 찾을 수 없습니다.";
     public static final String INQUIRY_NOT_FOUND = "문의글을 찾을 수 없습니다.";
     public static final String POST_NOT_FOUND = "게시글을 찾을 수 없습니다.";
     public static final String NOTICE_NOT_FOUND = "앱 공지 게시판을 찾을 수 없습니다.";
     public static final String SMALL_CLUB_NOT_FOUND = "소모임을 찾을 수 없습니다.";
     public static final String USER_APPLY_NOT_FOUND = "사용자의 가입 신청을 찾을 수 없습니다.";
     public static final String CIRCLE_WITHOUT_LEADER = "The board has circle without circle leader";
-    public static final String CIRCLE_APPLY_INVALID = "로그인된 사용자가 가입 신청한 소모임이 아닙니다.";
+    public static final String CIRCLE_APPLY_INVALID = "사용자가 가입 신청한 소모임이 아닙니다.";
     public static final String CIRCLE_DUPLICATE_NAME = "중복된 소모임 이름입니다.";
 
     // Locker
@@ -27,15 +32,21 @@ public class MessageUtil {
     public static final String LOCKER_DUPLICATE_NUMBER = "중복된 사물함 번호입니다.";
     public static final String LOCKER_ALREADY_REGISTERED = "이미 등록된 사물함 위치입니다.";
     public static final String LOCKER_ALREADY_EXIST = "사물함 위치에 사물함이 존재합니다.";
+    public static final String LOCKER_RETURN_TIME_NOT_SET = "사물함 반납 시간이 설정되지 않았습니다.";
+    public static final String LOCKER_UNUSED = "사용 중인 사물함이 아닙니다.";
+    public static final String LOCKER_DELETED = "사물함 삭제";
 
     // User
     public static final String USER_NOT_FOUND = "해당 사용자를 찾을 수 없습니다.";
     public static final String ADMISSION_EXCEPTION = "User id of the admission checked, but exception occurred";
     public static final String NO_ASSIGNED_CIRCLE_FOR_LEADER = "해당 동아리장이 배정된 동아리가 없습니다.";
+    public static final String NO_ASSIGNED_CIRCLE_FOR_MEMBER = "해당 동아리원이 배정된 동아리가 없습니다.";
     public static final String CIRCLE_ID_REQUIRED_FOR_LEADER_DELEGATION = "소모임장을 위임할 소모임 입력이 필요합니다.";
-    public static final String USER_NOT_APPLIED_FOR_CIRCLE = "사용자가 가입 신청한 소모임이 아닙니다.";
 
-    public static String exceptionOccur(String target) {
-        return target + " id checked, but exception occurred";
-    }
+    // Flag
+    public static final String FLAG_UPDATE_FAILED = "플래그 업데이트에 실패했습니다.";
+    public static final String FLAG_ALREADY_EXIST = "이미 존재하는 플래그 입니다.";
+
+    // 500
+    public static final String INTERNAL_SERVER_ERROR = "Internal Server Error";
 }


### PR DESCRIPTION
### 🚩 관련사항
#538

### 📢 전달사항
중복되는 하드코딩 문자열을 MessageUtil을 통해 중앙 통제하고자 합니다.

### 📸 스크린샷
<img width="853" alt="image" src="https://github.com/CAUCSE/CAUSW_backend/assets/53044069/fcea39d1-6630-4989-a9ab-e1f4cf292a42">


### 📃 진행사항
- [x] MessageUtil에 중복 문자열 삽입
- [x] 삽입된 상수 문자열을 기반으로 기존 Service 하드코딩 문자열 대체
- [x] 접두사가 존재하는 에러 메시지 문자열에 대한 협의 및 접두사 제거
- [x] but exception occured 문자열 INTERNER_SERVER_ERROR로 변경
- [x] 1개만 존재하는 하드코딩 문자열이라도 MessageUtil에 저장

### ⚙️ 기타사항
"id checked, but exception occured" 예외처리 문자열 앞에 해당 domain명이 붙는 게 필수적인지 의문이 있습니다!
일단은 MessageUtil에서 매개변수로 받아 해당 문자열을 반환하는 것으로 처리했습니다.

중복 제거가 목적이기에, 하드코딩된 문자열이 1개거나 하나의 파일에만 존재해 확장성이 없는 경우는 제외했습니다.
하드코딩된 또다른 문자열인 "LEADER_CIRCLE"의 경우 Role 구조 개편을 앞두고 있기에 보류했습니다.

주요 Service의 하드코딩된 한글 에러메시지에 "삭제할, 수정할" + "OO가 없습니다" 등의 추가 접두사가 붙어 상수 문자열을 활용할 수가 없는데,해당 메시지에서 데이터의 용도보다는 존재 여부가 더 가치있는 정보이기에 접두사가 존재하는 문장들을 모두 수정하고 단일화된 상수 문자열로 대체할 것을 건의합니다. 하드코딩된 문자열은 최대한 지양하는 것이 바람직하다고 생각합니다.

개발기간: 1주