### PR TITLE
fix : 댓글 및 대댓글 기능 개선

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/port/comment/ChildCommentPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/comment/ChildCommentPortImpl.java
@@ -3,11 +3,9 @@ package net.causw.adapter.persistence.port.comment;
 import net.causw.adapter.persistence.comment.ChildComment;
 import net.causw.adapter.persistence.port.mapper.DomainModelMapper;
 import net.causw.adapter.persistence.repository.ChildCommentRepository;
-import net.causw.adapter.persistence.page.PageableFactory;
 import net.causw.application.spi.ChildCommentPort;
 import net.causw.domain.model.comment.ChildCommentDomainModel;
 import net.causw.domain.model.post.PostDomainModel;
-import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
@@ -15,27 +13,16 @@ import java.util.Optional;
 @Component
 public class ChildCommentPortImpl extends DomainModelMapper implements ChildCommentPort {
     private final ChildCommentRepository childCommentRepository;
-    private final PageableFactory pageableFactory;
 
     public ChildCommentPortImpl(
-            ChildCommentRepository childCommentRepository,
-            PageableFactory pageableFactory
+            ChildCommentRepository childCommentRepository
     ) {
         this.childCommentRepository = childCommentRepository;
-        this.pageableFactory = pageableFactory;
     }
 
     @Override
     public Optional<ChildCommentDomainModel> findById(String id) {
         return this.childCommentRepository.findById(id).map(this::entityToDomainModel);
-    }
-
-    @Override
-    public Page<ChildCommentDomainModel> findByParentComment(String parentCommentId, Integer pageNum) {
-        Page<ChildComment> childComments = this.childCommentRepository.findByParentComment_IdOrderByCreatedAtAsc(parentCommentId, this.pageableFactory.create(pageNum));
-
-        return childComments
-                .map(this::entityToDomainModel);
     }
 
     @Override

--- a/src/main/java/net/causw/adapter/persistence/port/comment/CommentPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/comment/CommentPortImpl.java
@@ -2,6 +2,7 @@ package net.causw.adapter.persistence.port.comment;
 
 import net.causw.adapter.persistence.comment.Comment;
 import net.causw.adapter.persistence.port.mapper.DomainModelMapper;
+import net.causw.adapter.persistence.repository.ChildCommentRepository;
 import net.causw.adapter.persistence.repository.CommentRepository;
 import net.causw.adapter.persistence.page.PageableFactory;
 import net.causw.application.spi.CommentPort;
@@ -12,17 +13,20 @@ import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Component
 public class CommentPortImpl extends DomainModelMapper implements CommentPort {
     private final CommentRepository commentRepository;
+    private final ChildCommentRepository childCommentRepository;
     private final PageableFactory pageableFactory;
 
     public CommentPortImpl(
-            CommentRepository commentRepository,
+            CommentRepository commentRepository, ChildCommentRepository childCommentRepository,
             PageableFactory pageableFactory
     ) {
         this.commentRepository = commentRepository;
+        this.childCommentRepository = childCommentRepository;
         this.pageableFactory = pageableFactory;
     }
 
@@ -33,10 +37,20 @@ public class CommentPortImpl extends DomainModelMapper implements CommentPort {
 
     @Override
     public Page<CommentDomainModel> findByPostId(String postId, Integer pageNum) {
-        return this.commentRepository.findByPost_IdOrderByCreatedAt(
+        Page<CommentDomainModel> commentDomainModels = this.commentRepository.findByPost_IdOrderByCreatedAt(
                 postId,
                 this.pageableFactory.create(pageNum, StaticValue.DEFAULT_COMMENT_PAGE_SIZE)
         ).map(this::entityToDomainModel);
+
+        for (CommentDomainModel commentDomainModel : commentDomainModels) {
+            commentDomainModel.setChildCommentList(
+                    this.childCommentRepository.findByParentComment_Id(commentDomainModel.getId()).stream()
+                            .map(this::entityToDomainModel)
+                            .collect(Collectors.toList())
+            );
+        }
+
+        return commentDomainModels;
     }
 
     @Override

--- a/src/main/java/net/causw/adapter/persistence/port/comment/CommentPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/comment/CommentPortImpl.java
@@ -54,11 +54,6 @@ public class CommentPortImpl extends DomainModelMapper implements CommentPort {
     }
 
     @Override
-    public Long countByPostId(String postId) {
-        return this.commentRepository.countByPost_IdAndIsDeletedIsFalse(postId);
-    }
-
-    @Override
     public CommentDomainModel create(CommentDomainModel commentDomainModel, PostDomainModel postDomainModel) {
         return this.entityToDomainModel(this.commentRepository.save(Comment.from(commentDomainModel, postDomainModel)));
     }

--- a/src/main/java/net/causw/adapter/persistence/port/post/PostPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/post/PostPortImpl.java
@@ -30,6 +30,11 @@ public class PostPortImpl extends DomainModelMapper implements PostPort {
     }
 
     @Override
+    public Long countAllComment(String postId) {
+        return this.postRepository.countAllCommentByPost_Id(postId);
+    }
+
+    @Override
     public PostDomainModel createPost(PostDomainModel postDomainModel) {
         return this.entityToDomainModel(this.postRepository.save(Post.from(postDomainModel)));
     }

--- a/src/main/java/net/causw/adapter/persistence/repository/ChildCommentRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/ChildCommentRepository.java
@@ -4,11 +4,19 @@ import net.causw.adapter.persistence.comment.ChildComment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ChildCommentRepository extends JpaRepository<ChildComment, String> {
     Page<ChildComment> findByParentComment_IdOrderByCreatedAtAsc(String parentCommentId, Pageable pageable);
 
     Long countByParentComment_IdAndIsDeletedIsFalse(String parentCommentId);
+
+    @Query("select c from ChildComment c where c.parentComment.id = :parentCommentId")
+    List<ChildComment> findByParentComment_Id(@Param("parentCommentId") String parentCommentId);
+
 }

--- a/src/main/java/net/causw/adapter/persistence/repository/CommentRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/CommentRepository.java
@@ -12,8 +12,6 @@ import org.springframework.stereotype.Repository;
 public interface CommentRepository extends JpaRepository<Comment, String> {
     Page<Comment> findByPost_IdOrderByCreatedAt(String postId, Pageable pageable);
 
-    Long countByPost_IdAndIsDeletedIsFalse(String postId);
-
     @Query(value = "select * from tb_comment as co " +
             "join tb_post as p on co.post_id = p.id " +
             "join tb_board as b on p.board_id = b.id " +

--- a/src/main/java/net/causw/adapter/persistence/repository/PostRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/PostRepository.java
@@ -39,4 +39,14 @@ public interface PostRepository extends JpaRepository<Post, String> {
             "AND (c.id is NULL " +
             "OR (cm.status = 'MEMBER' AND c.is_deleted = false)) ORDER BY p.created_at DESC", nativeQuery = true)
     Page<Post> findByUserId(@Param("user_id") String userId, Pageable pageable);
+
+    // 게시물에 작성된 모든 댓글(댓글+대댓글)의 수 세기
+    @Query(value = "select count(distinct c.id) + count(distinct cc.id) - count(distinct case when c.is_deleted = true and not cc.is_deleted is null then c.id end)" +
+            "from tb_post as p " +
+            "join tb_comment as c on p.id = c.post_id " +
+            "left join tb_child_comment as cc on c.id = cc.parent_comment_id " +
+            "where p.id = :postId and p.is_deleted = false " +
+            "and not (c.is_deleted = true and cc.is_deleted is null)" +
+            "and (cc.is_deleted = false or cc.is_deleted is null)", nativeQuery = true)
+    Long countAllCommentByPost_Id(@Param("postId") String postId);
 }

--- a/src/main/java/net/causw/adapter/persistence/repository/PostRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/PostRepository.java
@@ -41,12 +41,12 @@ public interface PostRepository extends JpaRepository<Post, String> {
     Page<Post> findByUserId(@Param("user_id") String userId, Pageable pageable);
 
     // 게시물에 작성된 모든 댓글(댓글+대댓글)의 수 세기
-    @Query(value = "select count(distinct c.id) + count(distinct cc.id) - count(distinct case when c.is_deleted = true and not cc.is_deleted is null then c.id end)" +
-            "from tb_post as p " +
-            "join tb_comment as c on p.id = c.post_id " +
-            "left join tb_child_comment as cc on c.id = cc.parent_comment_id " +
-            "where p.id = :postId and p.is_deleted = false " +
-            "and not (c.is_deleted = true and cc.is_deleted is null)" +
-            "and (cc.is_deleted = false or cc.is_deleted is null)", nativeQuery = true)
+    @Query(value = "SELECT COUNT(DISTINCT c.id) + COUNT(DISTINCT cc.id) - COUNT(DISTINCT CASE WHEN c.is_deleted = true AND NOT cc.is_deleted IS NULL THEN c.id END)" +
+            "FROM tb_post AS p " +
+            "JOIN tb_comment AS c ON p.id = c.post_id " +
+            "LEFT JOIN tb_child_comment AS cc ON c.id = cc.parent_comment_id " +
+            "WHERE p.id = :postId AND p.is_deleted = false " +
+            "AND NOT (c.is_deleted = true AND cc.is_deleted IS NULL)" +
+            "AND (cc.is_deleted = false OR cc.is_deleted IS NULL)", nativeQuery = true)
     Long countAllCommentByPost_Id(@Param("postId") String postId);
 }

--- a/src/main/java/net/causw/adapter/web/ChildCommentController.java
+++ b/src/main/java/net/causw/adapter/web/ChildCommentController.java
@@ -64,39 +64,6 @@ public class ChildCommentController {
         return this.childCommentService.createChildComment(loginUserId, childCommentCreateRequestDto);
     }
 
-    @GetMapping(params = "parentCommentId")
-    @ResponseStatus(value = HttpStatus.OK)
-    @ApiOperation(value = "대댓글 조회 API(완료)")
-    @ApiResponses({
-            @ApiResponse(code = 201, message = "Created", response = String.class),
-            @ApiResponse(code = 4000, message = "로그인된 사용자를 찾을 수 없습니다.", response = BadRequestException.class),
-            @ApiResponse(code = 4000, message = "게시글을 찾을 수 없습니다.", response = BadRequestException.class),
-            @ApiResponse(code = 4000, message = "상위 댓글을 찾을 수 없습니다.", response = BadRequestException.class),
-            @ApiResponse(code = 4004, message = "삭제된 게시판입니다.", response = BadRequestException.class),
-            @ApiResponse(code = 4004, message = "삭제된 게시글입니다.", response = BadRequestException.class),
-            @ApiResponse(code = 4004, message = "삭제된 답글입니다.", response = BadRequestException.class),
-            @ApiResponse(code = 4102, message = "추방된 사용자 입니다.", response = UnauthorizedException.class),
-            @ApiResponse(code = 4103, message = "비활성화된 사용자 입니다.", response = UnauthorizedException.class),
-            @ApiResponse(code = 4104, message = "대기 중인 사용자 입니다.", response = UnauthorizedException.class),
-            @ApiResponse(code = 4102, message = "동아리에서 추방된 사용자 입니다.", response = UnauthorizedException.class),
-            @ApiResponse(code = 4102, message = "동아리 가입 거절된 사용자 입니다.", response = UnauthorizedException.class),
-            @ApiResponse(code = 4008, message = "동아리 가입 대기 중인 사용자 입니다.", response = BadRequestException.class),
-            @ApiResponse(code = 4006, message = "동아리를 떠난 사용자 입니다.", response = BadRequestException.class),
-            @ApiResponse(code = 4001, message = "이미 동아리에 가입한 사용자 입니다.", response = BadRequestException.class),
-            @ApiResponse(code = 4108, message = "로그인된 사용자가 가입 신청한 소모임이 아닙니다.", response = UnauthorizedException.class),
-            @ApiResponse(code = 4109, message = "가입이 거절된 사용자 입니다.", response = UnauthorizedException.class),
-            @ApiResponse(code = 4012, message = "접근 권한이 없습니다. 다시 로그인 해주세요. 문제 반복시 관리자에게 문의해주세요.", response = BadRequestException.class),
-            @ApiResponse(code = 4004, message = "삭제된 동아리입니다.", response = BadRequestException.class),
-    })
-    public ChildCommentsResponseDto findAllChildComments(
-            @RequestParam String parentCommentId,
-            @RequestParam(defaultValue = "0") Integer pageNum
-    ) {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String loginUserId = ((String) principal);
-        return this.childCommentService.findAllChildComments(loginUserId, parentCommentId, pageNum);
-    }
-
     @PutMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.OK)
     @ApiOperation(value = "대댓글 수정 API")

--- a/src/main/java/net/causw/application/circle/CircleService.java
+++ b/src/main/java/net/causw/application/circle/CircleService.java
@@ -172,7 +172,7 @@ public class CircleService {
                                         boardDomainModel,
                                         userDomainModel.getRole(),
                                         postDomainModel,
-                                        this.commentPort.countByPostId(postDomainModel.getId())
+                                        this.postPort.countAllComment(postDomainModel.getId())
                                 )
                         ).orElse(
                                 BoardOfCircleResponseDto.from(

--- a/src/main/java/net/causw/application/comment/CommentService.java
+++ b/src/main/java/net/causw/application/comment/CommentService.java
@@ -5,11 +5,7 @@ import net.causw.application.dto.comment.ChildCommentResponseDto;
 import net.causw.application.dto.comment.CommentCreateRequestDto;
 import net.causw.application.dto.comment.CommentResponseDto;
 import net.causw.application.dto.comment.CommentUpdateRequestDto;
-import net.causw.application.spi.ChildCommentPort;
-import net.causw.application.spi.CircleMemberPort;
-import net.causw.application.spi.CommentPort;
-import net.causw.application.spi.PostPort;
-import net.causw.application.spi.UserPort;
+import net.causw.application.spi.*;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
@@ -111,7 +107,11 @@ public class CommentService {
                 postDomainModel.getBoard(),
                 this.childCommentPort.countByParentComment(commentDomainModel.getId()),
                 commentDomainModel.getChildCommentList().stream()
-                        .map(ChildCommentResponseDto::new)
+                        .map(childCommentDomainModel -> ChildCommentResponseDto.from(
+                                childCommentDomainModel,
+                                creatorDomainModel,
+                                postDomainModel.getBoard()
+                        ))
                         .collect(Collectors.toList())
         );
     }
@@ -174,7 +174,11 @@ public class CommentService {
                                 postDomainModel.getBoard(),
                                 this.childCommentPort.countByParentComment(commentDomainModel.getId()),
                                 commentDomainModel.getChildCommentList().stream()
-                                        .map(ChildCommentResponseDto::new)
+                                        .map(childCommentDomainModel -> ChildCommentResponseDto.from(
+                                                childCommentDomainModel,
+                                                userDomainModel,
+                                                postDomainModel.getBoard()
+                                        ))
                                         .collect(Collectors.toList())
                         )
                 );
@@ -264,7 +268,11 @@ public class CommentService {
                 postDomainModel.getBoard(),
                 this.childCommentPort.countByParentComment(commentId),
                 commentDomainModel.getChildCommentList().stream()
-                        .map(ChildCommentResponseDto::new)
+                        .map(childCommentDomainModel -> ChildCommentResponseDto.from(
+                                childCommentDomainModel,
+                                requestUser,
+                                postDomainModel.getBoard()
+                        ))
                         .collect(Collectors.toList())
         );
     }
@@ -362,7 +370,11 @@ public class CommentService {
                 postDomainModel.getBoard(),
                 this.childCommentPort.countByParentComment(commentId),
                 commentDomainModel.getChildCommentList().stream()
-                        .map(ChildCommentResponseDto::new)
+                        .map(childCommentDomainModel -> ChildCommentResponseDto.from(
+                                childCommentDomainModel,
+                                deleterDomainModel,
+                                postDomainModel.getBoard()
+                        ))
                         .collect(Collectors.toList())
         );
     }

--- a/src/main/java/net/causw/application/comment/CommentService.java
+++ b/src/main/java/net/causw/application/comment/CommentService.java
@@ -1,6 +1,7 @@
 package net.causw.application.comment;
 
 import lombok.RequiredArgsConstructor;
+import net.causw.application.dto.comment.ChildCommentResponseDto;
 import net.causw.application.dto.comment.CommentCreateRequestDto;
 import net.causw.application.dto.comment.CommentResponseDto;
 import net.causw.application.dto.comment.CommentUpdateRequestDto;
@@ -34,6 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.validation.Validator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -107,7 +109,10 @@ public class CommentService {
                 this.commentPort.create(commentDomainModel, postDomainModel),
                 creatorDomainModel,
                 postDomainModel.getBoard(),
-                this.childCommentPort.countByParentComment(commentDomainModel.getId())
+                this.childCommentPort.countByParentComment(commentDomainModel.getId()),
+                commentDomainModel.getChildCommentList().stream()
+                        .map(ChildCommentResponseDto::new)
+                        .collect(Collectors.toList())
         );
     }
 
@@ -167,7 +172,10 @@ public class CommentService {
                                 commentDomainModel,
                                 userDomainModel,
                                 postDomainModel.getBoard(),
-                                this.childCommentPort.countByParentComment(commentDomainModel.getId())
+                                this.childCommentPort.countByParentComment(commentDomainModel.getId()),
+                                commentDomainModel.getChildCommentList().stream()
+                                        .map(ChildCommentResponseDto::new)
+                                        .collect(Collectors.toList())
                         )
                 );
     }
@@ -254,7 +262,10 @@ public class CommentService {
                 ),
                 requestUser,
                 postDomainModel.getBoard(),
-                this.childCommentPort.countByParentComment(commentId)
+                this.childCommentPort.countByParentComment(commentId),
+                commentDomainModel.getChildCommentList().stream()
+                        .map(ChildCommentResponseDto::new)
+                        .collect(Collectors.toList())
         );
     }
 
@@ -349,7 +360,10 @@ public class CommentService {
                 ),
                 deleterDomainModel,
                 postDomainModel.getBoard(),
-                this.childCommentPort.countByParentComment(commentId)
+                this.childCommentPort.countByParentComment(commentId),
+                commentDomainModel.getChildCommentList().stream()
+                        .map(ChildCommentResponseDto::new)
+                        .collect(Collectors.toList())
         );
     }
 }

--- a/src/main/java/net/causw/application/dto/comment/ChildCommentResponseDto.java
+++ b/src/main/java/net/causw/application/dto/comment/ChildCommentResponseDto.java
@@ -104,19 +104,4 @@ public class ChildCommentResponseDto {
                 deletable
         );
     }
-
-    public ChildCommentResponseDto(ChildCommentDomainModel domainModel) {
-        UserDomainModel writer = domainModel.getWriter();
-
-        this.id = domainModel.getId();
-        this.content = domainModel.getContent();
-        this.createdAt = domainModel.getCreatedAt();
-        this.updatedAt = domainModel.getUpdatedAt();
-        this.isDeleted = domainModel.getIsDeleted();
-        this.tagUserName = domainModel.getTagUserName();
-        this.refChildComment = domainModel.getRefChildComment();
-        this.writerName = writer.getName();
-        this.writerAdmissionYear = writer.getAdmissionYear();
-        this.writerProfileImage = writer.getProfileImage();
-    }
 }

--- a/src/main/java/net/causw/application/dto/comment/ChildCommentResponseDto.java
+++ b/src/main/java/net/causw/application/dto/comment/ChildCommentResponseDto.java
@@ -25,7 +25,6 @@ public class ChildCommentResponseDto {
     private String writerProfileImage;
     private Boolean updatable;
     private Boolean deletable;
-    private String parentCommentId;
 
     private ChildCommentResponseDto(
             String id,
@@ -39,8 +38,7 @@ public class ChildCommentResponseDto {
             Integer writerAdmissionYear,
             String writerProfileImage,
             Boolean updatable,
-            Boolean deletable,
-            String parentCommentId
+            Boolean deletable
     ) {
         this.id = id;
         this.content = content;
@@ -54,7 +52,6 @@ public class ChildCommentResponseDto {
         this.writerProfileImage = writerProfileImage;
         this.updatable = updatable;
         this.deletable = deletable;
-        this.parentCommentId = parentCommentId;
     }
 
     public static ChildCommentResponseDto from(
@@ -104,8 +101,22 @@ public class ChildCommentResponseDto {
                 comment.getWriter().getAdmissionYear(),
                 comment.getWriter().getProfileImage(),
                 updatable,
-                deletable,
-                comment.getParentComment().getId()
+                deletable
         );
+    }
+
+    public ChildCommentResponseDto(ChildCommentDomainModel domainModel) {
+        UserDomainModel writer = domainModel.getWriter();
+
+        this.id = domainModel.getId();
+        this.content = domainModel.getContent();
+        this.createdAt = domainModel.getCreatedAt();
+        this.updatedAt = domainModel.getUpdatedAt();
+        this.isDeleted = domainModel.getIsDeleted();
+        this.tagUserName = domainModel.getTagUserName();
+        this.refChildComment = domainModel.getRefChildComment();
+        this.writerName = writer.getName();
+        this.writerAdmissionYear = writer.getAdmissionYear();
+        this.writerProfileImage = writer.getProfileImage();
     }
 }

--- a/src/main/java/net/causw/application/dto/comment/CommentResponseDto.java
+++ b/src/main/java/net/causw/application/dto/comment/CommentResponseDto.java
@@ -9,6 +9,7 @@ import net.causw.domain.model.util.StaticValue;
 import net.causw.domain.model.user.UserDomainModel;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
@@ -25,6 +26,7 @@ public class CommentResponseDto {
     private Boolean updatable;
     private Boolean deletable;
     private Long numChildComment;
+    private List<ChildCommentResponseDto> childCommentList;
 
     private CommentResponseDto(
             String id,
@@ -38,7 +40,8 @@ public class CommentResponseDto {
             String writerProfileImage,
             Boolean updatable,
             Boolean deletable,
-            Long numChildComment
+            Long numChildComment,
+            List<ChildCommentResponseDto> childCommentList
     ) {
         this.id = id;
         this.content = content;
@@ -52,13 +55,15 @@ public class CommentResponseDto {
         this.updatable = updatable;
         this.deletable = deletable;
         this.numChildComment = numChildComment;
+        this.childCommentList = childCommentList;
     }
 
     public static CommentResponseDto from(
             CommentDomainModel comment,
             UserDomainModel user,
             BoardDomainModel board,
-            Long numChildComment
+            Long numChildComment,
+            List<ChildCommentResponseDto> childCommentList
     ) {
         boolean updatable = false;
         boolean deletable = false;
@@ -102,7 +107,8 @@ public class CommentResponseDto {
                 comment.getWriter().getProfileImage(),
                 updatable,
                 deletable,
-                numChildComment
+                numChildComment,
+                childCommentList
         );
     }
 }

--- a/src/main/java/net/causw/application/homepage/HomePageService.java
+++ b/src/main/java/net/causw/application/homepage/HomePageService.java
@@ -61,7 +61,7 @@ public class HomePageService {
                                 StaticValue.HOME_POST_PAGE_SIZE
                         ).map(postDomainModel -> PostsResponseDto.from(
                                 postDomainModel,
-                                this.commentPort.countByPostId(postDomainModel.getId())
+                                this.postPort.countAllComment(postDomainModel.getId())
                         )))
                 )
                 .collect(Collectors.toList());

--- a/src/main/java/net/causw/application/post/PostService.java
+++ b/src/main/java/net/causw/application/post/PostService.java
@@ -115,7 +115,11 @@ public class PostService {
                                         postDomainModel.getBoard(),
                                         this.childCommentPort.countByParentComment(commentDomainModel.getId()),
                                         commentDomainModel.getChildCommentList().stream()
-                                                .map(ChildCommentResponseDto::new)
+                                                .map(childCommentDomainModel -> ChildCommentResponseDto.from(
+                                                        childCommentDomainModel,
+                                                        userDomainModel,
+                                                        postDomainModel.getBoard()
+                                                ))
                                                 .collect(Collectors.toList())
                                 )
                         ),
@@ -617,7 +621,11 @@ public class PostService {
                                 updatedPostDomainModel.getBoard(),
                                 this.childCommentPort.countByParentComment(commentDomainModel.getId()),
                                 commentDomainModel.getChildCommentList().stream()
-                                        .map(ChildCommentResponseDto::new)
+                                        .map(childCommentDomainModel -> ChildCommentResponseDto.from(
+                                                childCommentDomainModel,
+                                                updaterDomainModel,
+                                                postDomainModel.getBoard()
+                                        ))
                                         .collect(Collectors.toList())
                         )),
                 this.postPort.countAllComment(postId)
@@ -731,7 +739,11 @@ public class PostService {
                                 restoredPostDomainModel.getBoard(),
                                 this.childCommentPort.countByParentComment(commentDomainModel.getId()),
                                 commentDomainModel.getChildCommentList().stream()
-                                        .map(ChildCommentResponseDto::new)
+                                        .map(childCommentDomainModel -> ChildCommentResponseDto.from(
+                                                childCommentDomainModel,
+                                                restorerDomainModel,
+                                                postDomainModel.getBoard()
+                                        ))
                                         .collect(Collectors.toList())
                         )),
                 this.postPort.countAllComment(postId)

--- a/src/main/java/net/causw/application/post/PostService.java
+++ b/src/main/java/net/causw/application/post/PostService.java
@@ -119,7 +119,8 @@ public class PostService {
                                                 .collect(Collectors.toList())
                                 )
                         ),
-                this.commentPort.countByPostId(postDomainModel.getId())
+//                this.commentPort.countByPostId(postDomainModel.getId())
+                this.postPort.countAllComment(postId)
         );
     }
 
@@ -191,7 +192,7 @@ public class PostService {
                     this.postPort.findAllPost(boardId, pageNum)
                             .map(postDomainModel -> PostsResponseDto.from(
                                     postDomainModel,
-                                    this.commentPort.countByPostId(postDomainModel.getId())
+                                    this.postPort.countAllComment(postDomainModel.getId())
                             ))
             );
         }
@@ -205,7 +206,7 @@ public class PostService {
                     this.postPort.findAllPost(boardId, pageNum, false)
                             .map(postDomainModel -> PostsResponseDto.from(
                                     postDomainModel,
-                                    this.commentPort.countByPostId(postDomainModel.getId())
+                                    this.postPort.countAllComment(postDomainModel.getId())
                             ))
             );
         }
@@ -285,7 +286,7 @@ public class PostService {
                     this.postPort.searchPost(keyword, boardId, pageNum)
                             .map(postDomainModel -> PostsResponseDto.from(
                                     postDomainModel,
-                                    this.commentPort.countByPostId(postDomainModel.getId())
+                                    this.postPort.countAllComment(postDomainModel.getId())
                             ))
             );
         }
@@ -299,7 +300,7 @@ public class PostService {
                     this.postPort.searchPost(keyword, boardId, pageNum, false)
                             .map(postDomainModel -> PostsResponseDto.from(
                                     postDomainModel,
-                                    this.commentPort.countByPostId(postDomainModel.getId())
+                                    this.postPort.countAllComment(postDomainModel.getId())
                             ))
             );
         }
@@ -332,7 +333,7 @@ public class PostService {
                 this.postPort.findAllPost(boardDomainModel.getId(), pageNum)
                         .map(postDomainModel -> PostsResponseDto.from(
                                 postDomainModel,
-                                this.commentPort.countByPostId(postDomainModel.getId())
+                                this.postPort.countAllComment(postDomainModel.getId())
                         ))
         );
     }
@@ -619,7 +620,7 @@ public class PostService {
                                         .map(ChildCommentResponseDto::new)
                                         .collect(Collectors.toList())
                         )),
-                this.commentPort.countByPostId(postDomainModel.getId())
+                this.postPort.countAllComment(postId)
         );
     }
 
@@ -733,7 +734,7 @@ public class PostService {
                                         .map(ChildCommentResponseDto::new)
                                         .collect(Collectors.toList())
                         )),
-                this.commentPort.countByPostId(postDomainModel.getId())
+                this.postPort.countAllComment(postId)
         );
     }
 

--- a/src/main/java/net/causw/application/post/PostService.java
+++ b/src/main/java/net/causw/application/post/PostService.java
@@ -1,6 +1,7 @@
 package net.causw.application.post;
 
 import lombok.RequiredArgsConstructor;
+import net.causw.application.dto.comment.ChildCommentResponseDto;
 import net.causw.application.dto.comment.CommentResponseDto;
 import net.causw.application.dto.post.BoardPostsResponseDto;
 import net.causw.application.dto.post.PostCreateRequestDto;
@@ -112,7 +113,10 @@ public class PostService {
                                         commentDomainModel,
                                         userDomainModel,
                                         postDomainModel.getBoard(),
-                                        this.childCommentPort.countByParentComment(commentDomainModel.getId())
+                                        this.childCommentPort.countByParentComment(commentDomainModel.getId()),
+                                        commentDomainModel.getChildCommentList().stream()
+                                                .map(ChildCommentResponseDto::new)
+                                                .collect(Collectors.toList())
                                 )
                         ),
                 this.commentPort.countByPostId(postDomainModel.getId())
@@ -610,7 +614,10 @@ public class PostService {
                                 commentDomainModel,
                                 updaterDomainModel,
                                 updatedPostDomainModel.getBoard(),
-                                this.childCommentPort.countByParentComment(commentDomainModel.getId())
+                                this.childCommentPort.countByParentComment(commentDomainModel.getId()),
+                                commentDomainModel.getChildCommentList().stream()
+                                        .map(ChildCommentResponseDto::new)
+                                        .collect(Collectors.toList())
                         )),
                 this.commentPort.countByPostId(postDomainModel.getId())
         );
@@ -721,9 +728,13 @@ public class PostService {
                                 commentDomainModel,
                                 restorerDomainModel,
                                 restoredPostDomainModel.getBoard(),
-                                this.childCommentPort.countByParentComment(commentDomainModel.getId())
+                                this.childCommentPort.countByParentComment(commentDomainModel.getId()),
+                                commentDomainModel.getChildCommentList().stream()
+                                        .map(ChildCommentResponseDto::new)
+                                        .collect(Collectors.toList())
                         )),
                 this.commentPort.countByPostId(postDomainModel.getId())
         );
     }
+
 }

--- a/src/main/java/net/causw/application/spi/ChildCommentPort.java
+++ b/src/main/java/net/causw/application/spi/ChildCommentPort.java
@@ -2,14 +2,11 @@ package net.causw.application.spi;
 
 import net.causw.domain.model.comment.ChildCommentDomainModel;
 import net.causw.domain.model.post.PostDomainModel;
-import org.springframework.data.domain.Page;
 
 import java.util.Optional;
 
 public interface ChildCommentPort {
     Optional<ChildCommentDomainModel> findById(String id);
-
-    Page<ChildCommentDomainModel> findByParentComment(String parentCommentId, Integer pageNum);
 
     Long countByParentComment(String parentCommentId);
 

--- a/src/main/java/net/causw/application/spi/CommentPort.java
+++ b/src/main/java/net/causw/application/spi/CommentPort.java
@@ -11,8 +11,6 @@ public interface CommentPort {
 
     Page<CommentDomainModel> findByPostId(String postId, Integer pageNum);
 
-    Long countByPostId(String postId);
-
     CommentDomainModel create(CommentDomainModel commentDomainModel, PostDomainModel postDomainModel);
 
     Optional<CommentDomainModel> update(String commentId, CommentDomainModel commentDomainModel);

--- a/src/main/java/net/causw/application/spi/PostPort.java
+++ b/src/main/java/net/causw/application/spi/PostPort.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 public interface PostPort {
     Optional<PostDomainModel> findPostById(String id);
 
+    Long countAllComment(String postId);
+
     PostDomainModel createPost(PostDomainModel postDomainModel);
 
     Optional<PostDomainModel> deletePost(String id);

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -200,7 +200,7 @@ public class UserService {
                         postDomainModel.getBoard().getName(),
                         postDomainModel.getBoard().getCircle().map(CircleDomainModel::getId).orElse(null),
                         postDomainModel.getBoard().getCircle().map(CircleDomainModel::getName).orElse(null),
-                        this.commentPort.countByPostId(postDomainModel.getId())
+                        this.postPort.countAllComment(postDomainModel.getId())
                 ))
         );
     }

--- a/src/main/java/net/causw/domain/model/comment/CommentDomainModel.java
+++ b/src/main/java/net/causw/domain/model/comment/CommentDomainModel.java
@@ -28,7 +28,7 @@ public class CommentDomainModel {
 
     @NotNull(message = "게시글이 입력되지 않았습니다.")
     private String postId;
-    private List<CommentDomainModel> childCommentList;
+    private List<ChildCommentDomainModel> childCommentList;
 
     private CommentDomainModel(
             String id,
@@ -38,7 +38,7 @@ public class CommentDomainModel {
             LocalDateTime updatedAt,
             UserDomainModel writer,
             String postId,
-            List<CommentDomainModel> childCommentList
+            List<ChildCommentDomainModel> childCommentList
     ) {
         this.id = id;
         this.content = content;
@@ -96,7 +96,7 @@ public class CommentDomainModel {
             LocalDateTime updatedAt,
             UserDomainModel writer,
             String postId,
-            List<CommentDomainModel> childCommentList
+            List<ChildCommentDomainModel> childCommentList
     ) {
         return new CommentDomainModel(
                 id,


### PR DESCRIPTION
### 🚩 관련사항
#539 

### 📢 전달사항

댓글과 대댓글의 기능을 개선하려고 합니다.

특정 게시물의 모든 댓글 수를 가져오는 쿼리를 작성하였습니다. 수정해야 할 부분이 있다면 알려주세요.
- 댓글이 삭제되어도 댓글에 달려 있던 대댓글은 유지
- 게시물/댓글/대댓글 join하여 한방 쿼리로 count

### 📸 스크린샷
<img width="1281" alt="image" src="https://github.com/CAUCSE/CAUSW_backend/assets/49549887/9f9a7b22-c502-47af-87a1-ef246001b2c7">



### 📃 진행사항
- [x] 특정 게시물의 모든 댓글 개수 반환하도록 수정 (댓글+대댓글)
- [x] 댓글 반환 시 댓글에 달린 대댓글 함께 반환하도록 수정


### ⚙️ 기타사항

- 댓글 조회에 대댓글 조회를 포함시켰기 때문에 대댓글 조회 기능을 삭제하였습니다.

개발기간: 1주