### PR TITLE
refactor: Post & Comment & ChildComment Port 제거 (#545)

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/board/Board.java
+++ b/src/main/java/net/causw/adapter/persistence/board/Board.java
@@ -1,8 +1,6 @@
 package net.causw.adapter.persistence.board;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import net.causw.adapter.persistence.circle.Circle;
 import net.causw.adapter.persistence.post.Post;
 import net.causw.adapter.persistence.base.BaseEntity;
@@ -19,9 +17,8 @@ import javax.persistence.Table;
 import java.util.Set;
 
 @Getter
-@Setter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "tb_board")
 public class Board extends BaseEntity {
     @Column(name = "name", nullable = false)
@@ -65,60 +62,6 @@ public class Board extends BaseEntity {
         this.circle = circle;
     }
 
-    private Board(
-            String name,
-            String description,
-            String createRoles,
-            String category,
-            Boolean isDeleted,
-            Circle circle
-    ) {
-        this.name = name;
-        this.description = description;
-        this.createRoles = createRoles;
-        this.category = category;
-        this.isDeleted = isDeleted;
-        this.circle = circle;
-    }
-
-    public static Board of(
-            String id,
-            String name,
-            String description,
-            String createRoles,
-            String category,
-            Boolean isDeleted,
-            Circle circle
-    ) {
-        return new Board(
-                id,
-                name,
-                description,
-                createRoles,
-                category,
-                isDeleted,
-                circle
-        );
-    }
-
-    public static Board of(
-            String name,
-            String description,
-            String createRoles,
-            String category,
-            Boolean isDeleted,
-            Circle circle
-    ) {
-        return new Board(
-                name,
-                description,
-                createRoles,
-                category,
-                isDeleted,
-                circle
-        );
-    }
-
     public static Board from(BoardDomainModel boardDomainModel) {
         Circle circle = boardDomainModel.getCircle().map(Circle::from).orElse(null);
 
@@ -131,5 +74,16 @@ public class Board extends BaseEntity {
                 boardDomainModel.getIsDeleted(),
                 circle
         );
+    }
+
+    public void setIsDeleted(boolean isDeleted){
+        this.isDeleted = isDeleted;
+    }
+
+    public void update(String name, String description, String createRoles, String category){
+        this.name = name;
+        this.description = description;
+        this.createRoles = createRoles;
+        this.category = category;
     }
 }

--- a/src/main/java/net/causw/adapter/persistence/board/FavoriteBoard.java
+++ b/src/main/java/net/causw/adapter/persistence/board/FavoriteBoard.java
@@ -1,5 +1,6 @@
 package net.causw.adapter.persistence.board;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.causw.adapter.persistence.user.User;
@@ -13,7 +14,7 @@ import javax.persistence.Table;
 
 @Getter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "TB_FAVORITE_BOARD")
 public class FavoriteBoard extends BaseEntity {
     @OneToOne
@@ -32,17 +33,6 @@ public class FavoriteBoard extends BaseEntity {
         super(id);
         this.user = user;
         this.board = board;
-    }
-
-    public static FavoriteBoard of(
-            User user,
-            Board board
-    ) {
-        return new FavoriteBoard(
-                null,
-                user,
-                board
-        );
     }
 
     public static FavoriteBoard from(FavoriteBoardDomainModel favoriteBoardDomainModel) {

--- a/src/main/java/net/causw/adapter/persistence/circle/Circle.java
+++ b/src/main/java/net/causw/adapter/persistence/circle/Circle.java
@@ -1,8 +1,8 @@
 package net.causw.adapter.persistence.circle;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import net.causw.adapter.persistence.user.User;
 import net.causw.adapter.persistence.base.BaseEntity;
 import net.causw.domain.model.circle.CircleDomainModel;
@@ -16,9 +16,8 @@ import javax.persistence.Table;
 import java.util.Optional;
 
 @Getter
-@Setter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "tb_circle")
 public class Circle extends BaseEntity {
     @Column(name = "name", nullable = false)
@@ -58,54 +57,6 @@ public class Circle extends BaseEntity {
         this.leader = leader;
     }
 
-    private Circle(
-            String name,
-            String mainImage,
-            String description,
-            Boolean isDeleted,
-            User leader
-    ) {
-        this.name = name;
-        this.mainImage = mainImage;
-        this.description = description;
-        this.isDeleted = isDeleted;
-        this.leader = leader;
-    }
-
-    public static Circle of(
-            String name,
-            String mainImage,
-            String description,
-            Boolean isDeleted,
-            User leader
-    ) {
-        return new Circle(
-                name,
-                mainImage,
-                description,
-                isDeleted,
-                leader
-        );
-    }
-
-    public static Circle of(
-            String id,
-            String name,
-            String mainImage,
-            String description,
-            Boolean isDeleted,
-            User leader
-    ) {
-        return new Circle(
-                id,
-                name,
-                mainImage,
-                description,
-                isDeleted,
-                leader
-        );
-    }
-
     public static Circle from(CircleDomainModel circleDomainModel) {
         return new Circle(
                 circleDomainModel.getId(),
@@ -115,5 +66,20 @@ public class Circle extends BaseEntity {
                 circleDomainModel.getIsDeleted(),
                 circleDomainModel.getLeader().map(User::from).orElse(null)
         );
+    }
+
+    public void update(String description, String name, String mainImage){
+        this.description = description;
+        this.name = name;
+        this.mainImage = mainImage;
+    }
+
+    public void setLeader(User leader){
+        this.leader = leader;
+    }
+
+    public void delete(){
+        this.isDeleted = true;
+        this.leader = null;
     }
 }

--- a/src/main/java/net/causw/adapter/persistence/circle/CircleMember.java
+++ b/src/main/java/net/causw/adapter/persistence/circle/CircleMember.java
@@ -1,8 +1,6 @@
 package net.causw.adapter.persistence.circle;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import net.causw.adapter.persistence.user.User;
 import net.causw.adapter.persistence.base.BaseEntity;
 import net.causw.domain.model.enums.CircleMemberStatus;
@@ -18,7 +16,8 @@ import javax.persistence.Table;
 @Getter
 @Setter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "tb_circle_member")
 public class CircleMember extends BaseEntity {
     @Column(name = "status", nullable = false)
@@ -33,51 +32,7 @@ public class CircleMember extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    private CircleMember(
-            String id,
-            CircleMemberStatus status,
-            Circle circle,
-            User user
-    ) {
-        super(id);
-        this.status = status;
-        this.circle = circle;
-        this.user = user;
-    }
-
-    private CircleMember(
-            CircleMemberStatus status,
-            Circle circle,
-            User user
-    ) {
-        this.status = status;
-        this.circle = circle;
-        this.user = user;
-    }
-
-    public static CircleMember of(
-            String id,
-            CircleMemberStatus status,
-            Circle circle,
-            User user
-    ) {
-        return new CircleMember(
-                id,
-                status,
-                circle,
-                user
-        );
-    }
-
-    public static CircleMember of(
-            CircleMemberStatus status,
-            Circle circle,
-            User user
-    ) {
-        return new CircleMember(
-                status,
-                circle,
-                user
-        );
+    public static CircleMember of(CircleMemberStatus status, Circle circle, User user) {
+        return new CircleMember(status, circle, user);
     }
 }

--- a/src/main/java/net/causw/adapter/persistence/comment/ChildComment.java
+++ b/src/main/java/net/causw/adapter/persistence/comment/ChildComment.java
@@ -1,6 +1,7 @@
 package net.causw.adapter.persistence.comment;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.causw.adapter.persistence.user.User;
@@ -18,6 +19,7 @@ import javax.persistence.Table;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "tb_child_comment")
 public class ChildComment extends BaseEntity {
     @Column(name = "content", nullable = false)
@@ -75,13 +77,29 @@ public class ChildComment extends BaseEntity {
         );
     }
 
+    public static ChildComment of(
+            String content,
+            Boolean isDeleted,
+            String tagUserName,
+            String refChildComment,
+            User writer,
+            Comment parentComment
+    ) {
+        return new ChildComment(content, isDeleted, tagUserName, refChildComment, writer, parentComment);
+    }
+
     public void delete(){
         this.isDeleted = true;
     }
 
+    // FIXME: Port 분리가 완전하게 다 끝나면 중복되는 메서드 삭제할 예정
     public void update(String content, String tagUserName, String refChildComment){
         this.content = content;
         this.tagUserName = tagUserName;
         this.refChildComment = refChildComment;
+    }
+
+    public void update(String content){
+        this.content = content;
     }
 }

--- a/src/main/java/net/causw/adapter/persistence/comment/ChildComment.java
+++ b/src/main/java/net/causw/adapter/persistence/comment/ChildComment.java
@@ -1,8 +1,8 @@
 package net.causw.adapter.persistence.comment;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import net.causw.adapter.persistence.user.User;
 import net.causw.adapter.persistence.base.BaseEntity;
 import net.causw.domain.model.comment.ChildCommentDomainModel;
@@ -16,9 +16,8 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 @Getter
-@Setter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "tb_child_comment")
 public class ChildComment extends BaseEntity {
     @Column(name = "content", nullable = false)
@@ -43,22 +42,6 @@ public class ChildComment extends BaseEntity {
     private Comment parentComment;
 
     private ChildComment(
-            String content,
-            Boolean isDeleted,
-            String tagUserName,
-            String refChildComment,
-            User writer,
-            Comment parentComment
-    ) {
-        this.content = content;
-        this.isDeleted = isDeleted;
-        this.tagUserName = tagUserName;
-        this.refChildComment = refChildComment;
-        this.writer = writer;
-        this.parentComment = parentComment;
-    }
-
-    private ChildComment(
             String id,
             String content,
             Boolean isDeleted,
@@ -76,43 +59,6 @@ public class ChildComment extends BaseEntity {
         this.parentComment = parentComment;
     }
 
-    public static ChildComment of(
-            String content,
-            Boolean isDeleted,
-            String tagUserName,
-            String refChildComment,
-            User writer,
-            Comment parentComment
-    ) {
-        return new ChildComment(
-                content,
-                isDeleted,
-                tagUserName,
-                refChildComment,
-                writer,
-                parentComment
-        );
-    }
-
-    public static ChildComment of(
-            String id,
-            String content,
-            Boolean isDeleted,
-            String tagUserName,
-            String refChildComment,
-            User writer,
-            Comment parentComment
-    ) {
-        return new ChildComment(
-                id,
-                content,
-                isDeleted,
-                tagUserName,
-                refChildComment,
-                writer,
-                parentComment
-        );
-    }
 
     public static ChildComment from(
             ChildCommentDomainModel childCommentDomainModel,
@@ -127,5 +73,15 @@ public class ChildComment extends BaseEntity {
                 User.from(childCommentDomainModel.getWriter()),
                 Comment.from(childCommentDomainModel.getParentComment(), postDomainModel)
         );
+    }
+
+    public void delete(){
+        this.isDeleted = true;
+    }
+
+    public void update(String content, String tagUserName, String refChildComment){
+        this.content = content;
+        this.tagUserName = tagUserName;
+        this.refChildComment = refChildComment;
     }
 }

--- a/src/main/java/net/causw/adapter/persistence/comment/Comment.java
+++ b/src/main/java/net/causw/adapter/persistence/comment/Comment.java
@@ -1,8 +1,8 @@
 package net.causw.adapter.persistence.comment;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import net.causw.adapter.persistence.post.Post;
 import net.causw.adapter.persistence.user.User;
 import net.causw.adapter.persistence.base.BaseEntity;
@@ -19,9 +19,8 @@ import javax.persistence.Table;
 import java.util.List;
 
 @Getter
-@Setter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "tb_comment")
 public class Comment extends BaseEntity {
     @Column(name = "content", nullable = false)
@@ -43,18 +42,6 @@ public class Comment extends BaseEntity {
     private List<ChildComment> childCommentList;
 
     private Comment(
-            String content,
-            Boolean isDeleted,
-            User writer,
-            Post post
-    ) {
-        this.content = content;
-        this.isDeleted = isDeleted;
-        this.writer = writer;
-        this.post = post;
-    }
-
-    private Comment(
             String id,
             String content,
             Boolean isDeleted,
@@ -68,36 +55,6 @@ public class Comment extends BaseEntity {
         this.post = post;
     }
 
-    public static Comment of(
-            String content,
-            Boolean isDeleted,
-            User writer,
-            Post post
-    ) {
-        return new Comment(
-                content,
-                isDeleted,
-                writer,
-                post
-        );
-    }
-
-    public static Comment of(
-            String id,
-            String content,
-            Boolean isDeleted,
-            User writer,
-            Post post
-    ) {
-        return new Comment(
-                id,
-                content,
-                isDeleted,
-                writer,
-                post
-        );
-    }
-
     public static Comment from(CommentDomainModel commentDomainModel, PostDomainModel postDomainModel) {
         return new Comment(
                 commentDomainModel.getId(),
@@ -106,5 +63,13 @@ public class Comment extends BaseEntity {
                 User.from(commentDomainModel.getWriter()),
                 Post.from(postDomainModel)
         );
+    }
+
+    public void update(String content) {
+        this.content = content;
+    }
+
+    public void delete() {
+        this.isDeleted = true;
     }
 }

--- a/src/main/java/net/causw/adapter/persistence/comment/Comment.java
+++ b/src/main/java/net/causw/adapter/persistence/comment/Comment.java
@@ -1,6 +1,7 @@
 package net.causw.adapter.persistence.comment;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.causw.adapter.persistence.post.Post;
@@ -16,11 +17,13 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "tb_comment")
 public class Comment extends BaseEntity {
     @Column(name = "content", nullable = false)
@@ -39,15 +42,9 @@ public class Comment extends BaseEntity {
     private Post post;
 
     @OneToMany(mappedBy = "parentComment")
-    private List<ChildComment> childCommentList;
+    private List<ChildComment> childCommentList = new ArrayList<>(); // 필드 초기화 없으면 NPE
 
-    private Comment(
-            String id,
-            String content,
-            Boolean isDeleted,
-            User writer,
-            Post post
-    ) {
+    private Comment(String id, String content, Boolean isDeleted, User writer, Post post) {
         super(id);
         this.content = content;
         this.isDeleted = isDeleted;
@@ -63,6 +60,14 @@ public class Comment extends BaseEntity {
                 User.from(commentDomainModel.getWriter()),
                 Post.from(postDomainModel)
         );
+    }
+
+    public static Comment of(String content, Boolean isDeleted, User writer, Post post) {
+        return new Comment(content, isDeleted, writer, post, new ArrayList<>());
+    }
+
+    public void setChildCommentList(List<ChildComment> childCommentList) {
+        this.childCommentList = childCommentList;
     }
 
     public void update(String content) {

--- a/src/main/java/net/causw/adapter/persistence/flag/Flag.java
+++ b/src/main/java/net/causw/adapter/persistence/flag/Flag.java
@@ -1,8 +1,6 @@
 package net.causw.adapter.persistence.flag;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import net.causw.adapter.persistence.base.BaseEntity;
 import org.hibernate.annotations.ColumnDefault;
 
@@ -13,7 +11,8 @@ import javax.persistence.Table;
 @Getter
 @Setter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "TB_FLAG")
 public class Flag extends BaseEntity {
     @Column(name = "tb_key", unique = true, nullable = false)
@@ -22,14 +21,6 @@ public class Flag extends BaseEntity {
     @Column(name = "value")
     @ColumnDefault("false")
     private Boolean value;
-
-    private Flag(
-            String key,
-            Boolean value
-    ) {
-        this.key = key;
-        this.value = value;
-    }
 
     public static Flag of(
             String key,

--- a/src/main/java/net/causw/adapter/persistence/inquiry/Inquiry.java
+++ b/src/main/java/net/causw/adapter/persistence/inquiry/Inquiry.java
@@ -1,5 +1,6 @@
 package net.causw.adapter.persistence.inquiry;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -17,7 +18,7 @@ import javax.persistence.Table;
 @Getter
 @Setter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "TB_INQUIRY")
 public class Inquiry extends BaseEntity {
     @Column(name = "title",nullable = false)
@@ -34,19 +35,6 @@ public class Inquiry extends BaseEntity {
     @ColumnDefault("false")
     private Boolean isDeleted;
 
-
-    private Inquiry(
-            String title,
-            String content,
-            User writer,
-            Boolean isDeleted
-    ){
-        this.title = title;
-        this.content = content;
-        this.writer = writer;
-        this.isDeleted = isDeleted;
-    }
-
     private Inquiry(
             String id,
             String title,
@@ -61,37 +49,6 @@ public class Inquiry extends BaseEntity {
         this.isDeleted = isDeleted;
     }
 
-    public static Inquiry of(
-            String title,
-            String content,
-            User writer,
-            Boolean isDeleted
-    ){
-        return new Inquiry(
-                title,
-                content,
-                writer,
-                isDeleted
-        );
-    }
-
-    public static Inquiry of(
-            String id,
-            String title,
-            String content,
-            User writer,
-            Boolean isDeleted,
-            Boolean isPublic
-    ){
-        return new Inquiry(
-                id,
-                title,
-                content,
-                writer,
-                isDeleted
-        );
-    }
-
     public static Inquiry from(InquiryDomainModel inquiryDomainModel) {
         return new Inquiry(
                 inquiryDomainModel.getId(),
@@ -101,5 +58,4 @@ public class Inquiry extends BaseEntity {
                 inquiryDomainModel.getIsDeleted()
         );
     }
-
 }

--- a/src/main/java/net/causw/adapter/persistence/locker/Locker.java
+++ b/src/main/java/net/causw/adapter/persistence/locker/Locker.java
@@ -1,8 +1,8 @@
 package net.causw.adapter.persistence.locker;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import net.causw.adapter.persistence.user.User;
 import net.causw.adapter.persistence.base.BaseEntity;
 import net.causw.domain.model.locker.LockerDomainModel;
@@ -18,9 +18,8 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Getter
-@Setter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "TB_LOCKER")
 public class Locker extends BaseEntity {
     @Column(name = "locker_number", nullable = false)
@@ -55,32 +54,6 @@ public class Locker extends BaseEntity {
         this.location = location;
     }
 
-    private Locker(
-            Long lockerNumber,
-            Boolean isActive,
-            User user,
-            LockerLocation location
-    ) {
-        this.lockerNumber = lockerNumber;
-        this.isActive = isActive;
-        this.user = user;
-        this.location = location;
-    }
-
-    public static Locker of(
-            Long lockerNumber,
-            Boolean isActive,
-            User user,
-            LockerLocation location
-    ) {
-        return new Locker(
-                lockerNumber,
-                isActive,
-                user,
-                location
-        );
-    }
-
     public static Locker from(LockerDomainModel lockerDomainModel) {
         return new Locker(
                 lockerDomainModel.getId(),
@@ -93,5 +66,15 @@ public class Locker extends BaseEntity {
 
     public Optional<User> getUser() {
         return Optional.ofNullable(this.user);
+    }
+
+    public void update(boolean isActive, User user, LocalDateTime expireDate) {
+        this.isActive = isActive;
+        this.user = user;
+        this.expireDate = expireDate;
+    }
+
+    public void setLocation(LockerLocation location) {
+        this.location = location;
     }
 }

--- a/src/main/java/net/causw/adapter/persistence/locker/LockerLocation.java
+++ b/src/main/java/net/causw/adapter/persistence/locker/LockerLocation.java
@@ -1,8 +1,8 @@
 package net.causw.adapter.persistence.locker;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import net.causw.adapter.persistence.base.BaseEntity;
 import net.causw.domain.model.locker.LockerLocationDomainModel;
 
@@ -11,9 +11,8 @@ import javax.persistence.Entity;
 import javax.persistence.Table;
 
 @Getter
-@Setter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "TB_LOCKER_LOCATION")
 public class LockerLocation extends BaseEntity {
     @Column(name = "name", unique = true, nullable = false)
@@ -24,18 +23,14 @@ public class LockerLocation extends BaseEntity {
         this.name = name;
     }
 
-    private LockerLocation(String name) {
-        this.name = name;
-    }
-
-    public static LockerLocation of(String name) {
-        return new LockerLocation(name);
-    }
-
     public static LockerLocation from(LockerLocationDomainModel lockerLocationDomainModel) {
         return new LockerLocation(
                 lockerLocationDomainModel.getId(),
                 lockerLocationDomainModel.getName()
         );
+    }
+
+    public void update(String name){
+        this.name = name;
     }
 }

--- a/src/main/java/net/causw/adapter/persistence/locker/LockerLog.java
+++ b/src/main/java/net/causw/adapter/persistence/locker/LockerLog.java
@@ -1,5 +1,7 @@
 package net.causw.adapter.persistence.locker;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.causw.adapter.persistence.base.BaseEntity;
@@ -13,7 +15,8 @@ import javax.persistence.Table;
 
 @Getter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "TB_LOCKER_LOG")
 public class LockerLog extends BaseEntity {
     @Column(name = "locker_number", nullable = false)
@@ -34,40 +37,6 @@ public class LockerLog extends BaseEntity {
 
     @Column(name = "message", nullable = true)
     private String message;
-
-    private LockerLog(
-            String id,
-            Long lockerNumber,
-            String lockerLocationName,
-            String userEmail,
-            String userName,
-            LockerLogAction action,
-            String message
-    ) {
-        super(id);
-        this.lockerNumber = lockerNumber;
-        this.lockerLocationName = lockerLocationName;
-        this.userEmail = userEmail;
-        this.userName = userName;
-        this.action = action;
-        this.message = message;
-    }
-
-    private LockerLog(
-            Long lockerNumber,
-            String lockerLocationName,
-            String userEmail,
-            String userName,
-            LockerLogAction action,
-            String message
-    ) {
-        this.lockerNumber = lockerNumber;
-        this.lockerLocationName = lockerLocationName;
-        this.userEmail = userEmail;
-        this.userName = userName;
-        this.action = action;
-        this.message = message;
-    }
 
     public static LockerLog of(
             Long lockerNumber,

--- a/src/main/java/net/causw/adapter/persistence/port/board/BoardPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/board/BoardPortImpl.java
@@ -76,11 +76,7 @@ public class BoardPortImpl extends DomainModelMapper implements BoardPort {
     public Optional<BoardDomainModel> updateBoard(String id, BoardDomainModel boardDomainModel) {
         return this.boardRepository.findById(id).map(
                 srcBoard -> {
-                    srcBoard.setName(boardDomainModel.getName());
-                    srcBoard.setDescription(boardDomainModel.getDescription());
-                    srcBoard.setCreateRoles(String.join(",", boardDomainModel.getCreateRoleList()));
-                    srcBoard.setCategory(boardDomainModel.getCategory());
-
+                    srcBoard.update(boardDomainModel.getName(), boardDomainModel.getDescription(),String.join(",", boardDomainModel.getCreateRoleList()), boardDomainModel.getCategory());
                     return this.entityToDomainModel(this.boardRepository.save(srcBoard));
                 }
         );

--- a/src/main/java/net/causw/adapter/persistence/port/circle/CirclePortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/circle/CirclePortImpl.java
@@ -54,9 +54,7 @@ public class CirclePortImpl extends DomainModelMapper implements CirclePort {
     public Optional<CircleDomainModel> update(String id, CircleDomainModel circleDomainModel) {
         return this.circleRepository.findById(id).map(
                 srcCircle -> {
-                    srcCircle.setDescription(circleDomainModel.getDescription());
-                    srcCircle.setName(circleDomainModel.getName());
-                    srcCircle.setMainImage(circleDomainModel.getMainImage());
+                    srcCircle.update(circleDomainModel.getDescription(), circleDomainModel.getName(), circleDomainModel.getMainImage());
 
                     return this.entityToDomainModel(this.circleRepository.save(srcCircle));
                 }
@@ -78,8 +76,7 @@ public class CirclePortImpl extends DomainModelMapper implements CirclePort {
     public Optional<CircleDomainModel> delete(String id) {
         return this.circleRepository.findById(id).map(
                 srcCircle -> {
-                    srcCircle.setIsDeleted(true);
-                    srcCircle.setLeader(null);
+                    srcCircle.delete();
 
                     return this.entityToDomainModel(this.circleRepository.save(srcCircle));
                 }

--- a/src/main/java/net/causw/adapter/persistence/port/comment/ChildCommentPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/comment/ChildCommentPortImpl.java
@@ -39,10 +39,7 @@ public class ChildCommentPortImpl extends DomainModelMapper implements ChildComm
     public Optional<ChildCommentDomainModel> update(String childCommentId, ChildCommentDomainModel childCommentDomainModel) {
         return this.childCommentRepository.findById(childCommentId).map(
                 srcChildComment -> {
-                    srcChildComment.setContent(childCommentDomainModel.getContent());
-                    srcChildComment.setTagUserName(childCommentDomainModel.getTagUserName());
-                    srcChildComment.setRefChildComment(childCommentDomainModel.getRefChildComment());
-
+                    srcChildComment.update(childCommentDomainModel.getContent(), childCommentDomainModel.getTagUserName(), childCommentDomainModel.getRefChildComment());
                     return this.entityToDomainModel(this.childCommentRepository.save(srcChildComment));
                 }
         );
@@ -52,7 +49,7 @@ public class ChildCommentPortImpl extends DomainModelMapper implements ChildComm
     public Optional<ChildCommentDomainModel> delete(String childCommentId) {
         return this.childCommentRepository.findById(childCommentId).map(
                 childComment -> {
-                    childComment.setIsDeleted(true);
+                    childComment.delete();
 
                     return this.entityToDomainModel(this.childCommentRepository.save(childComment));
                 }

--- a/src/main/java/net/causw/adapter/persistence/port/comment/CommentPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/comment/CommentPortImpl.java
@@ -62,7 +62,7 @@ public class CommentPortImpl extends DomainModelMapper implements CommentPort {
     public Optional<CommentDomainModel> update(String commentId, CommentDomainModel commentDomainModel) {
         return this.commentRepository.findById(commentId).map(
                 srcComment -> {
-                    srcComment.setContent(commentDomainModel.getContent());
+                    srcComment.update(commentDomainModel.getContent());
 
                     return this.entityToDomainModel(this.commentRepository.save(srcComment));
                 }
@@ -73,7 +73,7 @@ public class CommentPortImpl extends DomainModelMapper implements CommentPort {
     public Optional<CommentDomainModel> delete(String commentId) {
         return this.commentRepository.findById(commentId).map(
                 comment -> {
-                    comment.setIsDeleted(true);
+                    comment.delete();
 
                     return this.entityToDomainModel(this.commentRepository.save(comment));
                 }

--- a/src/main/java/net/causw/adapter/persistence/port/locker/LockerLocationPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/locker/LockerLocationPortImpl.java
@@ -48,7 +48,7 @@ public class LockerLocationPortImpl extends DomainModelMapper implements LockerL
     public Optional<LockerLocationDomainModel> update(String id, LockerLocationDomainModel lockerLocationDomainModel) {
         return this.lockerLocationRepository.findById(id).map(
                 srcLockerLocation -> {
-                    srcLockerLocation.setName(lockerLocationDomainModel.getName());
+                    srcLockerLocation.update(lockerLocationDomainModel.getName());
 
                     return this.entityToDomainModel(this.lockerLocationRepository.save(srcLockerLocation));
                 }

--- a/src/main/java/net/causw/adapter/persistence/port/locker/LockerPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/locker/LockerPortImpl.java
@@ -48,9 +48,7 @@ public class LockerPortImpl extends DomainModelMapper implements LockerPort {
     public Optional<LockerDomainModel> update(String id, LockerDomainModel lockerDomainModel) {
         return this.lockerRepository.findById(id).map(
                 locker -> {
-                    locker.setIsActive(lockerDomainModel.getIsActive());
-                    locker.setUser(lockerDomainModel.getUser().map(User::from).orElse(null));
-                    locker.setExpireDate(lockerDomainModel.getExpiredAt());
+                    locker.update(lockerDomainModel.getIsActive(), lockerDomainModel.getUser().map(User::from).orElse(null), lockerDomainModel.getExpiredAt());
 
                     return this.entityToDomainModel(this.lockerRepository.save(locker));
                 }

--- a/src/main/java/net/causw/adapter/persistence/post/Post.java
+++ b/src/main/java/net/causw/adapter/persistence/post/Post.java
@@ -1,9 +1,6 @@
 package net.causw.adapter.persistence.post;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import net.causw.adapter.persistence.user.User;
 import net.causw.adapter.persistence.base.BaseEntity;
 import net.causw.adapter.persistence.board.Board;
@@ -22,6 +19,7 @@ import java.util.Optional;
 @Setter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "tb_post")
 public class Post extends BaseEntity {
     @Column(name = "title", nullable = false)
@@ -73,6 +71,23 @@ public class Post extends BaseEntity {
                 Board.from(postDomainModel.getBoard()),
                 String.join(":::", postDomainModel.getAttachmentList())
         );
+    }
+
+    public static Post of(
+            String title,
+            String content,
+            User writer,
+            Boolean isDeleted,
+            Board board,
+            String attachments
+    ) {
+        return new Post(title, content, attachments, writer, isDeleted, board);
+    }
+
+    public void update(String title, String content, String attachments) {
+        this.title = title;
+        this.content = content;
+        this.attachments = attachments;
     }
 
     public Optional<String> getAttachments() {

--- a/src/main/java/net/causw/adapter/persistence/post/Post.java
+++ b/src/main/java/net/causw/adapter/persistence/post/Post.java
@@ -1,5 +1,6 @@
 package net.causw.adapter.persistence.post;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -20,7 +21,7 @@ import java.util.Optional;
 @Getter
 @Setter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "tb_post")
 public class Post extends BaseEntity {
     @Column(name = "title", nullable = false)
@@ -45,22 +46,6 @@ public class Post extends BaseEntity {
     private Board board;
 
     private Post(
-            String title,
-            String content,
-            User writer,
-            Boolean isDeleted,
-            Board board,
-            String attachments
-    ) {
-        this.title = title;
-        this.content = content;
-        this.writer = writer;
-        this.isDeleted = isDeleted;
-        this.board = board;
-        this.attachments = attachments;
-    }
-
-    private Post(
             String id,
             String title,
             String content,
@@ -76,44 +61,6 @@ public class Post extends BaseEntity {
         this.isDeleted = isDeleted;
         this.board = board;
         this.attachments = attachments;
-    }
-
-    public static Post of(
-            String title,
-            String content,
-            User writer,
-            Boolean isDeleted,
-            Board board,
-            String attachments
-    ) {
-        return new Post(
-                title,
-                content,
-                writer,
-                isDeleted,
-                board,
-                attachments
-        );
-    }
-
-    public static Post of(
-            String id,
-            String title,
-            String content,
-            User writer,
-            Boolean isDeleted,
-            Board board,
-            String attachments
-    ) {
-        return new Post(
-                id,
-                title,
-                content,
-                writer,
-                isDeleted,
-                board,
-                attachments
-        );
     }
 
     public static Post from(PostDomainModel postDomainModel) {

--- a/src/main/java/net/causw/adapter/persistence/user/User.java
+++ b/src/main/java/net/causw/adapter/persistence/user/User.java
@@ -1,5 +1,6 @@
 package net.causw.adapter.persistence.user;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -23,7 +24,7 @@ import java.util.List;
 @Getter
 @Setter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "tb_user")
 public class User extends BaseEntity {
     @Column(name = "email", unique = true, nullable = false)
@@ -64,26 +65,6 @@ public class User extends BaseEntity {
     private List<CircleMember> circleMemberList;
 
     private User(
-            String email,
-            String name,
-            String password,
-            String studentId,
-            Integer admissionYear,
-            Role role,
-            String profileImage,
-            UserState state
-    ) {
-        this.email = email;
-        this.name = name;
-        this.password = password;
-        this.studentId = studentId;
-        this.admissionYear = admissionYear;
-        this.role = role;
-        this.profileImage = profileImage;
-        this.state = state;
-    }
-
-    private User(
             String id,
             String email,
             String name,
@@ -103,52 +84,6 @@ public class User extends BaseEntity {
         this.role = role;
         this.profileImage = profileImage;
         this.state = state;
-    }
-
-    public static User of(
-            String email,
-            String name,
-            String password,
-            String studentId,
-            Integer admissionYear,
-            Role role,
-            String profileImage,
-            UserState state
-    ) {
-        return new User(
-                email,
-                name,
-                password,
-                studentId,
-                admissionYear,
-                role,
-                profileImage,
-                state
-        );
-    }
-
-    public static User of(
-            String id,
-            String email,
-            String name,
-            String password,
-            String studentId,
-            Integer admissionYear,
-            Role role,
-            String profileImage,
-            UserState state
-    ) {
-        return new User(
-                id,
-                email,
-                name,
-                password,
-                studentId,
-                admissionYear,
-                role,
-                profileImage,
-                state
-        );
     }
 
     public static User from(UserDomainModel userDomainModel) {

--- a/src/main/java/net/causw/adapter/persistence/user/UserAdmission.java
+++ b/src/main/java/net/causw/adapter/persistence/user/UserAdmission.java
@@ -1,5 +1,6 @@
 package net.causw.adapter.persistence.user;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.causw.adapter.persistence.base.BaseEntity;
@@ -13,7 +14,7 @@ import javax.persistence.Table;
 
 @Getter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "tb_user_admission")
 public class UserAdmission extends BaseEntity {
     @OneToOne
@@ -36,19 +37,6 @@ public class UserAdmission extends BaseEntity {
         this.user = user;
         this.attachImage = attachImage;
         this.description = description;
-    }
-
-    public static UserAdmission of(
-            User user,
-            String attachImage,
-            String description
-    ) {
-        return new UserAdmission(
-                null,
-                user,
-                attachImage,
-                description
-        );
     }
 
     public static UserAdmission from(UserAdmissionDomainModel userAdmissionDomainModel) {

--- a/src/main/java/net/causw/adapter/persistence/user/UserAdmissionLog.java
+++ b/src/main/java/net/causw/adapter/persistence/user/UserAdmissionLog.java
@@ -1,5 +1,7 @@
 package net.causw.adapter.persistence.user;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.causw.adapter.persistence.base.BaseEntity;
@@ -13,7 +15,8 @@ import javax.persistence.Table;
 
 @Getter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "tb_user_admission_log")
 public class UserAdmissionLog extends BaseEntity {
     @Column(name = "user_email", nullable = false)
@@ -38,44 +41,6 @@ public class UserAdmissionLog extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserAdmissionLogAction action;
 
-    private UserAdmissionLog(
-            String id,
-            String userEmail,
-            String userName,
-            String adminUserEmail,
-            String adminUserName,
-            UserAdmissionLogAction action,
-            String attachImage,
-            String description
-    ) {
-        super(id);
-        this.userEmail = userEmail;
-        this.userName = userName;
-        this.adminUserEmail = adminUserEmail;
-        this.adminUserName = adminUserName;
-        this.action = action;
-        this.attachImage = attachImage;
-        this.description = description;
-    }
-
-    private UserAdmissionLog(
-            String userEmail,
-            String userName,
-            String adminUserEmail,
-            String adminUserName,
-            UserAdmissionLogAction action,
-            String attachImage,
-            String description
-    ) {
-        this.userEmail = userEmail;
-        this.userName = userName;
-        this.adminUserEmail = adminUserEmail;
-        this.adminUserName = adminUserName;
-        this.action = action;
-        this.attachImage = attachImage;
-        this.description = description;
-    }
-
     public static UserAdmissionLog of(
             String userEmail,
             String userName,
@@ -90,9 +55,9 @@ public class UserAdmissionLog extends BaseEntity {
                 userName,
                 adminUserEmail,
                 adminUserName,
-                action,
                 attachImage,
-                description
+                description,
+                action
         );
     }
 }

--- a/src/main/java/net/causw/adapter/web/GlobalExceptionHandler.java
+++ b/src/main/java/net/causw/adapter/web/GlobalExceptionHandler.java
@@ -25,55 +25,55 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ExceptionDto handleBadRequestException(BadRequestException exception) {
         GlobalExceptionHandler.log.error("error message", exception);
-        return new ExceptionDto(exception.getErrorCode(), exception.getMessage());
+        return ExceptionDto.of(exception.getErrorCode(), exception.getMessage());
     }
 
     @ExceptionHandler(value = {ConstraintViolationException.class})
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ConstraintExceptionDto handleConstraintViolationException(ConstraintViolationException exception) {
         GlobalExceptionHandler.log.error("error message", exception);
-        return new ConstraintExceptionDto(ErrorCode.INVALID_PARAMETER, exception.getMessage(), exception);
+        return ConstraintExceptionDto.of(ErrorCode.INVALID_PARAMETER, exception.getMessage(), exception);
     }
 
     @ExceptionHandler(value = {IllegalArgumentException.class})
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ExceptionDto handleIllegalArgumentException(IllegalArgumentException exception) {
         GlobalExceptionHandler.log.error("error message", exception);
-        return new ExceptionDto(ErrorCode.INVALID_PARAMETER, exception.getMessage());
+        return ExceptionDto.of(ErrorCode.INVALID_PARAMETER, exception.getMessage());
     }
 
     @ExceptionHandler(value = {HttpRequestMethodNotSupportedException.class})
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ExceptionDto handleBadHttpRequestMethodException(HttpRequestMethodNotSupportedException exception) {
         GlobalExceptionHandler.log.error("error message", exception);
-        return new ExceptionDto(ErrorCode.INVALID_HTTP_METHOD, "Invalid request http method (GET, POST, PUT, DELETE)");
+        return ExceptionDto.of(ErrorCode.INVALID_HTTP_METHOD, "Invalid request http method (GET, POST, PUT, DELETE)");
     }
 
     @ExceptionHandler(value = {UnauthorizedException.class})
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     public ExceptionDto handleUnauthorizedException(UnauthorizedException exception) {
         GlobalExceptionHandler.log.error("error message", exception);
-        return new ExceptionDto(exception.getErrorCode(), exception.getMessage());
+        return ExceptionDto.of(exception.getErrorCode(), exception.getMessage());
     }
 
     @ExceptionHandler(value = {ServiceUnavailableException.class})
     @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
     public ExceptionDto handleServiceUnavailableException(ServiceUnavailableException exception) {
         GlobalExceptionHandler.log.error("error message", exception);
-        return new ExceptionDto(exception.getErrorCode(), exception.getMessage());
+        return ExceptionDto.of(exception.getErrorCode(), exception.getMessage());
     }
 
     @ExceptionHandler(value = {AccessDeniedException.class})
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     public ExceptionDto handleAccessDeniedException(AccessDeniedException exception) {
         GlobalExceptionHandler.log.error("error message", exception);
-        return new ExceptionDto(ErrorCode.API_NOT_ACCESSIBLE, exception.getMessage());
+        return ExceptionDto.of(ErrorCode.API_NOT_ACCESSIBLE, exception.getMessage());
     }
 
     @ExceptionHandler(value = {Exception.class})
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ExceptionDto unknownException(Exception exception) {
         GlobalExceptionHandler.log.error("error message", exception);
-        return new ExceptionDto(ErrorCode.INTERNAL_SERVER, "Internal server error");
+        return ExceptionDto.of(ErrorCode.INTERNAL_SERVER, "Internal server error");
     }
 }

--- a/src/main/java/net/causw/application/circle/CircleService.java
+++ b/src/main/java/net/causw/application/circle/CircleService.java
@@ -526,7 +526,7 @@ public class CircleService {
 
     @Transactional(readOnly = true)
     public DuplicatedCheckResponseDto isDuplicatedName(String name) {
-        return DuplicatedCheckResponseDto.of(this.circlePort.findByName(name).isPresent());
+        return DuplicatedCheckResponseDto.from(this.circlePort.findByName(name).isPresent());
     }
 
     @Transactional

--- a/src/main/java/net/causw/application/comment/ChildCommentService.java
+++ b/src/main/java/net/causw/application/comment/ChildCommentService.java
@@ -11,6 +11,7 @@ import net.causw.adapter.persistence.user.User;
 import net.causw.application.dto.comment.ChildCommentCreateRequestDto;
 import net.causw.application.dto.comment.ChildCommentResponseDto;
 import net.causw.application.dto.comment.ChildCommentUpdateRequestDto;
+import net.causw.application.dto.util.StatusUtil;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
@@ -67,7 +68,11 @@ public class ChildCommentService {
         );
         validatorBucket.validate();
 
-        return ChildCommentResponseDto.of(childCommentRepository.save(childComment), user, post.getBoard());
+        return ChildCommentResponseDto.of(
+                childCommentRepository.save(childComment),
+                StatusUtil.isUpdatable(childComment, user),
+                StatusUtil.isDeletable(childComment, user, post.getBoard())
+        );
     }
 
     @Transactional
@@ -93,7 +98,11 @@ public class ChildCommentService {
                 ));
         validatorBucket.validate();
 
-        return ChildCommentResponseDto.of(childCommentRepository.save(childComment), updater, post.getBoard());
+        return ChildCommentResponseDto.of(
+                childCommentRepository.save(childComment),
+                StatusUtil.isUpdatable(childComment, updater),
+                StatusUtil.isDeletable(childComment, updater, post.getBoard())
+        );
     }
 
     @Transactional
@@ -152,8 +161,8 @@ public class ChildCommentService {
 
         return ChildCommentResponseDto.of(
                 childCommentRepository.save(childComment),
-                deleter,
-                post.getBoard()
+                StatusUtil.isUpdatable(childComment, deleter),
+                StatusUtil.isDeletable(childComment, deleter, post.getBoard())
         );
     }
 

--- a/src/main/java/net/causw/application/comment/ChildCommentService.java
+++ b/src/main/java/net/causw/application/comment/ChildCommentService.java
@@ -132,7 +132,7 @@ public class ChildCommentService {
         validatorBucket
                 .validate();
 
-        return ChildCommentResponseDto.from(
+        return ChildCommentResponseDto.of(
                 this.childCommentPort.create(childCommentDomainModel, postDomainModel),
                 creatorDomainModel,
                 postDomainModel.getBoard()
@@ -212,7 +212,7 @@ public class ChildCommentService {
         validatorBucket
                 .validate();
 
-        return ChildCommentResponseDto.from(
+        return ChildCommentResponseDto.of(
                 this.childCommentPort.update(childCommentId, childCommentDomainModel).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
@@ -307,7 +307,7 @@ public class ChildCommentService {
         validatorBucket
                 .validate();
 
-        return ChildCommentResponseDto.from(
+        return ChildCommentResponseDto.of(
                 this.childCommentPort.delete(childCommentId).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,

--- a/src/main/java/net/causw/application/comment/CommentService.java
+++ b/src/main/java/net/causw/application/comment/CommentService.java
@@ -51,44 +51,14 @@ public class CommentService {
 
     @Transactional
     public CommentResponseDto createComment(String loginUserId, CommentCreateRequestDto commentCreateDto) {
-        ValidatorBucket validatorBucket = ValidatorBucket.of();
-
         User user = getUser(loginUserId);
         Post post = getPost(commentCreateDto.getPostId());
         Comment comment = Comment.of(commentCreateDto.getContent(), false, user, post);
 
-        validatorBucket
-                .consistOf(UserStateValidator.of(user.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
-                .consistOf(TargetIsDeletedValidator.of(post.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
-                .consistOf(TargetIsDeletedValidator.of(post.getIsDeleted(), StaticValue.DOMAIN_POST))
-                .consistOf(ConstraintValidator.of(comment, this.validator));
-
-        Optional<Circle> circles = Optional.ofNullable(post.getBoard().getCircle());
-        circles
-                .filter(circleDomainModel -> !user.getRole().equals(Role.ADMIN) && !user.getRole().getValue().contains("PRESIDENT"))
-                .ifPresent(
-                        circle -> {
-                            CircleMember member = circleMemberRepository.findByUser_IdAndCircle_Id(
-                                    loginUserId,
-                                    circle.getId()
-                            ).orElseThrow(
-                                    () -> new UnauthorizedException(
-                                            ErrorCode.NOT_MEMBER,
-                                            MessageUtil.CIRCLE_APPLY_INVALID
-                                    )
-                            );
-                            validatorBucket
-                                    .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
-                                    .consistOf(CircleMemberStatusValidator.of(
-                                            member.getStatus(),
-                                            List.of(CircleMemberStatus.MEMBER)
-                                    ));
-                        }
-                );
-
-        validatorBucket
-                .validate();
+        ValidatorBucket validatorBucket = initializeValidator(user, post);
+        validatorBucket.
+                consistOf(ConstraintValidator.of(comment, this.validator));
+        validatorBucket.validate();
 
         return CommentResponseDto.of(
                 commentRepository.save(comment),
@@ -103,70 +73,29 @@ public class CommentService {
 
     @Transactional(readOnly = true)
     public Page<CommentResponseDto> findAllComments(String loginUserId, String postId, Integer pageNum) {
-        ValidatorBucket validatorBucket = ValidatorBucket.of();
-
         User user = getUser(loginUserId);
         Post post = getPost(postId);
 
-        validatorBucket
-                .consistOf(UserStateValidator.of(user.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
-                .consistOf(TargetIsDeletedValidator.of(post.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
-                .consistOf(TargetIsDeletedValidator.of(post.getIsDeleted(), StaticValue.DOMAIN_POST));
-
-        Optional<Circle> circles = Optional.ofNullable(post.getBoard().getCircle());
-        circles
-                .filter(circle -> !user.getRole().equals(Role.ADMIN) && !user.getRole().getValue().contains("PRESIDENT"))
-                .ifPresent(
-                        circle -> {
-                            CircleMember member = circleMemberRepository.findByUser_IdAndCircle_Id(
-                                    loginUserId,
-                                    circle.getId()
-                            ).orElseThrow(
-                                    () -> new UnauthorizedException(
-                                            ErrorCode.NOT_MEMBER,
-                                            MessageUtil.CIRCLE_APPLY_INVALID
-                                    )
-                            );
-
-                            validatorBucket
-                                    .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
-                                    .consistOf(CircleMemberStatusValidator.of(
-                                            member.getStatus(),
-                                            List.of(CircleMemberStatus.MEMBER)
-                                    ));
-                        }
-                );
-
-        validatorBucket
-                .validate();
-
+        ValidatorBucket validatorBucket = initializeValidator(user, post);
+        validatorBucket.validate();
 
         Page<Comment> comments = commentRepository.findByPost_IdOrderByCreatedAt(
                 postId,
-                this.pageableFactory.create(pageNum, StaticValue.DEFAULT_COMMENT_PAGE_SIZE)
+                pageableFactory.create(pageNum, StaticValue.DEFAULT_COMMENT_PAGE_SIZE)
         );
-
-        for (Comment comment : comments) {
-            comment.setChildCommentList(childCommentRepository.findByParentComment_Id(comment.getId()));
-        }
+        comments.forEach(comment -> comment.setChildCommentList(childCommentRepository.findByParentComment_Id(comment.getId())));
 
         return comments.map(comment ->
-                        CommentResponseDto.of(
-                                comment,
-                                user,
-                                post.getBoard(),
-                                childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(comment.getId()),
-                                comment.getChildCommentList().stream()
-                                        .map(childComment -> ChildCommentResponseDto.of(
-                                                childComment,
-                                                user,
-                                                post.getBoard()
-                                        ))
-                                        .collect(Collectors.toList())
-                        )
-                );
-
+                CommentResponseDto.of(
+                        comment,
+                        user,
+                        post.getBoard(),
+                        childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(comment.getId()),
+                        comment.getChildCommentList().stream()
+                                .map(childComment -> ChildCommentResponseDto.of(childComment, user, post.getBoard()))
+                                .collect(Collectors.toList())
+                )
+        );
     }
 
     @Transactional
@@ -175,17 +104,12 @@ public class CommentService {
             String commentId,
             CommentUpdateRequestDto commentUpdateRequestDto
     ) {
-        ValidatorBucket validatorBucket = ValidatorBucket.of();
-
         User user = getUser(loginUserId);
         Comment comment = getComment(commentId);
         Post post = getPost(comment.getPost().getId());
 
+        ValidatorBucket validatorBucket = initializeValidator(user, post);
         validatorBucket
-                .consistOf(UserStateValidator.of(user.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
-                .consistOf(TargetIsDeletedValidator.of(post.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
-                .consistOf(TargetIsDeletedValidator.of(post.getIsDeleted(), StaticValue.DOMAIN_POST))
                 .consistOf(TargetIsDeletedValidator.of(comment.getIsDeleted(), StaticValue.DOMAIN_COMMENT))
                 .consistOf(ConstraintValidator.of(comment, this.validator))
                 .consistOf(ContentsAdminValidator.of(
@@ -194,25 +118,7 @@ public class CommentService {
                         comment.getWriter().getId(),
                         List.of()
                 ));
-
-        Optional<Circle> circles = Optional.ofNullable(post.getBoard().getCircle());
-        circles
-                .filter(circle -> !user.getRole().equals(Role.ADMIN) && !user.getRole().getValue().contains("PRESIDENT"))
-                .ifPresent(
-                        circle -> {
-                            CircleMember member = getCircleMember(loginUserId, circle.getId());
-
-                            validatorBucket
-                                    .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
-                                    .consistOf(CircleMemberStatusValidator.of(
-                                            member.getStatus(),
-                                            List.of(CircleMemberStatus.MEMBER)
-                                    ));
-                        }
-                );
-
-        validatorBucket
-                .validate();
+        validatorBucket.validate();
 
         comment.update(commentUpdateRequestDto.getContent());
 
@@ -230,12 +136,11 @@ public class CommentService {
 
     @Transactional
     public CommentResponseDto deleteComment(String loginUserId, String commentId) {
-        ValidatorBucket validatorBucket = ValidatorBucket.of();
-
         User user = getUser(loginUserId);
         Comment comment = getComment(commentId);
         Post post = getPost(comment.getPost().getId());
 
+        ValidatorBucket validatorBucket = initializeValidator(user, post);
         validatorBucket
                 .consistOf(UserStateValidator.of(user.getState()))
                 .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
@@ -246,15 +151,7 @@ public class CommentService {
                 .filter(circle -> !user.getRole().equals(Role.ADMIN) && !user.getRole().getValue().contains("PRESIDENT"))
                 .ifPresentOrElse(
                         circle -> {
-                            CircleMember member = circleMemberRepository.findByUser_IdAndCircle_Id(
-                                    loginUserId,
-                                    circle.getId()
-                            ).orElseThrow(
-                                    () -> new UnauthorizedException(
-                                            ErrorCode.NOT_MEMBER,
-                                            MessageUtil.CIRCLE_APPLY_INVALID
-                                    )
-                            );
+                            CircleMember member = getCircleMember(user.getId(), circle.getId());
 
                             validatorBucket
                                     .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
@@ -291,9 +188,7 @@ public class CommentService {
                                         List.of()
                                 ))
                 );
-
-        validatorBucket
-                .validate();
+        validatorBucket.validate();
 
         comment.delete();
 
@@ -308,39 +203,63 @@ public class CommentService {
         );
     }
 
-    private User getUser(String userId){
+    private ValidatorBucket initializeValidator(User user, Post post) {
+        ValidatorBucket validatorBucket = ValidatorBucket.of();
+        validatorBucket
+                .consistOf(UserStateValidator.of(user.getState()))
+                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
+                .consistOf(TargetIsDeletedValidator.of(post.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
+                .consistOf(TargetIsDeletedValidator.of(post.getIsDeleted(), StaticValue.DOMAIN_POST));
+
+        Optional<Circle> circles = Optional.ofNullable(post.getBoard().getCircle());
+        circles
+                .filter(circle -> !user.getRole().equals(Role.ADMIN) && !user.getRole().getValue().contains("PRESIDENT"))
+                .ifPresent(circle -> {
+                    CircleMember member = getCircleMember(user.getId(), circle.getId());
+
+                    validatorBucket
+                            .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
+                            .consistOf(CircleMemberStatusValidator.of(
+                                    member.getStatus(),
+                                    List.of(CircleMemberStatus.MEMBER)
+                            ));
+                });
+        return validatorBucket;
+    }
+
+    private User getUser(String userId) {
         return userRepository.findById(userId).orElseThrow(
-            () -> new BadRequestException(
-                    ErrorCode.ROW_DOES_NOT_EXIST,
-                    MessageUtil.USER_NOT_FOUND
-            )
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        MessageUtil.USER_NOT_FOUND
+                )
         );
     }
 
-    private Post getPost(String postId){
+    private Post getPost(String postId) {
         return postRepository.findById(postId).orElseThrow(
-            () -> new BadRequestException(
-                    ErrorCode.ROW_DOES_NOT_EXIST,
-                    MessageUtil.POST_NOT_FOUND
-            )
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        MessageUtil.POST_NOT_FOUND
+                )
         );
     }
 
-    private Comment getComment(String commentId){
+    private Comment getComment(String commentId) {
         return commentRepository.findById(commentId).orElseThrow(
-            () -> new BadRequestException(
-                    ErrorCode.ROW_DOES_NOT_EXIST,
-                    MessageUtil.COMMENT_NOT_FOUND
-            )
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        MessageUtil.COMMENT_NOT_FOUND
+                )
         );
     }
 
-    private CircleMember getCircleMember(String userId, String circleId){
+    private CircleMember getCircleMember(String userId, String circleId) {
         return circleMemberRepository.findByUser_IdAndCircle_Id(userId, circleId).orElseThrow(
-            () -> new BadRequestException(
-                    ErrorCode.ROW_DOES_NOT_EXIST,
-                    MessageUtil.CIRCLE_MEMBER_NOT_FOUND
-            )
+                () -> new UnauthorizedException(
+                        ErrorCode.NOT_MEMBER,
+                        MessageUtil.CIRCLE_APPLY_INVALID
+                )
         );
     }
 }

--- a/src/main/java/net/causw/application/comment/CommentService.java
+++ b/src/main/java/net/causw/application/comment/CommentService.java
@@ -12,6 +12,7 @@ import net.causw.application.dto.comment.ChildCommentResponseDto;
 import net.causw.application.dto.comment.CommentCreateRequestDto;
 import net.causw.application.dto.comment.CommentResponseDto;
 import net.causw.application.dto.comment.CommentUpdateRequestDto;
+import net.causw.application.dto.util.StatusUtil;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
@@ -62,12 +63,12 @@ public class CommentService {
 
         return CommentResponseDto.of(
                 commentRepository.save(comment),
-                user,
-                post.getBoard(),
                 childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(comment.getId()),
                 comment.getChildCommentList().stream()
-                        .map(childComment -> ChildCommentResponseDto.of(childComment, user, post.getBoard()))
-                        .collect(Collectors.toList())
+                        .map(childComment -> ChildCommentResponseDto.of(childComment, StatusUtil.isUpdatable(childComment, user), StatusUtil.isDeletable(childComment, user, post.getBoard())))
+                        .collect(Collectors.toList()),
+                StatusUtil.isUpdatable(comment, user),
+                StatusUtil.isDeletable(comment, user, post.getBoard())
         );
     }
 
@@ -88,12 +89,12 @@ public class CommentService {
         return comments.map(comment ->
                 CommentResponseDto.of(
                         comment,
-                        user,
-                        post.getBoard(),
                         childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(comment.getId()),
                         comment.getChildCommentList().stream()
-                                .map(childComment -> ChildCommentResponseDto.of(childComment, user, post.getBoard()))
-                                .collect(Collectors.toList())
+                                .map(childComment -> ChildCommentResponseDto.of(childComment, StatusUtil.isUpdatable(childComment, user), StatusUtil.isDeletable(childComment, user, post.getBoard())))
+                                .collect(Collectors.toList()),
+                        StatusUtil.isUpdatable(comment, user),
+                        StatusUtil.isDeletable(comment, user, post.getBoard())
                 )
         );
     }
@@ -124,12 +125,12 @@ public class CommentService {
 
         return CommentResponseDto.of(
                 commentRepository.save(comment),
-                user,
-                post.getBoard(),
                 childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(comment.getId()),
                 comment.getChildCommentList().stream()
-                        .map(childComment -> ChildCommentResponseDto.of(childComment, user, post.getBoard()))
-                        .collect(Collectors.toList())
+                        .map(childComment -> ChildCommentResponseDto.of(childComment, StatusUtil.isUpdatable(childComment, user), StatusUtil.isDeletable(childComment, user, post.getBoard())))
+                        .collect(Collectors.toList()),
+                StatusUtil.isUpdatable(comment, user),
+                StatusUtil.isDeletable(comment, user, post.getBoard())
         );
     }
 
@@ -194,12 +195,12 @@ public class CommentService {
 
         return CommentResponseDto.of(
                 commentRepository.save(comment),
-                user,
-                post.getBoard(),
                 childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(commentId),
                 comment.getChildCommentList().stream()
-                        .map(childCommentDomainModel -> ChildCommentResponseDto.of(childCommentDomainModel, user, post.getBoard()))
-                        .collect(Collectors.toList())
+                        .map(childComment -> ChildCommentResponseDto.of(childComment, StatusUtil.isUpdatable(childComment, user), StatusUtil.isDeletable(childComment, user, post.getBoard())))
+                        .collect(Collectors.toList()),
+                StatusUtil.isUpdatable(comment, user),
+                StatusUtil.isDeletable(comment, user, post.getBoard())
         );
     }
 

--- a/src/main/java/net/causw/application/comment/CommentService.java
+++ b/src/main/java/net/causw/application/comment/CommentService.java
@@ -102,13 +102,13 @@ public class CommentService {
         validatorBucket
                 .validate();
 
-        return CommentResponseDto.from(
+        return CommentResponseDto.of(
                 this.commentPort.create(commentDomainModel, postDomainModel),
                 creatorDomainModel,
                 postDomainModel.getBoard(),
                 this.childCommentPort.countByParentComment(commentDomainModel.getId()),
                 commentDomainModel.getChildCommentList().stream()
-                        .map(childCommentDomainModel -> ChildCommentResponseDto.from(
+                        .map(childCommentDomainModel -> ChildCommentResponseDto.of(
                                 childCommentDomainModel,
                                 creatorDomainModel,
                                 postDomainModel.getBoard()
@@ -169,13 +169,13 @@ public class CommentService {
 
         return this.commentPort.findByPostId(postId, pageNum)
                 .map(commentDomainModel ->
-                        CommentResponseDto.from(
+                        CommentResponseDto.of(
                                 commentDomainModel,
                                 userDomainModel,
                                 postDomainModel.getBoard(),
                                 this.childCommentPort.countByParentComment(commentDomainModel.getId()),
                                 commentDomainModel.getChildCommentList().stream()
-                                        .map(childCommentDomainModel -> ChildCommentResponseDto.from(
+                                        .map(childCommentDomainModel -> ChildCommentResponseDto.of(
                                                 childCommentDomainModel,
                                                 userDomainModel,
                                                 postDomainModel.getBoard()
@@ -258,7 +258,7 @@ public class CommentService {
         validatorBucket
                 .validate();
 
-        return CommentResponseDto.from(
+        return CommentResponseDto.of(
                 this.commentPort.update(commentId, commentDomainModel).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
@@ -269,7 +269,7 @@ public class CommentService {
                 postDomainModel.getBoard(),
                 this.childCommentPort.countByParentComment(commentId),
                 commentDomainModel.getChildCommentList().stream()
-                        .map(childCommentDomainModel -> ChildCommentResponseDto.from(
+                        .map(childCommentDomainModel -> ChildCommentResponseDto.of(
                                 childCommentDomainModel,
                                 requestUser,
                                 postDomainModel.getBoard()
@@ -360,7 +360,7 @@ public class CommentService {
         validatorBucket
                 .validate();
 
-        return CommentResponseDto.from(
+        return CommentResponseDto.of(
                 this.commentPort.delete(commentId).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
@@ -371,7 +371,7 @@ public class CommentService {
                 postDomainModel.getBoard(),
                 this.childCommentPort.countByParentComment(commentId),
                 commentDomainModel.getChildCommentList().stream()
-                        .map(childCommentDomainModel -> ChildCommentResponseDto.from(
+                        .map(childCommentDomainModel -> ChildCommentResponseDto.of(
                                 childCommentDomainModel,
                                 deleterDomainModel,
                                 postDomainModel.getBoard()

--- a/src/main/java/net/causw/application/comment/CommentService.java
+++ b/src/main/java/net/causw/application/comment/CommentService.java
@@ -1,23 +1,25 @@
 package net.causw.application.comment;
 
 import lombok.RequiredArgsConstructor;
+import net.causw.adapter.persistence.circle.Circle;
+import net.causw.adapter.persistence.circle.CircleMember;
+import net.causw.adapter.persistence.comment.Comment;
+import net.causw.adapter.persistence.page.PageableFactory;
+import net.causw.adapter.persistence.post.Post;
+import net.causw.adapter.persistence.repository.*;
+import net.causw.adapter.persistence.user.User;
 import net.causw.application.dto.comment.ChildCommentResponseDto;
 import net.causw.application.dto.comment.CommentCreateRequestDto;
 import net.causw.application.dto.comment.CommentResponseDto;
 import net.causw.application.dto.comment.CommentUpdateRequestDto;
-import net.causw.application.spi.*;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
 import net.causw.domain.exceptions.UnauthorizedException;
-import net.causw.domain.model.circle.CircleMemberDomainModel;
 import net.causw.domain.model.enums.CircleMemberStatus;
-import net.causw.domain.model.comment.CommentDomainModel;
-import net.causw.domain.model.post.PostDomainModel;
 import net.causw.domain.model.enums.Role;
 import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
-import net.causw.domain.model.user.UserDomainModel;
 import net.causw.domain.validation.CircleMemberStatusValidator;
 import net.causw.domain.validation.ConstraintValidator;
 import net.causw.domain.validation.ContentsAdminValidator;
@@ -32,58 +34,44 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.validation.Validator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class CommentService {
-    private final CommentPort commentPort;
-    private final UserPort userPort;
-    private final PostPort postPort;
-    private final CircleMemberPort circleMemberPort;
-    private final ChildCommentPort childCommentPort;
+
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final CircleMemberRepository circleMemberRepository;
+    private final ChildCommentRepository childCommentRepository;
+    private final PageableFactory pageableFactory;
     private final Validator validator;
 
     @Transactional
     public CommentResponseDto createComment(String loginUserId, CommentCreateRequestDto commentCreateDto) {
         ValidatorBucket validatorBucket = ValidatorBucket.of();
 
-        UserDomainModel creatorDomainModel = this.userPort.findById(loginUserId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.LOGIN_USER_NOT_FOUND
-                )
-        );
+        User user = getUser(loginUserId);
+        Post post = getPost(commentCreateDto.getPostId());
+        Comment comment = Comment.of(commentCreateDto.getContent(), false, user, post);
 
         validatorBucket
-                .consistOf(UserStateValidator.of(creatorDomainModel.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(creatorDomainModel.getRole()));
+                .consistOf(UserStateValidator.of(user.getState()))
+                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
+                .consistOf(TargetIsDeletedValidator.of(post.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
+                .consistOf(TargetIsDeletedValidator.of(post.getIsDeleted(), StaticValue.DOMAIN_POST))
+                .consistOf(ConstraintValidator.of(comment, this.validator));
 
-        PostDomainModel postDomainModel = this.postPort.findPostById(commentCreateDto.getPostId()).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.POST_NOT_FOUND
-                )
-        );
-
-        CommentDomainModel commentDomainModel = CommentDomainModel.of(
-                commentCreateDto.getContent(),
-                creatorDomainModel,
-                postDomainModel.getId()
-        );
-
-        validatorBucket
-                .consistOf(TargetIsDeletedValidator.of(postDomainModel.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
-                .consistOf(TargetIsDeletedValidator.of(postDomainModel.getIsDeleted(), StaticValue.DOMAIN_POST))
-                .consistOf(ConstraintValidator.of(commentDomainModel, this.validator));
-
-        postDomainModel.getBoard().getCircle()
-                .filter(circleDomainModel -> !creatorDomainModel.getRole().equals(Role.ADMIN) && !creatorDomainModel.getRole().getValue().contains("PRESIDENT"))
+        Optional<Circle> circles = Optional.ofNullable(post.getBoard().getCircle());
+        circles
+                .filter(circleDomainModel -> !user.getRole().equals(Role.ADMIN) && !user.getRole().getValue().contains("PRESIDENT"))
                 .ifPresent(
-                        circleDomainModel -> {
-                            CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
+                        circle -> {
+                            CircleMember member = circleMemberRepository.findByUser_IdAndCircle_Id(
                                     loginUserId,
-                                    circleDomainModel.getId()
+                                    circle.getId()
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
@@ -91,9 +79,9 @@ public class CommentService {
                                     )
                             );
                             validatorBucket
-                                    .consistOf(TargetIsDeletedValidator.of(circleDomainModel.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
+                                    .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
                                     .consistOf(CircleMemberStatusValidator.of(
-                                            circleMemberDomainModel.getStatus(),
+                                            member.getStatus(),
                                             List.of(CircleMemberStatus.MEMBER)
                                     ));
                         }
@@ -103,16 +91,12 @@ public class CommentService {
                 .validate();
 
         return CommentResponseDto.of(
-                this.commentPort.create(commentDomainModel, postDomainModel),
-                creatorDomainModel,
-                postDomainModel.getBoard(),
-                this.childCommentPort.countByParentComment(commentDomainModel.getId()),
-                commentDomainModel.getChildCommentList().stream()
-                        .map(childCommentDomainModel -> ChildCommentResponseDto.of(
-                                childCommentDomainModel,
-                                creatorDomainModel,
-                                postDomainModel.getBoard()
-                        ))
+                commentRepository.save(comment),
+                user,
+                post.getBoard(),
+                childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(comment.getId()),
+                comment.getChildCommentList().stream()
+                        .map(childComment -> ChildCommentResponseDto.of(childComment, user, post.getBoard()))
                         .collect(Collectors.toList())
         );
     }
@@ -121,33 +105,23 @@ public class CommentService {
     public Page<CommentResponseDto> findAllComments(String loginUserId, String postId, Integer pageNum) {
         ValidatorBucket validatorBucket = ValidatorBucket.of();
 
-        UserDomainModel userDomainModel = this.userPort.findById(loginUserId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.LOGIN_USER_NOT_FOUND
-                )
-        );
-
-        PostDomainModel postDomainModel = this.postPort.findPostById(postId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.POST_NOT_FOUND
-                )
-        );
+        User user = getUser(loginUserId);
+        Post post = getPost(postId);
 
         validatorBucket
-                .consistOf(UserStateValidator.of(userDomainModel.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(userDomainModel.getRole()))
-                .consistOf(TargetIsDeletedValidator.of(postDomainModel.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
-                .consistOf(TargetIsDeletedValidator.of(postDomainModel.getIsDeleted(), StaticValue.DOMAIN_POST));
+                .consistOf(UserStateValidator.of(user.getState()))
+                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
+                .consistOf(TargetIsDeletedValidator.of(post.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
+                .consistOf(TargetIsDeletedValidator.of(post.getIsDeleted(), StaticValue.DOMAIN_POST));
 
-        postDomainModel.getBoard().getCircle()
-                .filter(circleDomainModel -> !userDomainModel.getRole().equals(Role.ADMIN) && !userDomainModel.getRole().getValue().contains("PRESIDENT"))
+        Optional<Circle> circles = Optional.ofNullable(post.getBoard().getCircle());
+        circles
+                .filter(circle -> !user.getRole().equals(Role.ADMIN) && !user.getRole().getValue().contains("PRESIDENT"))
                 .ifPresent(
-                        circleDomainModel -> {
-                            CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
+                        circle -> {
+                            CircleMember member = circleMemberRepository.findByUser_IdAndCircle_Id(
                                     loginUserId,
-                                    circleDomainModel.getId()
+                                    circle.getId()
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
@@ -156,9 +130,9 @@ public class CommentService {
                             );
 
                             validatorBucket
-                                    .consistOf(TargetIsDeletedValidator.of(circleDomainModel.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
+                                    .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
                                     .consistOf(CircleMemberStatusValidator.of(
-                                            circleMemberDomainModel.getStatus(),
+                                            member.getStatus(),
                                             List.of(CircleMemberStatus.MEMBER)
                                     ));
                         }
@@ -167,22 +141,32 @@ public class CommentService {
         validatorBucket
                 .validate();
 
-        return this.commentPort.findByPostId(postId, pageNum)
-                .map(commentDomainModel ->
+
+        Page<Comment> comments = commentRepository.findByPost_IdOrderByCreatedAt(
+                postId,
+                this.pageableFactory.create(pageNum, StaticValue.DEFAULT_COMMENT_PAGE_SIZE)
+        );
+
+        for (Comment comment : comments) {
+            comment.setChildCommentList(childCommentRepository.findByParentComment_Id(comment.getId()));
+        }
+
+        return comments.map(comment ->
                         CommentResponseDto.of(
-                                commentDomainModel,
-                                userDomainModel,
-                                postDomainModel.getBoard(),
-                                this.childCommentPort.countByParentComment(commentDomainModel.getId()),
-                                commentDomainModel.getChildCommentList().stream()
-                                        .map(childCommentDomainModel -> ChildCommentResponseDto.of(
-                                                childCommentDomainModel,
-                                                userDomainModel,
-                                                postDomainModel.getBoard()
+                                comment,
+                                user,
+                                post.getBoard(),
+                                childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(comment.getId()),
+                                comment.getChildCommentList().stream()
+                                        .map(childComment -> ChildCommentResponseDto.of(
+                                                childComment,
+                                                user,
+                                                post.getBoard()
                                         ))
                                         .collect(Collectors.toList())
                         )
                 );
+
     }
 
     @Transactional
@@ -193,63 +177,35 @@ public class CommentService {
     ) {
         ValidatorBucket validatorBucket = ValidatorBucket.of();
 
-        UserDomainModel requestUser = this.userPort.findById(loginUserId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.LOGIN_USER_NOT_FOUND
-                )
-        );
-
-        CommentDomainModel commentDomainModel = this.commentPort.findById(commentId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.COMMENT_NOT_FOUND
-                )
-        );
-
-        PostDomainModel postDomainModel = this.postPort.findPostById(commentDomainModel.getPostId()).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.POST_NOT_FOUND
-                )
-        );
-
-        commentDomainModel.update(
-                commentUpdateRequestDto.getContent()
-        );
+        User user = getUser(loginUserId);
+        Comment comment = getComment(commentId);
+        Post post = getPost(comment.getPost().getId());
 
         validatorBucket
-                .consistOf(UserStateValidator.of(requestUser.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(requestUser.getRole()))
-                .consistOf(TargetIsDeletedValidator.of(postDomainModel.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
-                .consistOf(TargetIsDeletedValidator.of(postDomainModel.getIsDeleted(), StaticValue.DOMAIN_POST))
-                .consistOf(TargetIsDeletedValidator.of(commentDomainModel.getIsDeleted(), StaticValue.DOMAIN_COMMENT))
-                .consistOf(ConstraintValidator.of(commentDomainModel, this.validator))
+                .consistOf(UserStateValidator.of(user.getState()))
+                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
+                .consistOf(TargetIsDeletedValidator.of(post.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
+                .consistOf(TargetIsDeletedValidator.of(post.getIsDeleted(), StaticValue.DOMAIN_POST))
+                .consistOf(TargetIsDeletedValidator.of(comment.getIsDeleted(), StaticValue.DOMAIN_COMMENT))
+                .consistOf(ConstraintValidator.of(comment, this.validator))
                 .consistOf(ContentsAdminValidator.of(
-                        requestUser.getRole(),
+                        user.getRole(),
                         loginUserId,
-                        commentDomainModel.getWriter().getId(),
+                        comment.getWriter().getId(),
                         List.of()
                 ));
 
-        postDomainModel.getBoard().getCircle()
-                .filter(circleDomainModel -> !requestUser.getRole().equals(Role.ADMIN) && !requestUser.getRole().getValue().contains("PRESIDENT"))
+        Optional<Circle> circles = Optional.ofNullable(post.getBoard().getCircle());
+        circles
+                .filter(circle -> !user.getRole().equals(Role.ADMIN) && !user.getRole().getValue().contains("PRESIDENT"))
                 .ifPresent(
-                        circleDomainModel -> {
-                            CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
-                                    loginUserId,
-                                    circleDomainModel.getId()
-                            ).orElseThrow(
-                                    () -> new UnauthorizedException(
-                                            ErrorCode.NOT_MEMBER,
-                                            MessageUtil.CIRCLE_APPLY_INVALID
-                                    )
-                            );
+                        circle -> {
+                            CircleMember member = getCircleMember(loginUserId, circle.getId());
 
                             validatorBucket
-                                    .consistOf(TargetIsDeletedValidator.of(circleDomainModel.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
+                                    .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
                                     .consistOf(CircleMemberStatusValidator.of(
-                                            circleMemberDomainModel.getStatus(),
+                                            member.getStatus(),
                                             List.of(CircleMemberStatus.MEMBER)
                                     ));
                         }
@@ -258,63 +214,41 @@ public class CommentService {
         validatorBucket
                 .validate();
 
+        comment.update(commentUpdateRequestDto.getContent());
+
         return CommentResponseDto.of(
-                this.commentPort.update(commentId, commentDomainModel).orElseThrow(
-                        () -> new InternalServerException(
-                                ErrorCode.INTERNAL_SERVER,
-                                MessageUtil.INTERNAL_SERVER_ERROR
-                        )
-                ),
-                requestUser,
-                postDomainModel.getBoard(),
-                this.childCommentPort.countByParentComment(commentId),
-                commentDomainModel.getChildCommentList().stream()
-                        .map(childCommentDomainModel -> ChildCommentResponseDto.of(
-                                childCommentDomainModel,
-                                requestUser,
-                                postDomainModel.getBoard()
-                        ))
+                commentRepository.save(comment),
+                user,
+                post.getBoard(),
+                childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(comment.getId()),
+                comment.getChildCommentList().stream()
+                        .map(childComment -> ChildCommentResponseDto.of(childComment, user, post.getBoard()))
                         .collect(Collectors.toList())
         );
     }
+
 
     @Transactional
     public CommentResponseDto deleteComment(String loginUserId, String commentId) {
         ValidatorBucket validatorBucket = ValidatorBucket.of();
 
-        UserDomainModel deleterDomainModel = this.userPort.findById(loginUserId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.LOGIN_USER_NOT_FOUND
-                )
-        );
-
-        CommentDomainModel commentDomainModel = this.commentPort.findById(commentId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.COMMENT_NOT_FOUND
-                )
-        );
-
-        PostDomainModel postDomainModel = this.postPort.findPostById(commentDomainModel.getPostId()).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.POST_NOT_FOUND
-                )
-        );
+        User user = getUser(loginUserId);
+        Comment comment = getComment(commentId);
+        Post post = getPost(comment.getPost().getId());
 
         validatorBucket
-                .consistOf(UserStateValidator.of(deleterDomainModel.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(deleterDomainModel.getRole()))
-                .consistOf(TargetIsDeletedValidator.of(commentDomainModel.getIsDeleted(), StaticValue.DOMAIN_COMMENT));
+                .consistOf(UserStateValidator.of(user.getState()))
+                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
+                .consistOf(TargetIsDeletedValidator.of(comment.getIsDeleted(), StaticValue.DOMAIN_COMMENT));
 
-        postDomainModel.getBoard().getCircle()
-                .filter(circleDomainModel -> !deleterDomainModel.getRole().equals(Role.ADMIN) && !deleterDomainModel.getRole().getValue().contains("PRESIDENT"))
+        Optional<Circle> circles = Optional.ofNullable(post.getBoard().getCircle());
+        circles
+                .filter(circle -> !user.getRole().equals(Role.ADMIN) && !user.getRole().getValue().contains("PRESIDENT"))
                 .ifPresentOrElse(
-                        circleDomainModel -> {
-                            CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
+                        circle -> {
+                            CircleMember member = circleMemberRepository.findByUser_IdAndCircle_Id(
                                     loginUserId,
-                                    circleDomainModel.getId()
+                                    circle.getId()
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
@@ -323,25 +257,26 @@ public class CommentService {
                             );
 
                             validatorBucket
-                                    .consistOf(TargetIsDeletedValidator.of(circleDomainModel.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
+                                    .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
                                     .consistOf(CircleMemberStatusValidator.of(
-                                            circleMemberDomainModel.getStatus(),
+                                            member.getStatus(),
                                             List.of(CircleMemberStatus.MEMBER)
                                     ))
                                     .consistOf(ContentsAdminValidator.of(
-                                            deleterDomainModel.getRole(),
+                                            user.getRole(),
                                             loginUserId,
-                                            commentDomainModel.getWriter().getId(),
+                                            comment.getWriter().getId(),
                                             List.of(Role.LEADER_CIRCLE)
                                     ));
 
-                            if (deleterDomainModel.getRole().getValue().contains("LEADER_CIRCLE") && !commentDomainModel.getWriter().getId().equals(loginUserId)) {
+                            if (user.getRole().getValue().contains("LEADER_CIRCLE") && !comment.getWriter().getId().equals(loginUserId)) {
                                 validatorBucket
                                         .consistOf(UserEqualValidator.of(
-                                                circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
+                                                circle.getLeader().map(User::getId).orElseThrow(
                                                         () -> new InternalServerException(
-                                                                ErrorCode.INTERNAL_SERVER,
+                                                                ErrorCode.ROW_DOES_NOT_EXIST,
                                                                 MessageUtil.CIRCLE_WITHOUT_LEADER
+
                                                         )
                                                 ),
                                                 loginUserId
@@ -350,9 +285,9 @@ public class CommentService {
                         },
                         () -> validatorBucket
                                 .consistOf(ContentsAdminValidator.of(
-                                        deleterDomainModel.getRole(),
+                                        user.getRole(),
                                         loginUserId,
-                                        commentDomainModel.getWriter().getId(),
+                                        comment.getWriter().getId(),
                                         List.of()
                                 ))
                 );
@@ -360,23 +295,52 @@ public class CommentService {
         validatorBucket
                 .validate();
 
+        comment.delete();
+
         return CommentResponseDto.of(
-                this.commentPort.delete(commentId).orElseThrow(
-                        () -> new InternalServerException(
-                                ErrorCode.INTERNAL_SERVER,
-                                MessageUtil.INTERNAL_SERVER_ERROR
-                        )
-                ),
-                deleterDomainModel,
-                postDomainModel.getBoard(),
-                this.childCommentPort.countByParentComment(commentId),
-                commentDomainModel.getChildCommentList().stream()
-                        .map(childCommentDomainModel -> ChildCommentResponseDto.of(
-                                childCommentDomainModel,
-                                deleterDomainModel,
-                                postDomainModel.getBoard()
-                        ))
+                commentRepository.save(comment),
+                user,
+                post.getBoard(),
+                childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(commentId),
+                comment.getChildCommentList().stream()
+                        .map(childCommentDomainModel -> ChildCommentResponseDto.of(childCommentDomainModel, user, post.getBoard()))
                         .collect(Collectors.toList())
+        );
+    }
+
+    private User getUser(String userId){
+        return userRepository.findById(userId).orElseThrow(
+            () -> new BadRequestException(
+                    ErrorCode.ROW_DOES_NOT_EXIST,
+                    MessageUtil.USER_NOT_FOUND
+            )
+        );
+    }
+
+    private Post getPost(String postId){
+        return postRepository.findById(postId).orElseThrow(
+            () -> new BadRequestException(
+                    ErrorCode.ROW_DOES_NOT_EXIST,
+                    MessageUtil.POST_NOT_FOUND
+            )
+        );
+    }
+
+    private Comment getComment(String commentId){
+        return commentRepository.findById(commentId).orElseThrow(
+            () -> new BadRequestException(
+                    ErrorCode.ROW_DOES_NOT_EXIST,
+                    MessageUtil.COMMENT_NOT_FOUND
+            )
+        );
+    }
+
+    private CircleMember getCircleMember(String userId, String circleId){
+        return circleMemberRepository.findByUser_IdAndCircle_Id(userId, circleId).orElseThrow(
+            () -> new BadRequestException(
+                    ErrorCode.ROW_DOES_NOT_EXIST,
+                    MessageUtil.CIRCLE_MEMBER_NOT_FOUND
+            )
         );
     }
 }

--- a/src/main/java/net/causw/application/dto/board/BoardOfCircleResponseDto.java
+++ b/src/main/java/net/causw/application/dto/board/BoardOfCircleResponseDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.board;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.domain.model.board.BoardDomainModel;
@@ -11,6 +12,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@Builder
 public class BoardOfCircleResponseDto {
 
     @ApiModelProperty(value = "게시판 id 값", example = "uuid 형식의 String 값입니다.")
@@ -43,65 +45,36 @@ public class BoardOfCircleResponseDto {
     @ApiModelProperty(value = "게시글 댓글 개수", example =  "12")
     private Long postNumComment;
 
-    private BoardOfCircleResponseDto(
-            String id,
-            String name,
-            Boolean writable,
-            Boolean isDeleted,
-            String postId,
-            String postTitle,
-            String postWriterName,
-            String postWriterStudentId,
-            LocalDateTime postCreatedAt,
-            Long postNumComment
-    ) {
-        this.id = id;
-        this.name = name;
-        this.writable = writable;
-        this.isDeleted = isDeleted;
-        this.postId = postId;
-        this.postTitle = postTitle;
-        this.postWriterName = postWriterName;
-        this.postWriterStudentId = postWriterStudentId;
-        this.postCreatedAt = postCreatedAt;
-        this.postNumComment = postNumComment;
-    }
-
     public static BoardOfCircleResponseDto from(
             BoardDomainModel boardDomainModel,
             Role userRole,
             PostDomainModel postDomainModel,
             Long numComment
     ) {
-        return new BoardOfCircleResponseDto(
-                boardDomainModel.getId(),
-                boardDomainModel.getName(),
-                boardDomainModel.getCreateRoleList().stream().anyMatch(str -> userRole.getValue().contains(str)),
-                boardDomainModel.getIsDeleted(),
-                postDomainModel.getId(),
-                postDomainModel.getTitle(),
-                postDomainModel.getWriter().getName(),
-                postDomainModel.getWriter().getStudentId(),
-                postDomainModel.getCreatedAt(),
-                numComment
-        );
+        return BoardOfCircleResponseDto.builder()
+                .id(boardDomainModel.getId())
+                .name(boardDomainModel.getName())
+                .writable(boardDomainModel.getCreateRoleList().stream().anyMatch(str -> userRole.getValue().contains(str)))
+                .isDeleted(boardDomainModel.getIsDeleted())
+                .postId(postDomainModel.getId())
+                .postTitle(postDomainModel.getTitle())
+                .postWriterName(postDomainModel.getWriter().getName())
+                .postWriterStudentId(postDomainModel.getWriter().getStudentId())
+                .postCreatedAt(postDomainModel.getCreatedAt())
+                .postNumComment(numComment)
+                .build();
     }
 
     public static BoardOfCircleResponseDto from(
             BoardDomainModel boardDomainModel,
             Role userRole
     ) {
-        return new BoardOfCircleResponseDto(
-                boardDomainModel.getId(),
-                boardDomainModel.getName(),
-                boardDomainModel.getCreateRoleList().stream().anyMatch(str -> userRole.getValue().contains(str)),
-                boardDomainModel.getIsDeleted(),
-                null,
-                null,
-                null,
-                null,
-                null,
-                0L
-        );
+        return BoardOfCircleResponseDto.builder()
+                .id(boardDomainModel.getId())
+                .name(boardDomainModel.getName())
+                .writable(boardDomainModel.getCreateRoleList().stream().anyMatch(str -> userRole.getValue().contains(str)))
+                .isDeleted(boardDomainModel.getIsDeleted())
+                .postNumComment(0L)
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/board/BoardResponseDto.java
+++ b/src/main/java/net/causw/application/dto/board/BoardResponseDto.java
@@ -4,11 +4,16 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import net.causw.adapter.persistence.board.Board;
+import net.causw.adapter.persistence.circle.Circle;
 import net.causw.domain.model.board.BoardDomainModel;
 import net.causw.domain.model.circle.CircleDomainModel;
 import net.causw.domain.model.enums.Role;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 @Getter
 @Setter
@@ -41,6 +46,7 @@ public class BoardResponseDto {
     @ApiModelProperty(value = "속한 동아리 이름", example = "circleName_example")
     private String circleName;
 
+    // FIXME: Port 분리 후 삭제 필요
     public static BoardResponseDto from(BoardDomainModel boardDomainModel, Role userRole) {
         String circleId = boardDomainModel.getCircle().map(CircleDomainModel::getId).orElse(null);
         String circleName = boardDomainModel.getCircle().map(CircleDomainModel::getName).orElse(null);
@@ -53,6 +59,24 @@ public class BoardResponseDto {
                 .category(boardDomainModel.getCategory())
                 .writable(boardDomainModel.getCreateRoleList().stream().anyMatch(str -> userRole.getValue().contains(str)))
                 .isDeleted(boardDomainModel.getIsDeleted())
+                .circleId(circleId)
+                .circleName(circleName)
+                .build();
+    }
+
+    public static BoardResponseDto of(Board board, Role userRole) {
+        List<String> roles = new ArrayList<>(Arrays.asList(board.getCreateRoles().split(",")));
+        String circleId = Optional.ofNullable(board.getCircle()).map(Circle::getId).orElse(null);
+        String circleName = Optional.ofNullable(board.getCircle()).map(Circle::getName).orElse(null);
+
+        return BoardResponseDto.builder()
+                .id(board.getId())
+                .name(board.getName())
+                .description(board.getDescription())
+                .createRoleList(roles)
+                .category(board.getCategory())
+                .writable(roles.stream().anyMatch(str -> userRole.getValue().contains(str)))
+                .isDeleted(board.getIsDeleted())
                 .circleId(circleId)
                 .circleName(circleName)
                 .build();

--- a/src/main/java/net/causw/application/dto/board/BoardResponseDto.java
+++ b/src/main/java/net/causw/application/dto/board/BoardResponseDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.board;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.domain.model.board.BoardDomainModel;
@@ -11,6 +12,7 @@ import java.util.List;
 
 @Getter
 @Setter
+@Builder
 public class BoardResponseDto {
     @ApiModelProperty(value = "게시판 id 값", example = "uuid 형식의 String 값입니다.")
     private String id;
@@ -39,42 +41,20 @@ public class BoardResponseDto {
     @ApiModelProperty(value = "속한 동아리 이름", example = "circleName_example")
     private String circleName;
 
-    private BoardResponseDto(
-            String id,
-            String name,
-            String description,
-            List<String> createRoleList,
-            String category,
-            Boolean writable,
-            Boolean isDeleted,
-            String circleId,
-            String circleName
-    ) {
-        this.id = id;
-        this.name = name;
-        this.description = description;
-        this.createRoleList = createRoleList;
-        this.category = category;
-        this.writable = writable;
-        this.isDeleted = isDeleted;
-        this.circleId = circleId;
-        this.circleName = circleName;
-    }
-
     public static BoardResponseDto from(BoardDomainModel boardDomainModel, Role userRole) {
         String circleId = boardDomainModel.getCircle().map(CircleDomainModel::getId).orElse(null);
         String circleName = boardDomainModel.getCircle().map(CircleDomainModel::getName).orElse(null);
 
-        return new BoardResponseDto(
-                boardDomainModel.getId(),
-                boardDomainModel.getName(),
-                boardDomainModel.getDescription(),
-                boardDomainModel.getCreateRoleList(),
-                boardDomainModel.getCategory(),
-                boardDomainModel.getCreateRoleList().stream().anyMatch(str -> userRole.getValue().contains(str)),
-                boardDomainModel.getIsDeleted(),
-                circleId,
-                circleName
-        );
+        return BoardResponseDto.builder()
+                .id(boardDomainModel.getId())
+                .name(boardDomainModel.getName())
+                .description(boardDomainModel.getDescription())
+                .createRoleList(boardDomainModel.getCreateRoleList())
+                .category(boardDomainModel.getCategory())
+                .writable(boardDomainModel.getCreateRoleList().stream().anyMatch(str -> userRole.getValue().contains(str)))
+                .isDeleted(boardDomainModel.getIsDeleted())
+                .circleId(circleId)
+                .circleName(circleName)
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/circle/CircleBoardsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/circle/CircleBoardsResponseDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.circle;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.application.dto.board.BoardOfCircleResponseDto;
@@ -9,6 +10,7 @@ import java.util.List;
 
 @Getter
 @Setter
+@Builder
 public class CircleBoardsResponseDto {
 
     @ApiModelProperty(value ="동아리 정보", example = "동아리 responseDTO 객체를 반환합니다.")
@@ -17,18 +19,13 @@ public class CircleBoardsResponseDto {
     @ApiModelProperty(value ="동아리 게시판 리스트", example = "동아리의 속한 게시판 목록을 List<BoardOfCircleResponseDto> 객체(리스트)로 반환합니다.")
     private List<BoardOfCircleResponseDto> boardList;
 
-    private CircleBoardsResponseDto(
-            CircleResponseDto circle,
-            List<BoardOfCircleResponseDto> boardList
-    ) {
-        this.circle = circle;
-        this.boardList = boardList;
-    }
-
     public static CircleBoardsResponseDto from(
             CircleResponseDto circle,
             List<BoardOfCircleResponseDto> boardList
     ) {
-        return new CircleBoardsResponseDto(circle, boardList);
+        return CircleBoardsResponseDto.builder()
+                .circle(circle)
+                .boardList(boardList)
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/circle/CircleMemberResponseDto.java
+++ b/src/main/java/net/causw/application/dto/circle/CircleMemberResponseDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.circle;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.application.dto.user.UserResponseDto;
@@ -10,6 +11,7 @@ import net.causw.domain.model.user.UserDomainModel;
 
 @Getter
 @Setter
+@Builder
 public class CircleMemberResponseDto {
 
     @ApiModelProperty(value = "동아리원 고유 ID", example = "동아리원의 UUID 형식 유저 고유 ID 값입니다.")
@@ -24,29 +26,15 @@ public class CircleMemberResponseDto {
     @ApiModelProperty(value = "UserResponseDTO", example = "유저 responseDTO 객체를 반환합니다.")
     private UserResponseDto user;
 
-    private CircleMemberResponseDto(
-            String id,
-            CircleMemberStatus status,
-            CircleResponseDto circle,
-            UserResponseDto user
-    ) {
-        this.id = id;
-        this.status = status;
-        this.circle = circle;
-        this.user = user;
-    }
-
     public static CircleMemberResponseDto from(
             UserDomainModel user,
             CircleMemberDomainModel circleMember
     ) {
-        return new CircleMemberResponseDto(
-                circleMember.getId(),
-                circleMember.getStatus(),
-                CircleResponseDto.from(
-                        circleMember.getCircle()
-                ),
-                UserResponseDto.from(user)
-        );
+        return CircleMemberResponseDto.builder()
+                .id(circleMember.getId())
+                .status(circleMember.getStatus())
+                .circle(CircleResponseDto.from(circleMember.getCircle()))
+                .user(UserResponseDto.from(user))
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/circle/CircleResponseDto.java
+++ b/src/main/java/net/causw/application/dto/circle/CircleResponseDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.circle;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.domain.model.circle.CircleDomainModel;
@@ -10,6 +11,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@Builder
 public class CircleResponseDto {
 
     @ApiModelProperty(value = "동아리 ID", example = "UUID 형식의 동아리 고유 ID String 값 입니다.")
@@ -39,72 +41,31 @@ public class CircleResponseDto {
     @ApiModelProperty(value = "동아리 생성 일시", example = "2024-02-04 16:11:02.342644")
     private LocalDateTime createdAt;
 
-    private CircleResponseDto(
-            String id,
-            String name,
-            String mainImage,
-            String description,
-            Boolean isDeleted,
-            String leaderId,
-            String leaderName,
-            LocalDateTime createdAt
-    ) {
-        this.id = id;
-        this.name = name;
-        this.mainImage = mainImage;
-        this.description = description;
-        this.isDeleted = isDeleted;
-        this.leaderId = leaderId;
-        this.leaderName = leaderName;
-        this.createdAt = createdAt;
-    }
-
-    private CircleResponseDto(
-            String id,
-            String name,
-            String mainImage,
-            String description,
-            Boolean isDeleted,
-            String leaderId,
-            String leaderName,
-            Long numMember,
-            LocalDateTime createdAt
-    ) {
-        this.id = id;
-        this.name = name;
-        this.mainImage = mainImage;
-        this.description = description;
-        this.isDeleted = isDeleted;
-        this.leaderId = leaderId;
-        this.leaderName = leaderName;
-        this.numMember = numMember;
-        this.createdAt = createdAt;
-    }
 
     public static CircleResponseDto from(CircleDomainModel circle) {
-        return new CircleResponseDto(
-                circle.getId(),
-                circle.getName(),
-                circle.getMainImage(),
-                circle.getDescription(),
-                circle.getIsDeleted(),
-                circle.getLeader().map(UserDomainModel::getId).orElse(null),
-                circle.getLeader().map(UserDomainModel::getName).orElse(null),
-                circle.getCreatedAt()
-        );
+        return CircleResponseDto.builder()
+                .id(circle.getId())
+                .name(circle.getName())
+                .mainImage(circle.getMainImage())
+                .description(circle.getDescription())
+                .isDeleted(circle.getIsDeleted())
+                .leaderId(circle.getLeader().map(UserDomainModel::getId).orElse(null))
+                .leaderName(circle.getLeader().map(UserDomainModel::getName).orElse(null))
+                .createdAt(circle.getCreatedAt())
+                .build();
     }
 
     public static CircleResponseDto from(CircleDomainModel circle, Long numMember) {
-        return new CircleResponseDto(
-                circle.getId(),
-                circle.getName(),
-                circle.getMainImage(),
-                circle.getDescription(),
-                circle.getIsDeleted(),
-                circle.getLeader().map(UserDomainModel::getId).orElse(null),
-                circle.getLeader().map(UserDomainModel::getName).orElse(null),
-                numMember,
-                circle.getCreatedAt()
-        );
+        return CircleResponseDto.builder()
+                .id(circle.getId())
+                .name(circle.getName())
+                .mainImage(circle.getMainImage())
+                .description(circle.getDescription())
+                .isDeleted(circle.getIsDeleted())
+                .leaderId(circle.getLeader().map(UserDomainModel::getId).orElse(null))
+                .leaderName(circle.getLeader().map(UserDomainModel::getName).orElse(null))
+                .numMember(numMember)
+                .createdAt(circle.getCreatedAt())
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/circle/CirclesResponseDto.java
+++ b/src/main/java/net/causw/application/dto/circle/CirclesResponseDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.circle;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.domain.model.circle.CircleDomainModel;
@@ -10,6 +11,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@Builder
 public class CirclesResponseDto {
 
     @ApiModelProperty(value = "동아리 ID", example = "UUID 형식의 동아리 고유 ID String 값입니다.")
@@ -42,46 +44,21 @@ public class CirclesResponseDto {
     @ApiModelProperty(value = "동아리 가입 시점\n(User Role ADMIN 일 시 항상 API 호출 시점)", example = "2024-02-04 16:11:02.342644")
     private LocalDateTime joinedAt;
 
-    private CirclesResponseDto(
-            String id,
-            String name,
-            String mainImage,
-            String description,
-            String leaderId,
-            String leaderName,
-            Long numMember,
-            Boolean isJoined,
-            LocalDateTime createdAt,
-            LocalDateTime joinedAt
-    ) {
-        this.id = id;
-        this.name = name;
-        this.mainImage = mainImage;
-        this.description = description;
-        this.leaderId = leaderId;
-        this.leaderName = leaderName;
-        this.numMember = numMember;
-        this.isJoined = isJoined;
-        this.createdAt = createdAt;
-        this.joinedAt = joinedAt;
-    }
-
     public static CirclesResponseDto from(
             CircleDomainModel circleDomainModel,
             Long numMember
     ) {
-        return new CirclesResponseDto(
-                circleDomainModel.getId(),
-                circleDomainModel.getName(),
-                circleDomainModel.getMainImage(),
-                circleDomainModel.getDescription(),
-                circleDomainModel.getLeader().map(UserDomainModel::getId).orElse(null),
-                circleDomainModel.getLeader().map(UserDomainModel::getName).orElse(null),
-                numMember,
-                false,
-                circleDomainModel.getCreatedAt(),
-                null
-        );
+        return CirclesResponseDto.builder()
+                .id(circleDomainModel.getId())
+                .name(circleDomainModel.getName())
+                .mainImage(circleDomainModel.getMainImage())
+                .description(circleDomainModel.getDescription())
+                .leaderId(circleDomainModel.getLeader().map(UserDomainModel::getId).orElse(null))
+                .leaderName(circleDomainModel.getLeader().map(UserDomainModel::getName).orElse(null))
+                .numMember(numMember)
+                .isJoined(false)
+                .createdAt(circleDomainModel.getCreatedAt())
+                .build();
     }
 
     public static CirclesResponseDto from(
@@ -89,17 +66,17 @@ public class CirclesResponseDto {
             Long numMember,
             LocalDateTime joinedAt
     ) {
-        return new CirclesResponseDto(
-                circleDomainModel.getId(),
-                circleDomainModel.getName(),
-                circleDomainModel.getMainImage(),
-                circleDomainModel.getDescription(),
-                circleDomainModel.getLeader().map(UserDomainModel::getId).orElse(null),
-                circleDomainModel.getLeader().map(UserDomainModel::getName).orElse(null),
-                numMember,
-                true,
-                circleDomainModel.getCreatedAt(),
-                joinedAt
-        );
+        return CirclesResponseDto.builder()
+                .id(circleDomainModel.getId())
+                .name(circleDomainModel.getName())
+                .mainImage(circleDomainModel.getMainImage())
+                .description(circleDomainModel.getDescription())
+                .leaderId(circleDomainModel.getLeader().map(UserDomainModel::getId).orElse(null))
+                .leaderName(circleDomainModel.getLeader().map(UserDomainModel::getName).orElse(null))
+                .numMember(numMember)
+                .isJoined(true)
+                .createdAt(circleDomainModel.getCreatedAt())
+                .joinedAt(joinedAt)
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/comment/ChildCommentResponseDto.java
+++ b/src/main/java/net/causw/application/dto/comment/ChildCommentResponseDto.java
@@ -3,11 +3,7 @@ package net.causw.application.dto.comment;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import net.causw.adapter.persistence.board.Board;
 import net.causw.adapter.persistence.comment.ChildComment;
-import net.causw.adapter.persistence.user.User;
-import net.causw.domain.model.enums.Role;
-import net.causw.domain.model.util.StaticValue;
 
 import java.time.LocalDateTime;
 
@@ -30,16 +26,12 @@ public class ChildCommentResponseDto {
 
     public static ChildCommentResponseDto of(
             ChildComment comment,
-            User user,
-            Board board
+            boolean updatable,
+            boolean deletable
     ) {
-        String content = comment.getIsDeleted() ? StaticValue.CONTENT_DELETED_COMMENT : comment.getContent();
-        boolean updatable = determineUpdatable(comment, user);
-        boolean deletable = determineDeletable(comment, user, board);
-
         return ChildCommentResponseDto.builder()
                 .id(comment.getId())
-                .content(content)
+                .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
                 .updatedAt(comment.getUpdatedAt())
                 .isDeleted(comment.getIsDeleted())
@@ -51,19 +43,5 @@ public class ChildCommentResponseDto {
                 .updatable(updatable)
                 .deletable(deletable)
                 .build();
-    }
-
-    private static boolean determineUpdatable(ChildComment comment, User user) {
-        if (comment.getIsDeleted()) return false;
-        return user.getRole() == Role.ADMIN || comment.getWriter().getId().equals(user.getId());
-    }
-
-    private static boolean determineDeletable(ChildComment comment, User user, Board board) {
-        if (comment.getIsDeleted()) return false;
-        if (user.getRole() == Role.ADMIN || user.getRole().getValue().contains("PRESIDENT") || comment.getWriter().getId().equals(user.getId())) {
-            return true;
-        }
-        return board.getCircle() != null && user.getRole().getValue().contains("LEADER_CIRCLE")
-                && board.getCircle().getLeader().map(leader -> leader.getId().equals(user.getId())).orElse(false);
     }
 }

--- a/src/main/java/net/causw/application/dto/comment/ChildCommentResponseDto.java
+++ b/src/main/java/net/causw/application/dto/comment/ChildCommentResponseDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.comment;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.domain.model.board.BoardDomainModel;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@Builder
 public class ChildCommentResponseDto {
     private String id;
     private String content;
@@ -26,35 +28,7 @@ public class ChildCommentResponseDto {
     private Boolean updatable;
     private Boolean deletable;
 
-    private ChildCommentResponseDto(
-            String id,
-            String content,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            Boolean isDeleted,
-            String tagUserName,
-            String refChildComment,
-            String writerName,
-            Integer writerAdmissionYear,
-            String writerProfileImage,
-            Boolean updatable,
-            Boolean deletable
-    ) {
-        this.id = id;
-        this.content = content;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.isDeleted = isDeleted;
-        this.tagUserName = tagUserName;
-        this.refChildComment = refChildComment;
-        this.writerName = writerName;
-        this.writerAdmissionYear = writerAdmissionYear;
-        this.writerProfileImage = writerProfileImage;
-        this.updatable = updatable;
-        this.deletable = deletable;
-    }
-
-    public static ChildCommentResponseDto from(
+    public static ChildCommentResponseDto of(
             ChildCommentDomainModel comment,
             UserDomainModel user,
             BoardDomainModel board
@@ -63,10 +37,7 @@ public class ChildCommentResponseDto {
         boolean deletable = false;
         String content = comment.getContent();
 
-        if (user.getRole() == Role.ADMIN) {
-            updatable = true;
-            deletable = true;
-        } else if (comment.getWriter().getId().equals(user.getId())) {
+        if (user.getRole() == Role.ADMIN || comment.getWriter().getId().equals(user.getId())) {
             updatable = true;
             deletable = true;
         } else if (user.getRole().getValue().contains("PRESIDENT")) {
@@ -89,19 +60,19 @@ public class ChildCommentResponseDto {
             content = StaticValue.CONTENT_DELETED_COMMENT;
         }
 
-        return new ChildCommentResponseDto(
-                comment.getId(),
-                content,
-                comment.getCreatedAt(),
-                comment.getUpdatedAt(),
-                comment.getIsDeleted(),
-                comment.getTagUserName(),
-                comment.getRefChildComment(),
-                comment.getWriter().getName(),
-                comment.getWriter().getAdmissionYear(),
-                comment.getWriter().getProfileImage(),
-                updatable,
-                deletable
-        );
+        return ChildCommentResponseDto.builder()
+                .id(comment.getId())
+                .content(content)
+                .createdAt(comment.getCreatedAt())
+                .updatedAt(comment.getUpdatedAt())
+                .isDeleted(comment.getIsDeleted())
+                .tagUserName(comment.getTagUserName())
+                .refChildComment(comment.getRefChildComment())
+                .writerName(comment.getWriter().getName())
+                .writerAdmissionYear(comment.getWriter().getAdmissionYear())
+                .writerProfileImage(comment.getWriter().getProfileImage())
+                .updatable(updatable)
+                .deletable(deletable)
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/comment/ChildCommentsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/comment/ChildCommentsResponseDto.java
@@ -1,27 +1,24 @@
 package net.causw.application.dto.comment;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.domain.Page;
 
 @Setter
 @Getter
+@Builder
 public class ChildCommentsResponseDto {
     private CommentResponseDto parentComment;
     private Page<ChildCommentResponseDto> childComments;
 
-    private ChildCommentsResponseDto(
+    public static ChildCommentsResponseDto of(
             CommentResponseDto parentComment,
             Page<ChildCommentResponseDto> childComments
     ) {
-        this.parentComment = parentComment;
-        this.childComments = childComments;
-    }
-
-    public static ChildCommentsResponseDto from(
-            CommentResponseDto parentComment,
-            Page<ChildCommentResponseDto> childComments
-    ) {
-        return new ChildCommentsResponseDto(parentComment, childComments);
+        return ChildCommentsResponseDto.builder()
+                .parentComment(parentComment)
+                .childComments(childComments)
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/comment/CommentResponseDto.java
+++ b/src/main/java/net/causw/application/dto/comment/CommentResponseDto.java
@@ -3,11 +3,7 @@ package net.causw.application.dto.comment;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import net.causw.adapter.persistence.board.Board;
 import net.causw.adapter.persistence.comment.Comment;
-import net.causw.adapter.persistence.user.User;
-import net.causw.domain.model.enums.Role;
-import net.causw.domain.model.util.StaticValue;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -32,18 +28,14 @@ public class CommentResponseDto {
 
     public static CommentResponseDto of(
             Comment comment,
-            User user,
-            Board board,
             Long numChildComment,
-            List<ChildCommentResponseDto> childCommentList
-    ) {
-        String content = comment.getIsDeleted() ? StaticValue.CONTENT_DELETED_COMMENT : comment.getContent();
-        boolean updatable = determineUpdatable(comment, user);
-        boolean deletable = determineDeletable(comment, user, board);
-
+            List<ChildCommentResponseDto> childCommentList,
+            boolean updatable,
+            boolean deletable
+    ){
         return CommentResponseDto.builder()
                 .id(comment.getId())
-                .content(content)
+                .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
                 .updatedAt(comment.getUpdatedAt())
                 .isDeleted(comment.getIsDeleted())
@@ -56,19 +48,5 @@ public class CommentResponseDto {
                 .numChildComment(numChildComment)
                 .childCommentList(childCommentList)
                 .build();
-    }
-
-    private static boolean determineUpdatable(Comment comment, User user) {
-        if (comment.getIsDeleted()) return false;
-        return user.getRole() == Role.ADMIN || comment.getWriter().getId().equals(user.getId());
-    }
-
-    private static boolean determineDeletable(Comment comment, User user, Board board) {
-        if (comment.getIsDeleted()) return false;
-        if (user.getRole() == Role.ADMIN || user.getRole().getValue().contains("PRESIDENT") || comment.getWriter().getId().equals(user.getId())) {
-            return true;
-        }
-        return board.getCircle() != null && user.getRole().getValue().contains("LEADER_CIRCLE")
-                && board.getCircle().getLeader().map(leader -> leader.getId().equals(user.getId())).orElse(false);
     }
 }

--- a/src/main/java/net/causw/application/dto/comment/CommentResponseDto.java
+++ b/src/main/java/net/causw/application/dto/comment/CommentResponseDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.comment;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.domain.model.board.BoardDomainModel;
@@ -13,6 +14,7 @@ import java.util.List;
 
 @Getter
 @Setter
+@Builder
 public class CommentResponseDto {
     private String id;
     private String content;
@@ -28,37 +30,7 @@ public class CommentResponseDto {
     private Long numChildComment;
     private List<ChildCommentResponseDto> childCommentList;
 
-    private CommentResponseDto(
-            String id,
-            String content,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            Boolean isDeleted,
-            String postId,
-            String writerName,
-            Integer writerAdmissionYear,
-            String writerProfileImage,
-            Boolean updatable,
-            Boolean deletable,
-            Long numChildComment,
-            List<ChildCommentResponseDto> childCommentList
-    ) {
-        this.id = id;
-        this.content = content;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.isDeleted = isDeleted;
-        this.postId = postId;
-        this.writerName = writerName;
-        this.writerAdmissionYear = writerAdmissionYear;
-        this.writerProfileImage = writerProfileImage;
-        this.updatable = updatable;
-        this.deletable = deletable;
-        this.numChildComment = numChildComment;
-        this.childCommentList = childCommentList;
-    }
-
-    public static CommentResponseDto from(
+    public static CommentResponseDto of(
             CommentDomainModel comment,
             UserDomainModel user,
             BoardDomainModel board,
@@ -69,10 +41,7 @@ public class CommentResponseDto {
         boolean deletable = false;
         String content = comment.getContent();
 
-        if (user.getRole() == Role.ADMIN) {
-            updatable = true;
-            deletable = true;
-        } else if (comment.getWriter().getId().equals(user.getId())) {
+        if (user.getRole() == Role.ADMIN || comment.getWriter().getId().equals(user.getId())) {
             updatable = true;
             deletable = true;
         } else if (user.getRole().getValue().contains("PRESIDENT")) {
@@ -95,20 +64,20 @@ public class CommentResponseDto {
             content = StaticValue.CONTENT_DELETED_COMMENT;
         }
 
-        return new CommentResponseDto(
-                comment.getId(),
-                content,
-                comment.getCreatedAt(),
-                comment.getUpdatedAt(),
-                comment.getIsDeleted(),
-                comment.getPostId(),
-                comment.getWriter().getName(),
-                comment.getWriter().getAdmissionYear(),
-                comment.getWriter().getProfileImage(),
-                updatable,
-                deletable,
-                numChildComment,
-                childCommentList
-        );
+        return CommentResponseDto.builder()
+                .id(comment.getId())
+                .content(content)
+                .createdAt(comment.getCreatedAt())
+                .updatedAt(comment.getUpdatedAt())
+                .isDeleted(comment.getIsDeleted())
+                .postId(comment.getPostId())
+                .writerName(comment.getWriter().getName())
+                .writerAdmissionYear(comment.getWriter().getAdmissionYear())
+                .writerProfileImage(comment.getWriter().getProfileImage())
+                .updatable(updatable)
+                .deletable(deletable)
+                .numChildComment(numChildComment)
+                .childCommentList(childCommentList)
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/comment/CommentResponseDto.java
+++ b/src/main/java/net/causw/application/dto/comment/CommentResponseDto.java
@@ -3,11 +3,11 @@ package net.causw.application.dto.comment;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import net.causw.domain.model.board.BoardDomainModel;
-import net.causw.domain.model.comment.CommentDomainModel;
+import net.causw.adapter.persistence.board.Board;
+import net.causw.adapter.persistence.comment.Comment;
+import net.causw.adapter.persistence.user.User;
 import net.causw.domain.model.enums.Role;
 import net.causw.domain.model.util.StaticValue;
-import net.causw.domain.model.user.UserDomainModel;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -31,38 +31,15 @@ public class CommentResponseDto {
     private List<ChildCommentResponseDto> childCommentList;
 
     public static CommentResponseDto of(
-            CommentDomainModel comment,
-            UserDomainModel user,
-            BoardDomainModel board,
+            Comment comment,
+            User user,
+            Board board,
             Long numChildComment,
             List<ChildCommentResponseDto> childCommentList
     ) {
-        boolean updatable = false;
-        boolean deletable = false;
-        String content = comment.getContent();
-
-        if (user.getRole() == Role.ADMIN || comment.getWriter().getId().equals(user.getId())) {
-            updatable = true;
-            deletable = true;
-        } else if (user.getRole().getValue().contains("PRESIDENT")) {
-            deletable = true;
-        } else {
-            if (board.getCircle().isPresent()) {
-                boolean isLeader = user.getRole().getValue().contains("LEADER_CIRCLE")
-                        && board.getCircle().get().getLeader()
-                        .map(leader -> leader.getId().equals(user.getId()))
-                        .orElse(false);
-                if (isLeader) {
-                    deletable = true;
-                }
-            }
-        }
-
-        if (comment.getIsDeleted()) {
-            updatable = false;
-            deletable = false;
-            content = StaticValue.CONTENT_DELETED_COMMENT;
-        }
+        String content = comment.getIsDeleted() ? StaticValue.CONTENT_DELETED_COMMENT : comment.getContent();
+        boolean updatable = determineUpdatable(comment, user);
+        boolean deletable = determineDeletable(comment, user, board);
 
         return CommentResponseDto.builder()
                 .id(comment.getId())
@@ -70,7 +47,7 @@ public class CommentResponseDto {
                 .createdAt(comment.getCreatedAt())
                 .updatedAt(comment.getUpdatedAt())
                 .isDeleted(comment.getIsDeleted())
-                .postId(comment.getPostId())
+                .postId(comment.getPost().getId())
                 .writerName(comment.getWriter().getName())
                 .writerAdmissionYear(comment.getWriter().getAdmissionYear())
                 .writerProfileImage(comment.getWriter().getProfileImage())
@@ -79,5 +56,19 @@ public class CommentResponseDto {
                 .numChildComment(numChildComment)
                 .childCommentList(childCommentList)
                 .build();
+    }
+
+    private static boolean determineUpdatable(Comment comment, User user) {
+        if (comment.getIsDeleted()) return false;
+        return user.getRole() == Role.ADMIN || comment.getWriter().getId().equals(user.getId());
+    }
+
+    private static boolean determineDeletable(Comment comment, User user, Board board) {
+        if (comment.getIsDeleted()) return false;
+        if (user.getRole() == Role.ADMIN || user.getRole().getValue().contains("PRESIDENT") || comment.getWriter().getId().equals(user.getId())) {
+            return true;
+        }
+        return board.getCircle() != null && user.getRole().getValue().contains("LEADER_CIRCLE")
+                && board.getCircle().getLeader().map(leader -> leader.getId().equals(user.getId())).orElse(false);
     }
 }

--- a/src/main/java/net/causw/application/dto/comment/CommentsOfUserResponseDto.java
+++ b/src/main/java/net/causw/application/dto/comment/CommentsOfUserResponseDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.comment;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.domain.model.comment.CommentDomainModel;
@@ -8,6 +9,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@Builder
 public class CommentsOfUserResponseDto {
     private String id;
     private String content;
@@ -21,33 +23,7 @@ public class CommentsOfUserResponseDto {
     private String circleId;
     private String circleName;
 
-    private CommentsOfUserResponseDto(
-            String id,
-            String content,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            Boolean isDeleted,
-            String boardId,
-            String boardName,
-            String postId,
-            String postName,
-            String circleId,
-            String circleName
-    ) {
-        this.id = id;
-        this.content = content;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.isDeleted = isDeleted;
-        this.boardId = boardId;
-        this.boardName = boardName;
-        this.postId = postId;
-        this.postName = postName;
-        this.circleId = circleId;
-        this.circleName = circleName;
-    }
-
-    public static CommentsOfUserResponseDto from(
+    public static CommentsOfUserResponseDto of(
             CommentDomainModel comment,
             String boardId,
             String boardName,
@@ -56,18 +32,18 @@ public class CommentsOfUserResponseDto {
             String circleId,
             String circleName
     ) {
-        return new CommentsOfUserResponseDto(
-                comment.getId(),
-                comment.getContent(),
-                comment.getCreatedAt(),
-                comment.getUpdatedAt(),
-                comment.getIsDeleted(),
-                boardId,
-                boardName,
-                postId,
-                postName,
-                circleId,
-                circleName
-        );
+        return CommentsOfUserResponseDto.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .updatedAt(comment.getUpdatedAt())
+                .isDeleted(comment.getIsDeleted())
+                .boardId(boardId)
+                .boardName(boardName)
+                .postId(postId)
+                .postName(postName)
+                .circleId(circleId)
+                .circleName(circleName)
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/duplicate/DuplicatedCheckResponseDto.java
+++ b/src/main/java/net/causw/application/dto/duplicate/DuplicatedCheckResponseDto.java
@@ -1,21 +1,21 @@
 package net.causw.application.dto.duplicate;
 
 import io.swagger.annotations.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Builder
 public class DuplicatedCheckResponseDto {
 
     @ApiModelProperty(value = "중복 여부 boolean 값", example = "true")
     private Boolean result;
 
-    private DuplicatedCheckResponseDto(boolean result) {
-        this.result = result;
-    }
-
-    public static DuplicatedCheckResponseDto of(boolean result) {
-        return new DuplicatedCheckResponseDto(result);
+    public static DuplicatedCheckResponseDto from(boolean result) {
+        return DuplicatedCheckResponseDto.builder()
+                .result(result)
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/exception/ConstraintExceptionDto.java
+++ b/src/main/java/net/causw/application/dto/exception/ConstraintExceptionDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.exception;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.domain.exceptions.ErrorCode;
@@ -11,22 +12,24 @@ import java.util.List;
 
 @Getter
 @Setter
+@Builder
 public class ConstraintExceptionDto {
     private final Integer errorCode;
     private final String message;
     private final LocalDateTime timeStamp;
     private final List<String> violations;
 
-    public ConstraintExceptionDto(ErrorCode errorCode, String message, ConstraintViolationException exception) {
-        this.errorCode = errorCode.getCode();
-        this.message = message;
-
+    public static ConstraintExceptionDto of(ErrorCode errorCode, String message, ConstraintViolationException exception) {
         List<String> errors = new ArrayList<>();
         exception.getConstraintViolations().forEach(violation ->
                 errors.add(violation.getRootBeanClass().getName() + " " +
-                violation.getPropertyPath() + ": " + violation.getMessage()));
+                        violation.getPropertyPath() + ": " + violation.getMessage()));
 
-        this.violations = errors;
-        this.timeStamp = LocalDateTime.now();
+        return ConstraintExceptionDto.builder()
+                .errorCode(errorCode.getCode())
+                .message(message)
+                .violations(errors)
+                .timeStamp(LocalDateTime.now())
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/exception/ExceptionDto.java
+++ b/src/main/java/net/causw/application/dto/exception/ExceptionDto.java
@@ -1,19 +1,25 @@
 package net.causw.application.dto.exception;
 
+import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 import net.causw.domain.exceptions.ErrorCode;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
+@Builder
 public class ExceptionDto {
     private final Integer errorCode;
     private final String message;
     private final LocalDateTime timeStamp;
 
-    public ExceptionDto(ErrorCode errorCode, String message) {
-        this.errorCode = errorCode.getCode();
-        this.message = message;
-        this.timeStamp = LocalDateTime.now();
+    public static ExceptionDto of(ErrorCode errorCode, String message) {
+        return ExceptionDto.builder()
+                .errorCode(errorCode.getCode())
+                .message(message)
+                .timeStamp(LocalDateTime.now())
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/file/FileResponseDto.java
+++ b/src/main/java/net/causw/application/dto/file/FileResponseDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.file;
 
 //import com.google.cloud.storage.Blob;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,23 +11,16 @@ import java.util.Arrays;
 
 @Getter
 @Setter
+@Builder
 public class FileResponseDto {
     private String originalFileName;
     private String downloadFilePath;
 
-    private FileResponseDto(
-            String originalFileName,
-            String downloadFilePath
-    ) {
-        this.originalFileName = originalFileName;
-        this.downloadFilePath = downloadFilePath;
-    }
-
     public static FileResponseDto from(String filePath) {
-        return new FileResponseDto(
-                Arrays.stream(URLDecoder.decode(filePath, StandardCharsets.UTF_8).split("/"))
-                        .reduce((a, b) -> b).orElse(null),
-                filePath
-        );
+        return FileResponseDto.builder()
+                .originalFileName(Arrays.stream(URLDecoder.decode(filePath, StandardCharsets.UTF_8).split("/"))
+                        .reduce((a, b) -> b).orElse(null))
+                .downloadFilePath(filePath)
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/file/UploadFileResponseDto.java
+++ b/src/main/java/net/causw/application/dto/file/UploadFileResponseDto.java
@@ -1,18 +1,18 @@
 package net.causw.application.dto.file;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Builder
 public class UploadFileResponseDto {
     private String path;
 
-    private UploadFileResponseDto(String path) {
-        this.path = path;
-    }
-
-    public static UploadFileResponseDto of(String path) {
-        return new UploadFileResponseDto(path);
+    public static UploadFileResponseDto from(String path) {
+        return UploadFileResponseDto.builder()
+                .path(path)
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/homepage/HomePageResponseDto.java
+++ b/src/main/java/net/causw/application/dto/homepage/HomePageResponseDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.homepage;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.application.dto.board.BoardResponseDto;
@@ -8,25 +9,18 @@ import org.springframework.data.domain.Page;
 
 @Getter
 @Setter
+@Builder
 public class HomePageResponseDto {
     private BoardResponseDto board;
     private Page<PostsResponseDto> posts;
 
-    private HomePageResponseDto(
+    public static HomePageResponseDto of(
             BoardResponseDto board,
             Page<PostsResponseDto> posts
     ) {
-        this.board = board;
-        this.posts = posts;
-    }
-
-    public static HomePageResponseDto from(
-            BoardResponseDto board,
-            Page<PostsResponseDto> posts
-    ) {
-        return new HomePageResponseDto(
-                board,
-                posts
-        );
+        return HomePageResponseDto.builder()
+                .board(board)
+                .posts(posts)
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/inquiry/InquiryCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/inquiry/InquiryCreateRequestDto.java
@@ -2,11 +2,13 @@ package net.causw.application.dto.inquiry;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
 @AllArgsConstructor
+@NoArgsConstructor
 public class InquiryCreateRequestDto {
     private String title;
     private String content;

--- a/src/main/java/net/causw/application/dto/inquiry/InquiryResponseDto.java
+++ b/src/main/java/net/causw/application/dto/inquiry/InquiryResponseDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.inquiry;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.domain.model.inquiry.InquiryDomainModel;
@@ -10,6 +11,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@Builder
 public class InquiryResponseDto {
     private String id;
     private String title;
@@ -21,49 +23,28 @@ public class InquiryResponseDto {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    private InquiryResponseDto(
-            String id,
-            String title,
-            String content,
-            Boolean isDeleted,
-            String writerName,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt
-    ) {
-        this.id = id;
-        this.title = title;
-        this.content = content;
-        this.isDeleted = isDeleted;
-        this.writerName = writerName;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-    }
-
-    public static InquiryResponseDto from(
+    public static InquiryResponseDto of(
             InquiryDomainModel inquiry,
             UserDomainModel user
     ){
         boolean updatable = false;
         boolean deletable = false;
 
-        if (user.getRole() == Role.ADMIN) {
+        if (user.getRole() == Role.ADMIN || inquiry.getWriter().getId().equals(user.getId())) {
             updatable = true;
             deletable = true;
-        } else if (inquiry.getWriter().getId().equals(user.getId())) {
-            updatable = true;
-            deletable = true;
-        } else {
-
         }
 
-        return new InquiryResponseDto(
-                inquiry.getId(),
-                inquiry.getTitle(),
-                inquiry.getContent(),
-                inquiry.getIsDeleted(),
-                inquiry.getWriter().getName(),
-                inquiry.getCreatedAt(),
-                inquiry.getUpdatedAt()
-        );
+        return InquiryResponseDto.builder()
+                .id(inquiry.getId())
+                .title(inquiry.getTitle())
+                .content(inquiry.getContent())
+                .isDeleted(inquiry.getIsDeleted())
+                .writerName(inquiry.getWriter().getName())
+                .updatable(updatable)
+                .deletable(deletable)
+                .createdAt(inquiry.getCreatedAt())
+                .updatedAt(inquiry.getUpdatedAt())
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/locker/LockerExpiredAtRequestDto.java
+++ b/src/main/java/net/causw/application/dto/locker/LockerExpiredAtRequestDto.java
@@ -1,14 +1,15 @@
 package net.causw.application.dto.locker;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class LockerExpiredAtRequestDto {

--- a/src/main/java/net/causw/application/dto/locker/LockerLocationResponseDto.java
+++ b/src/main/java/net/causw/application/dto/locker/LockerLocationResponseDto.java
@@ -1,40 +1,29 @@
 package net.causw.application.dto.locker;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.domain.model.locker.LockerLocationDomainModel;
 
 @Getter
 @Setter
+@Builder
 public class LockerLocationResponseDto {
     private String id;
     private String name;
     private Long enableLockerCount;
     private Long totalLockerCount;
 
-    private LockerLocationResponseDto(
-            String id,
-            String name,
-            Long enableLockerCount,
-            Long totalLockerCount
-    ) {
-        this.id = id;
-        this.name = name;
-        this.enableLockerCount = enableLockerCount;
-        this.totalLockerCount = totalLockerCount;
-    }
-
-    public static LockerLocationResponseDto from(
+    public static LockerLocationResponseDto of(
             LockerLocationDomainModel lockerLocation,
             Long enableLockerCount,
             Long totalLockerCount
     ) {
-        return new LockerLocationResponseDto(
-                lockerLocation.getId(),
-                lockerLocation.getName(),
-                enableLockerCount,
-                totalLockerCount
-        );
+        return LockerLocationResponseDto.builder()
+                .id(lockerLocation.getId())
+                .name(lockerLocation.getName())
+                .enableLockerCount(enableLockerCount)
+                .totalLockerCount(totalLockerCount)
+                .build();
     }
-
 }

--- a/src/main/java/net/causw/application/dto/locker/LockerLocationsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/locker/LockerLocationsResponseDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.locker;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -7,22 +8,18 @@ import java.util.List;
 
 @Getter
 @Setter
+@Builder
 public class LockerLocationsResponseDto {
     private List<LockerLocationResponseDto> lockerLocations;
     private LockerResponseDto myLocker;
-
-    private LockerLocationsResponseDto(
-            List<LockerLocationResponseDto> lockerLocations,
-            LockerResponseDto myLocker
-    ) {
-        this.lockerLocations = lockerLocations;
-        this.myLocker = myLocker;
-    }
 
     public static LockerLocationsResponseDto of(
             List<LockerLocationResponseDto> lockerLocations,
             LockerResponseDto myLocker
     ) {
-        return new LockerLocationsResponseDto(lockerLocations, myLocker);
+        return LockerLocationsResponseDto.builder()
+                .lockerLocations(lockerLocations)
+                .myLocker(myLocker)
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/locker/LockerLogResponseDto.java
+++ b/src/main/java/net/causw/application/dto/locker/LockerLogResponseDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.locker;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.adapter.persistence.locker.LockerLog;
@@ -9,6 +10,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@Builder
 public class LockerLogResponseDto {
     private final Long lockerNumber;
     private final String userEmail;
@@ -18,33 +20,15 @@ public class LockerLogResponseDto {
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    private LockerLogResponseDto(
-            Long lockerNumber,
-            String userEmail,
-            String userName,
-            LockerLogAction action,
-            String message,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt
-    ) {
-        this.lockerNumber = lockerNumber;
-        this.userEmail = userEmail;
-        this.userName = userName;
-        this.action = action;
-        this.message = message;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-    }
-
     public static LockerLogResponseDto from(LockerLog lockerLog) {
-        return new LockerLogResponseDto(
-                lockerLog.getLockerNumber(),
-                lockerLog.getUserEmail(),
-                lockerLog.getUserName(),
-                lockerLog.getAction(),
-                lockerLog.getMessage(),
-                lockerLog.getCreatedAt(),
-                lockerLog.getUpdatedAt()
-        );
+        return LockerLogResponseDto.builder()
+                .lockerNumber(lockerLog.getLockerNumber())
+                .userEmail(lockerLog.getUserEmail())
+                .userName(lockerLog.getUserName())
+                .action(lockerLog.getAction())
+                .message(lockerLog.getMessage())
+                .createdAt(lockerLog.getCreatedAt())
+                .updatedAt(lockerLog.getUpdatedAt())
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/locker/LockerResponseDto.java
+++ b/src/main/java/net/causw/application/dto/locker/LockerResponseDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.locker;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.adapter.persistence.locker.Locker;
@@ -13,6 +14,7 @@ import java.util.Optional;
 
 @Getter
 @Setter
+@Builder
 public class LockerResponseDto {
     private String id;
     private String lockerNumber;
@@ -21,61 +23,45 @@ public class LockerResponseDto {
     private String expireAt;
     private LocalDateTime updatedAt;
 
-    private LockerResponseDto(
-            String id,
-            String lockerNumber,
-            Boolean isActive,
-            Boolean isMine,
-            String expireAt,
-            LocalDateTime updateAt
-    ) {
-        this.id = id;
-        this.lockerNumber = lockerNumber;
-        this.isActive = isActive;
-        this.isMine = isMine;
-        this.expireAt = expireAt;
-        this.updatedAt = updateAt;
+    public static LockerResponseDto of(Locker locker, UserDomainModel user) {
+        return LockerResponseDto.builder()
+                .id(locker.getId())
+                .lockerNumber(String.valueOf(locker.getLockerNumber()))
+                .isActive(locker.getIsActive())
+                .isMine(locker.getUser().map(User::getId).orElse("").equals(user.getId()))
+                .expireAt(Optional.ofNullable(locker.getExpireDate()).map(
+                        expire -> expire.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"))).orElse(null))
+                .updatedAt(locker.getUpdatedAt())
+                .build();
     }
 
-    public static LockerResponseDto from(Locker locker, UserDomainModel user) {
-        return new LockerResponseDto(
-                locker.getId(),
-                String.valueOf(locker.getLockerNumber()),
-                locker.getIsActive(),
-                locker.getUser().map(User::getId).orElse("").equals(user.getId()),
-                Optional.ofNullable(locker.getExpireDate()).map(
-                        expire -> expire.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"))).orElse(null),
-                locker.getUpdatedAt()
-        );
+    public static LockerResponseDto of(LockerDomainModel locker, UserDomainModel user) {
+        return LockerResponseDto.builder()
+                .id(locker.getId())
+                .lockerNumber(String.valueOf(locker.getLockerNumber()))
+                .isActive(locker.getIsActive())
+                .isMine(locker.getUser().map(UserDomainModel::getId).orElse("").equals(user.getId()))
+                .expireAt(Optional.ofNullable(locker.getExpiredAt()).map(
+                        expire -> expire.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"))).orElse(null))
+                .updatedAt(locker.getUpdatedAt())
+                .build();
     }
 
-    public static LockerResponseDto from(LockerDomainModel locker, UserDomainModel user) {
-        return new LockerResponseDto(
-                locker.getId(),
-                String.valueOf(locker.getLockerNumber()),
-                locker.getIsActive(),
-                locker.getUser().map(UserDomainModel::getId).orElse("").equals(user.getId()),
-                Optional.ofNullable(locker.getExpiredAt()).map(
-                        expire -> expire.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"))).orElse(null),
-                locker.getUpdatedAt()
-        );
-    }
-
-    public static LockerResponseDto from(
+    public static LockerResponseDto of(
             LockerDomainModel locker,
             UserDomainModel user,
             String locationName
     ) {
         String location = locationName + " " + locker.getLockerNumber();
 
-        return new LockerResponseDto(
-                locker.getId(),
-                location,
-                locker.getIsActive(),
-                locker.getUser().map(UserDomainModel::getId).orElse("").equals(user.getId()),
-                Optional.ofNullable(locker.getExpiredAt()).map(
-                        expire -> expire.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"))).orElse(null),
-                locker.getUpdatedAt()
-        );
+        return LockerResponseDto.builder()
+                .id(locker.getId())
+                .lockerNumber(location)
+                .isActive(locker.getIsActive())
+                .isMine(locker.getUser().map(UserDomainModel::getId).orElse("").equals(user.getId()))
+                .expireAt(Optional.ofNullable(locker.getExpiredAt()).map(
+                        expire -> expire.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"))).orElse(null))
+                .updatedAt(locker.getUpdatedAt())
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/locker/LockersResponseDto.java
+++ b/src/main/java/net/causw/application/dto/locker/LockersResponseDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.locker;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -7,16 +8,15 @@ import java.util.List;
 
 @Getter
 @Setter
+@Builder
 public class LockersResponseDto {
     private String locationName;
     private List<LockerResponseDto> lockerList;
 
-    private LockersResponseDto(String locationName, List<LockerResponseDto> lockerList) {
-        this.locationName = locationName;
-        this.lockerList = lockerList;
-    }
-
     public static LockersResponseDto of(String locationName, List<LockerResponseDto> lockerList) {
-        return new LockersResponseDto(locationName, lockerList);
+        return LockersResponseDto.builder()
+                .locationName(locationName)
+                .lockerList(lockerList)
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/post/BoardPostsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/BoardPostsResponseDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.post;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.domain.model.board.BoardDomainModel;
@@ -9,6 +10,7 @@ import org.springframework.data.domain.Page;
 
 @Getter
 @Setter
+@Builder
 public class BoardPostsResponseDto {
 
     @ApiModelProperty(value = "게시판 id", example = "uuid 형식의 String 값입니다.")
@@ -26,32 +28,18 @@ public class BoardPostsResponseDto {
     @ApiModelProperty(value = "게시글 정보입니다", example = "게시글 정보입니다")
     private Page<PostsResponseDto> post;
 
-    private BoardPostsResponseDto(
-            String boardId,
-            String boardName,
-            Boolean writable,
-            Boolean isFavorite,
-            Page<PostsResponseDto> post
-    ) {
-        this.boardId = boardId;
-        this.boardName = boardName;
-        this.writable = writable;
-        this.isFavorite = isFavorite;
-        this.post = post;
-    }
-
     public static BoardPostsResponseDto from(
             BoardDomainModel boardDomainModel,
             Role userRole,
             Boolean isFavorite,
             Page<PostsResponseDto> post
     ) {
-        return new BoardPostsResponseDto(
-                boardDomainModel.getId(),
-                boardDomainModel.getName(),
-                boardDomainModel.getCreateRoleList().stream().anyMatch(str -> userRole.getValue().contains(str)),
-                isFavorite,
-                post
-        );
+        return BoardPostsResponseDto.builder()
+                .boardId(boardDomainModel.getId())
+                .boardName(boardDomainModel.getName())
+                .writable(boardDomainModel.getCreateRoleList().stream().anyMatch(str -> userRole.getValue().contains(str)))
+                .isFavorite(isFavorite)
+                .post(post)
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/post/BoardPostsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/BoardPostsResponseDto.java
@@ -4,9 +4,13 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import net.causw.domain.model.board.BoardDomainModel;
+import net.causw.adapter.persistence.board.Board;
 import net.causw.domain.model.enums.Role;
 import org.springframework.data.domain.Page;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 @Getter
 @Setter
@@ -28,16 +32,17 @@ public class BoardPostsResponseDto {
     @ApiModelProperty(value = "게시글 정보입니다", example = "게시글 정보입니다")
     private Page<PostsResponseDto> post;
 
-    public static BoardPostsResponseDto from(
-            BoardDomainModel boardDomainModel,
+    public static BoardPostsResponseDto of(
+            Board board,
             Role userRole,
             Boolean isFavorite,
             Page<PostsResponseDto> post
     ) {
+        List<String> roles = new ArrayList<>(Arrays.asList(board.getCreateRoles().split(",")));
         return BoardPostsResponseDto.builder()
-                .boardId(boardDomainModel.getId())
-                .boardName(boardDomainModel.getName())
-                .writable(boardDomainModel.getCreateRoleList().stream().anyMatch(str -> userRole.getValue().contains(str)))
+                .boardId(board.getId())
+                .boardName(board.getName())
+                .writable(roles.stream().anyMatch(str -> userRole.getValue().contains(str)))
                 .isFavorite(isFavorite)
                 .post(post)
                 .build();

--- a/src/main/java/net/causw/application/dto/post/PostResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/PostResponseDto.java
@@ -4,12 +4,9 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import net.causw.adapter.persistence.board.Board;
 import net.causw.adapter.persistence.post.Post;
-import net.causw.adapter.persistence.user.User;
 import net.causw.application.dto.file.FileResponseDto;
 import net.causw.application.dto.comment.CommentResponseDto;
-import net.causw.domain.model.enums.Role;
 import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
@@ -68,12 +65,10 @@ public class PostResponseDto {
 
     public static PostResponseDto of(
             Post post,
-            User user
+            boolean updatable,
+            boolean deletable
     ) {
-        boolean updatable = determineUpdatable(post, user);
-        boolean deletable = determineDeletable(post, user, post.getBoard());
         List<String> attachmentList = post.getAttachments().map(attachments -> Arrays.asList(attachments.split(":::"))).orElse(List.of());
-
         return PostResponseDto.builder()
                 .id(post.getId())
                 .title(post.getTitle())
@@ -93,12 +88,11 @@ public class PostResponseDto {
 
     public static PostResponseDto of(
             Post post,
-            User user,
             Page<CommentResponseDto> commentList,
-            Long numComment
+            Long numComment,
+            boolean updatable,
+            boolean deletable
     ) {
-        boolean updatable = determineUpdatable(post, user);
-        boolean deletable = determineDeletable(post, user, post.getBoard());
         List<String> attachmentList = post.getAttachments().map(attachments -> Arrays.asList(attachments.split(":::"))).orElse(List.of());
 
         return PostResponseDto.builder()
@@ -118,20 +112,5 @@ public class PostResponseDto {
                 .commentList(commentList)
                 .boardName(post.getBoard().getName())
                 .build();
-    }
-
-    // FIXME: 일종의 비즈니스 및 유효성 검사 로직이 Dto에 존재하는 상황은 바람직하지 않음. 수정 필요
-    private static boolean determineUpdatable(Post post, User user) {
-        if (post.getIsDeleted()) return false;
-        return user.getRole() == Role.ADMIN || post.getWriter().getId().equals(user.getId());
-    }
-
-    private static boolean determineDeletable(Post post, User user, Board board) {
-        if (post.getIsDeleted()) return false;
-        if (user.getRole() == Role.ADMIN || user.getRole().getValue().contains("PRESIDENT") || post.getWriter().getId().equals(user.getId())) {
-            return true;
-        }
-        return board.getCircle() != null && user.getRole().getValue().contains("LEADER_CIRCLE")
-                && board.getCircle().getLeader().map(leader -> leader.getId().equals(user.getId())).orElse(false);
     }
 }

--- a/src/main/java/net/causw/application/dto/post/PostResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/PostResponseDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.post;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.application.dto.file.FileResponseDto;
@@ -16,6 +17,7 @@ import java.util.stream.Collectors;
 
 @Getter
 @Setter
+@Builder
 public class PostResponseDto {
     @ApiModelProperty(value = "게시글 id", example = "uuid 형식의 String 값입니다.")
     private String id;
@@ -62,51 +64,14 @@ public class PostResponseDto {
     @ApiModelProperty(value = "게시판 이름", example =  "게시판 이름입니다.")
     private String boardName;
 
-    private PostResponseDto(
-            String id,
-            String title,
-            String content,
-            Boolean isDeleted,
-            String writerProfileImage,
-            String writerName,
-            Integer writerAdmissionYear,
-            List<FileResponseDto> attachmentList,
-            Long numComment,
-            Boolean updatable,
-            Boolean deletable,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            Page<CommentResponseDto> commentList,
-            String boardName
-    ) {
-        this.id = id;
-        this.title = title;
-        this.content = content;
-        this.isDeleted = isDeleted;
-        this.writerProfileImage = writerProfileImage;
-        this.writerName = writerName;
-        this.writerAdmissionYear = writerAdmissionYear;
-        this.attachmentList = attachmentList;
-        this.numComment = numComment;
-        this.updatable = updatable;
-        this.deletable = deletable;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.commentList = commentList;
-        this.boardName = boardName;
-    }
-
-    public static PostResponseDto from(
+    public static PostResponseDto of(
             PostDomainModel post,
             UserDomainModel user
     ) {
         boolean updatable = false;
         boolean deletable = false;
 
-        if (user.getRole() == Role.ADMIN) {
-            updatable = true;
-            deletable = true;
-        } else if (post.getWriter().getId().equals(user.getId())) {
+        if (user.getRole() == Role.ADMIN || post.getWriter().getId().equals(user.getId())) {
             updatable = true;
             deletable = true;
         } else if (user.getRole().getValue().contains("PRESIDENT")) {
@@ -123,26 +88,24 @@ public class PostResponseDto {
             }
         }
 
-        return new PostResponseDto(
-                post.getId(),
-                post.getTitle(),
-                post.getContent(),
-                post.getIsDeleted(),
-                post.getWriter().getProfileImage(),
-                post.getWriter().getName(),
-                post.getWriter().getAdmissionYear(),
-                post.getAttachmentList().stream().map(FileResponseDto::from).collect(Collectors.toList()),
-                0L,
-                updatable,
-                deletable,
-                post.getCreatedAt(),
-                post.getUpdatedAt(),
-                null,
-                null
-        );
+        return PostResponseDto.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .isDeleted(post.getIsDeleted())
+                .writerName(post.getWriter().getName())
+                .writerAdmissionYear(post.getWriter().getAdmissionYear())
+                .writerProfileImage(post.getWriter().getProfileImage())
+                .attachmentList(post.getAttachmentList().stream().map(FileResponseDto::from).collect(Collectors.toList()))
+                .numComment(0L)
+                .updatable(updatable)
+                .deletable(deletable)
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
     }
 
-    public static PostResponseDto from(
+    public static PostResponseDto of(
             PostDomainModel post,
             UserDomainModel user,
             Page<CommentResponseDto> commentList,
@@ -151,10 +114,7 @@ public class PostResponseDto {
         boolean updatable = false;
         boolean deletable = false;
 
-        if (user.getRole() == Role.ADMIN) {
-            updatable = true;
-            deletable = true;
-        } else if (post.getWriter().getId().equals(user.getId())) {
+        if (user.getRole() == Role.ADMIN || post.getWriter().getId().equals(user.getId())) {
             updatable = true;
             deletable = true;
         } else if (user.getRole().getValue().contains("PRESIDENT")) {
@@ -171,22 +131,22 @@ public class PostResponseDto {
             }
         }
 
-        return new PostResponseDto(
-                post.getId(),
-                post.getTitle(),
-                post.getContent(),
-                post.getIsDeleted(),
-                post.getWriter().getProfileImage(),
-                post.getWriter().getName(),
-                post.getWriter().getAdmissionYear(),
-                post.getAttachmentList().stream().map(FileResponseDto::from).collect(Collectors.toList()),
-                numComment,
-                updatable,
-                deletable,
-                post.getCreatedAt(),
-                post.getUpdatedAt(),
-                commentList,
-                post.getBoard().getName()
-        );
+        return PostResponseDto.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .isDeleted(post.getIsDeleted())
+                .writerName(post.getWriter().getName())
+                .writerAdmissionYear(post.getWriter().getAdmissionYear())
+                .writerProfileImage(post.getWriter().getProfileImage())
+                .attachmentList(post.getAttachmentList().stream().map(FileResponseDto::from).collect(Collectors.toList()))
+                .numComment(numComment)
+                .updatable(updatable)
+                .deletable(deletable)
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .commentList(commentList)
+                .boardName(post.getBoard().getName())
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/post/PostsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/PostsResponseDto.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import net.causw.adapter.persistence.post.Post;
 import net.causw.domain.model.post.PostDomainModel;
 
 import java.time.LocalDateTime;
@@ -36,8 +37,25 @@ public class PostsResponseDto {
     @ApiModelProperty(value = "게시글 삭제여부", example = "false")
     private Boolean isDeleted;
 
+    // FIXME: Domain model 사용하는 생성메서드 삭제 필요 (컴파일 에러 방지 목적으로 일단 대기)
     public static PostsResponseDto of(
             PostDomainModel post,
+            Long numComment
+    ) {
+        return PostsResponseDto.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .writerName(post.getWriter().getName())
+                .writerAdmissionYear(post.getWriter().getAdmissionYear())
+                .numComment(numComment)
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .isDeleted(post.getIsDeleted())
+                .build();
+    }
+
+    public static PostsResponseDto of(
+            Post post,
             Long numComment
     ) {
         return PostsResponseDto.builder()

--- a/src/main/java/net/causw/application/dto/post/PostsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/PostsResponseDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.post;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.domain.model.post.PostDomainModel;
@@ -9,6 +10,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@Builder
 public class PostsResponseDto {
     @ApiModelProperty(value = "게시글 id", example = "uuid 형식의 String 값입니다.")
     private String id;
@@ -34,39 +36,19 @@ public class PostsResponseDto {
     @ApiModelProperty(value = "게시글 삭제여부", example = "false")
     private Boolean isDeleted;
 
-    private PostsResponseDto(
-            String id,
-            String title,
-            String writerName,
-            Integer writerAdmissionYear,
-            Long numComment,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            Boolean isDeleted
-    ) {
-        this.id = id;
-        this.title = title;
-        this.writerName = writerName;
-        this.writerAdmissionYear = writerAdmissionYear;
-        this.numComment = numComment;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.isDeleted = isDeleted;
-    }
-
-    public static PostsResponseDto from(
+    public static PostsResponseDto of(
             PostDomainModel post,
             Long numComment
     ) {
-        return new PostsResponseDto(
-                post.getId(),
-                post.getTitle(),
-                post.getWriter().getName(),
-                post.getWriter().getAdmissionYear(),
-                numComment,
-                post.getCreatedAt(),
-                post.getUpdatedAt(),
-                post.getIsDeleted()
-        );
+        return PostsResponseDto.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .writerName(post.getWriter().getName())
+                .writerAdmissionYear(post.getWriter().getAdmissionYear())
+                .numComment(numComment)
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .isDeleted(post.getIsDeleted())
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/user/UserAdmissionResponseDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserAdmissionResponseDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.user;
 
 import io.swagger.annotations.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.domain.model.user.UserAdmissionDomainModel;
@@ -10,12 +11,14 @@ import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@Builder
 public class UserAdmissionResponseDto {
 
     @ApiModelProperty(value = "승인 고유 id 값", example = "uuid 형식의 String 값입니다.", required = true)
     private String id;
 
     private UserResponseDto user;
+
     private String attachImage;
 
     @ApiModelProperty(value = "자기소개 글 (255자 이내)", example = "안녕하세요! 코딩을 좋아하는 신입생 이예빈입니다.")
@@ -27,44 +30,28 @@ public class UserAdmissionResponseDto {
     @ApiModelProperty(value = "마지막 업데이트된 시각", example = "2024-01-24T00:26:40.643Z")
     private LocalDateTime updatedAt;
 
-    public UserAdmissionResponseDto(
-            String id,
-            UserResponseDto user,
-            String attachImage,
-            String description,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt
-    ) {
-        this.id = id;
-        this.user = user;
-        this.attachImage = attachImage;
-        this.description = description;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-    }
-
     public static UserAdmissionResponseDto from(UserAdmissionDomainModel userAdmissionDomainModel) {
-        return new UserAdmissionResponseDto(
-                userAdmissionDomainModel.getId(),
-                UserResponseDto.from(userAdmissionDomainModel.getUser()),
-                userAdmissionDomainModel.getAttachImage(),
-                userAdmissionDomainModel.getDescription(),
-                userAdmissionDomainModel.getCreatedAt(),
-                userAdmissionDomainModel.getUpdatedAt()
-        );
+        return UserAdmissionResponseDto.builder()
+                .id(userAdmissionDomainModel.getId())
+                .user(UserResponseDto.from(userAdmissionDomainModel.getUser()))
+                .attachImage(userAdmissionDomainModel.getAttachImage())
+                .description(userAdmissionDomainModel.getDescription())
+                .createdAt(userAdmissionDomainModel.getCreatedAt())
+                .updatedAt(userAdmissionDomainModel.getUpdatedAt())
+                .build();
     }
 
-    public static UserAdmissionResponseDto from(
+    public static UserAdmissionResponseDto of(
             UserAdmissionDomainModel userAdmissionDomainModel,
             UserDomainModel user
     ) {
-        return new UserAdmissionResponseDto(
-                userAdmissionDomainModel.getId(),
-                UserResponseDto.from(user),
-                userAdmissionDomainModel.getAttachImage(),
-                userAdmissionDomainModel.getDescription(),
-                userAdmissionDomainModel.getCreatedAt(),
-                userAdmissionDomainModel.getUpdatedAt()
-        );
+        return UserAdmissionResponseDto.builder()
+                .id(userAdmissionDomainModel.getId())
+                .user(UserResponseDto.from(user))
+                .attachImage(userAdmissionDomainModel.getAttachImage())
+                .description(userAdmissionDomainModel.getDescription())
+                .createdAt(userAdmissionDomainModel.getCreatedAt())
+                .updatedAt(userAdmissionDomainModel.getUpdatedAt())
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/user/UserAdmissionsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserAdmissionsResponseDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.user;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.domain.model.user.UserAdmissionDomainModel;
@@ -9,6 +10,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@Builder
 public class UserAdmissionsResponseDto {
     private String id;
     private String userName;
@@ -20,39 +22,17 @@ public class UserAdmissionsResponseDto {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public UserAdmissionsResponseDto(
-            String id,
-            String userName,
-            String userEmail,
-            Integer admissionYear,
-            String attachImage,
-            String description,
-            UserState userState,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt
-    ) {
-        this.id = id;
-        this.userName = userName;
-        this.userEmail = userEmail;
-        this.admissionYear = admissionYear;
-        this.attachImage = attachImage;
-        this.description = description;
-        this.userState = userState;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-    }
-
     public static UserAdmissionsResponseDto from(UserAdmissionDomainModel userAdmissionDomainModel) {
-        return new UserAdmissionsResponseDto(
-                userAdmissionDomainModel.getId(),
-                userAdmissionDomainModel.getUser().getName(),
-                userAdmissionDomainModel.getUser().getEmail(),
-                userAdmissionDomainModel.getUser().getAdmissionYear(),
-                userAdmissionDomainModel.getAttachImage(),
-                userAdmissionDomainModel.getDescription(),
-                userAdmissionDomainModel.getUser().getState(),
-                userAdmissionDomainModel.getCreatedAt(),
-                userAdmissionDomainModel.getUpdatedAt()
-        );
+        return UserAdmissionsResponseDto.builder()
+                .id(userAdmissionDomainModel.getId())
+                .userName(userAdmissionDomainModel.getUser().getName())
+                .userEmail(userAdmissionDomainModel.getUser().getEmail())
+                .admissionYear(userAdmissionDomainModel.getUser().getAdmissionYear())
+                .attachImage(userAdmissionDomainModel.getAttachImage())
+                .description(userAdmissionDomainModel.getDescription())
+                .userState(userAdmissionDomainModel.getUser().getState())
+                .createdAt(userAdmissionDomainModel.getCreatedAt())
+                .updatedAt(userAdmissionDomainModel.getUpdatedAt())
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/user/UserCommentsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserCommentsResponseDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.user;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.application.dto.comment.CommentsOfUserResponseDto;
@@ -8,6 +9,7 @@ import org.springframework.data.domain.Page;
 
 @Getter
 @Setter
+@Builder
 public class UserCommentsResponseDto {
     private String id;
     private String email;
@@ -17,36 +19,18 @@ public class UserCommentsResponseDto {
     private String profileImage;
     private Page<CommentsOfUserResponseDto> comment;
 
-    private UserCommentsResponseDto(
-            String id,
-            String email,
-            String name,
-            String studentId,
-            Integer admissionYear,
-            String profileImage,
-            Page<CommentsOfUserResponseDto> comment
-    ) {
-        this.id = id;
-        this.email = email;
-        this.name = name;
-        this.studentId = studentId;
-        this.admissionYear = admissionYear;
-        this.profileImage = profileImage;
-        this.comment = comment;
-    }
-
-    public static UserCommentsResponseDto from(
+    public static UserCommentsResponseDto of(
             UserDomainModel user,
             Page<CommentsOfUserResponseDto> comment
     ) {
-        return new UserCommentsResponseDto(
-                user.getId(),
-                user.getEmail(),
-                user.getName(),
-                user.getStudentId(),
-                user.getAdmissionYear(),
-                user.getProfileImage(),
-                comment
-        );
+        return UserCommentsResponseDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .studentId(user.getStudentId())
+                .admissionYear(user.getAdmissionYear())
+                .profileImage(user.getProfileImage())
+                .comment(comment)
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/user/UserPostResponseDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserPostResponseDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.user;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.domain.model.post.PostDomainModel;
@@ -8,6 +9,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@Builder
 public class UserPostResponseDto {
     private String id;
     private String title;
@@ -19,29 +21,7 @@ public class UserPostResponseDto {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    private UserPostResponseDto(
-            String id,
-            String title,
-            String boardId,
-            String boardName,
-            String circleId,
-            String circleName,
-            Long numComment,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt
-    ) {
-        this.id = id;
-        this.title = title;
-        this.boardId = boardId;
-        this.boardName = boardName;
-        this.circleId = circleId;
-        this.circleName = circleName;
-        this.numComment = numComment;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-    }
-
-    public static UserPostResponseDto from(
+    public static UserPostResponseDto of(
             PostDomainModel post,
             String boardId,
             String boardName,
@@ -49,16 +29,16 @@ public class UserPostResponseDto {
             String circleName,
             Long numComment
     ) {
-        return new UserPostResponseDto(
-                post.getId(),
-                post.getTitle(),
-                boardId,
-                boardName,
-                circleId,
-                circleName,
-                numComment,
-                post.getCreatedAt(),
-                post.getUpdatedAt()
-        );
+        return UserPostResponseDto.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .boardId(boardId)
+                .boardName(boardName)
+                .circleId(circleId)
+                .circleName(circleName)
+                .numComment(numComment)
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/user/UserPostsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserPostsResponseDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.user;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.domain.model.user.UserDomainModel;
@@ -7,6 +8,7 @@ import org.springframework.data.domain.Page;
 
 @Getter
 @Setter
+@Builder
 public class UserPostsResponseDto {
     private String id;
     private String email;
@@ -16,36 +18,18 @@ public class UserPostsResponseDto {
     private String profileImage;
     private Page<UserPostResponseDto> post;
 
-    private UserPostsResponseDto(
-            String id,
-            String email,
-            String name,
-            String studentId,
-            Integer admissionYear,
-            String profileImage,
-            Page<UserPostResponseDto> post
-    ) {
-        this.id = id;
-        this.email = email;
-        this.name = name;
-        this.studentId = studentId;
-        this.admissionYear = admissionYear;
-        this.profileImage = profileImage;
-        this.post = post;
-    }
-
-    public static UserPostsResponseDto from(
+    public static UserPostsResponseDto of(
             UserDomainModel user,
             Page<UserPostResponseDto> post
     ) {
-        return new UserPostsResponseDto(
-                user.getId(),
-                user.getEmail(),
-                user.getName(),
-                user.getStudentId(),
-                user.getAdmissionYear(),
-                user.getProfileImage(),
-                post
-        );
+        return UserPostsResponseDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .studentId(user.getStudentId())
+                .admissionYear(user.getAdmissionYear())
+                .profileImage(user.getProfileImage())
+                .post(post)
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/user/UserPrivilegedResponseDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserPrivilegedResponseDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.user;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,6 +9,7 @@ import java.util.List;
 
 @Getter
 @Setter
+@Builder
 public class UserPrivilegedResponseDto {
     private List<UserResponseDto> presidentUser;
     private List<UserResponseDto> vicePresidentUser;
@@ -16,23 +18,7 @@ public class UserPrivilegedResponseDto {
     private List<UserResponseDto> leaderCircleUsers;
     private List<UserResponseDto> leaderAlumni;
 
-    private UserPrivilegedResponseDto(
-            List<UserResponseDto> presidentUser,
-            List<UserResponseDto> vicePresidentUser,
-            List<UserResponseDto> councilUsers,
-            List<UserResponseDto> leaderGradeUsers,
-            List<UserResponseDto> leaderCircleUsers,
-            List<UserResponseDto> leaderAlumniUser
-    ) {
-        this.presidentUser = presidentUser;
-        this.vicePresidentUser = vicePresidentUser;
-        this.councilUsers = councilUsers;
-        this.leaderGradeUsers = leaderGradeUsers;
-        this.leaderCircleUsers = leaderCircleUsers;
-        this.leaderAlumni = leaderAlumniUser;
-    }
-
-    public static UserPrivilegedResponseDto from(
+    public static UserPrivilegedResponseDto of(
             List<UserResponseDto> presidentUser,
             List<UserResponseDto> vicePresidentUser,
             List<UserResponseDto> councilUsers,
@@ -48,13 +34,13 @@ public class UserPrivilegedResponseDto {
         leaderGradeUsers.addAll(leaderGrade3);
         leaderGradeUsers.addAll(leaderGrade4);
 
-        return new UserPrivilegedResponseDto(
-                presidentUser,
-                vicePresidentUser,
-                councilUsers,
-                leaderGradeUsers,
-                leaderCircleUsers,
-                leaderAlumniUser
-        );
+        return UserPrivilegedResponseDto.builder()
+                .presidentUser(presidentUser)
+                .vicePresidentUser(vicePresidentUser)
+                .councilUsers(councilUsers)
+                .leaderGradeUsers(leaderGradeUsers)
+                .leaderCircleUsers(leaderCircleUsers)
+                .leaderAlumni(leaderAlumniUser)
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/user/UserResponseDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserResponseDto.java
@@ -1,14 +1,17 @@
 package net.causw.application.dto.user;
 
 import io.swagger.annotations.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.domain.model.enums.Role;
 import net.causw.domain.model.user.UserDomainModel;
 import net.causw.domain.model.enums.UserState;
 import java.util.List;
+
 @Getter
 @Setter
+@Builder
 public class UserResponseDto {
 
     @ApiModelProperty(value = "고유 id값", example = "uuid 형식의 String 값입니다.")
@@ -41,62 +44,35 @@ public class UserResponseDto {
     @ApiModelProperty(value = "리더일 경우, 동아리 이름", example = "[개발 동아리, 퍼주마,..]")
     private List<String> circleNameIfLeader;
 
-
-    private UserResponseDto(
-            String id,
-            String email,
-            String name,
-            String studentId,
-            Integer admissionYear,
-            Role role,
-            String profileImage,
-            UserState state,
-            List<String> circleIdIfLeader,
-            List<String> circleNameIfLeader
-    ) {
-        this.id = id;
-        this.email = email;
-        this.name = name;
-        this.studentId = studentId;
-        this.admissionYear = admissionYear;
-        this.role = role;
-        this.profileImage = profileImage;
-        this.state = state;
-        this.circleIdIfLeader = circleIdIfLeader;
-        this.circleNameIfLeader = circleNameIfLeader;
-    }
-
     public static UserResponseDto from(UserDomainModel user) {
-        return new UserResponseDto(
-                user.getId(),
-                user.getEmail(),
-                user.getName(),
-                user.getStudentId(),
-                user.getAdmissionYear(),
-                user.getRole(),
-                user.getProfileImage(),
-                user.getState(),
-                null,
-                null
-        );
+        return UserResponseDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .studentId(user.getStudentId())
+                .admissionYear(user.getAdmissionYear())
+                .role(user.getRole())
+                .profileImage(user.getProfileImage())
+                .state(user.getState())
+                .build();
     }
 
-    public static UserResponseDto from(
+    public static UserResponseDto of(
             UserDomainModel user,
             List<String> circleId,
             List<String> circleName
     ) {
-        return new UserResponseDto(
-                user.getId(),
-                user.getEmail(),
-                user.getName(),
-                user.getStudentId(),
-                user.getAdmissionYear(),
-                user.getRole(),
-                user.getProfileImage(),
-                user.getState(),
-                circleId,
-                circleName
-        );
+        return UserResponseDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .studentId(user.getStudentId())
+                .admissionYear(user.getAdmissionYear())
+                .role(user.getRole())
+                .profileImage(user.getProfileImage())
+                .state(user.getState())
+                .circleIdIfLeader(circleId)
+                .circleNameIfLeader(circleName)
+                .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/user/UserSignOutRequestDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserSignOutRequestDto.java
@@ -1,8 +1,14 @@
 package net.causw.application.dto.user;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class UserSignOutRequestDto {
     private String refreshToken;
     private String accessToken;

--- a/src/main/java/net/causw/application/dto/user/UserSignOutResponseDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserSignOutResponseDto.java
@@ -3,8 +3,8 @@ package net.causw.application.dto.user;
 import lombok.Builder;
 import lombok.Getter;
 
-@Builder
 @Getter
+@Builder
 public class UserSignOutResponseDto {
     String message;
 }

--- a/src/main/java/net/causw/application/dto/user/UserUpdateTokenRequestDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserUpdateTokenRequestDto.java
@@ -1,8 +1,14 @@
 package net.causw.application.dto.user;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class UserUpdateTokenRequestDto {
     private String refreshToken;
 }

--- a/src/main/java/net/causw/application/dto/util/StatusUtil.java
+++ b/src/main/java/net/causw/application/dto/util/StatusUtil.java
@@ -1,0 +1,56 @@
+package net.causw.application.dto.util;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import net.causw.adapter.persistence.board.Board;
+import net.causw.adapter.persistence.comment.ChildComment;
+import net.causw.adapter.persistence.comment.Comment;
+import net.causw.adapter.persistence.post.Post;
+import net.causw.adapter.persistence.user.User;
+import net.causw.domain.model.enums.Role;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class StatusUtil {
+
+    public static boolean isUpdatable(Comment comment, User user) {
+        if (comment.getIsDeleted()) return false;
+        return user.getRole() == Role.ADMIN || comment.getWriter().getId().equals(user.getId());
+    }
+
+    public static boolean isDeletable(Comment comment, User user, Board board) {
+        if (comment.getIsDeleted()) return false;
+        if (user.getRole() == Role.ADMIN || user.getRole().getValue().contains("PRESIDENT") || comment.getWriter().getId().equals(user.getId())) {
+            return true;
+        }
+        return board.getCircle() != null && user.getRole().getValue().contains("LEADER_CIRCLE")
+                && board.getCircle().getLeader().map(leader -> leader.getId().equals(user.getId())).orElse(false);
+    }
+
+    public static boolean isUpdatable(ChildComment comment, User user) {
+        if (comment.getIsDeleted()) return false;
+        return user.getRole() == Role.ADMIN || comment.getWriter().getId().equals(user.getId());
+    }
+
+    public static boolean isDeletable(ChildComment comment, User user, Board board) {
+        if (comment.getIsDeleted()) return false;
+        if (user.getRole() == Role.ADMIN || user.getRole().getValue().contains("PRESIDENT") || comment.getWriter().getId().equals(user.getId())) {
+            return true;
+        }
+        return board.getCircle() != null && user.getRole().getValue().contains("LEADER_CIRCLE")
+                && board.getCircle().getLeader().map(leader -> leader.getId().equals(user.getId())).orElse(false);
+    }
+
+    public static boolean isUpdatable(Post post, User user) {
+        if (post.getIsDeleted()) return false;
+        return user.getRole() == Role.ADMIN || post.getWriter().getId().equals(user.getId());
+    }
+
+    public static boolean isDeletable(Post post, User user, Board board) {
+        if (post.getIsDeleted()) return false;
+        if (user.getRole() == Role.ADMIN || user.getRole().getValue().contains("PRESIDENT") || post.getWriter().getId().equals(user.getId())) {
+            return true;
+        }
+        return board.getCircle() != null && user.getRole().getValue().contains("LEADER_CIRCLE")
+                && board.getCircle().getLeader().map(leader -> leader.getId().equals(user.getId())).orElse(false);
+    }
+}

--- a/src/main/java/net/causw/application/homepage/HomePageService.java
+++ b/src/main/java/net/causw/application/homepage/HomePageService.java
@@ -55,13 +55,13 @@ public class HomePageService {
         }
         return boardDomainModelList
                 .stream()
-                .map(boardDomainModel -> HomePageResponseDto.from(
+                .map(boardDomainModel -> HomePageResponseDto.of(
                         BoardResponseDto.from(boardDomainModel, userDomainModel.getRole()),
                         this.postPort.findAllPost(
                                 boardDomainModel.getId(),
                                 0,
                                 StaticValue.HOME_POST_PAGE_SIZE
-                        ).map(postDomainModel -> PostsResponseDto.from(
+                        ).map(postDomainModel -> PostsResponseDto.of(
                                 postDomainModel,
                                 this.postPort.countAllComment(postDomainModel.getId())
                         )))

--- a/src/main/java/net/causw/application/homepage/HomePageService.java
+++ b/src/main/java/net/causw/application/homepage/HomePageService.java
@@ -1,20 +1,19 @@
 package net.causw.application.homepage;
 
 import lombok.RequiredArgsConstructor;
+import net.causw.adapter.persistence.board.Board;
+import net.causw.adapter.persistence.page.PageableFactory;
+import net.causw.adapter.persistence.repository.BoardRepository;
+import net.causw.adapter.persistence.repository.PostRepository;
+import net.causw.adapter.persistence.repository.UserRepository;
+import net.causw.adapter.persistence.user.User;
 import net.causw.application.dto.homepage.HomePageResponseDto;
 import net.causw.application.dto.board.BoardResponseDto;
 import net.causw.application.dto.post.PostsResponseDto;
-import net.causw.application.spi.BoardPort;
-import net.causw.application.spi.CommentPort;
-import net.causw.application.spi.FavoriteBoardPort;
-import net.causw.application.spi.PostPort;
-import net.causw.application.spi.UserPort;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
-import net.causw.domain.model.board.BoardDomainModel;
 import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
-import net.causw.domain.model.user.UserDomainModel;
 import net.causw.domain.validation.UserRoleIsNoneValidator;
 import net.causw.domain.validation.UserStateValidator;
 import net.causw.domain.validation.ValidatorBucket;
@@ -26,45 +25,40 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class HomePageService {
-    private final FavoriteBoardPort favoriteBoardPort;
-    private final UserPort userPort;
-    private final BoardPort boardPort;
-    private final PostPort postPort;
-    private final CommentPort commentPort;
+
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final BoardRepository boardRepository;
+    private final PageableFactory pageableFactory;
 
     public List<HomePageResponseDto> getHomePage(String userId) {
-        UserDomainModel userDomainModel = this.userPort.findById(userId).orElseThrow(
-                () -> new BadRequestException(
+        User user = this.userRepository.findById(userId)
+                .orElseThrow(() -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.LOGIN_USER_NOT_FOUND
-                )
-        );
+                        MessageUtil.USER_NOT_FOUND));
 
         ValidatorBucket.of()
-                .consistOf(UserStateValidator.of(userDomainModel.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(userDomainModel.getRole()))
+                .consistOf(UserStateValidator.of(user.getState()))
+                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
                 .validate();
 
-
-        List<BoardDomainModel> boardDomainModelList = this.boardPort.findAllBoard(false);
-        if(boardDomainModelList.isEmpty()){
+        List<Board> boards = boardRepository.findByCircle_IdIsNullAndIsDeletedOrderByCreatedAtAsc(false);
+        if (boards.isEmpty()) {
             throw new BadRequestException(
                     ErrorCode.ROW_DOES_NOT_EXIST,
                     MessageUtil.BOARD_NOT_FOUND
             );
         }
-        return boardDomainModelList
+
+        return boards
                 .stream()
-                .map(boardDomainModel -> HomePageResponseDto.of(
-                        BoardResponseDto.from(boardDomainModel, userDomainModel.getRole()),
-                        this.postPort.findAllPost(
-                                boardDomainModel.getId(),
-                                0,
-                                StaticValue.HOME_POST_PAGE_SIZE
-                        ).map(postDomainModel -> PostsResponseDto.of(
-                                postDomainModel,
-                                this.postPort.countAllComment(postDomainModel.getId())
-                        )))
+                .map(board -> HomePageResponseDto.of(
+                        BoardResponseDto.of(board, user.getRole()),
+                        postRepository.findAllByBoard_IdAndIsDeletedIsFalseOrderByCreatedAtDesc(board.getId(), pageableFactory.create(0, StaticValue.HOME_POST_PAGE_SIZE))
+                                .map(post -> PostsResponseDto.of(
+                                        post,
+                                        postRepository.countAllCommentByPost_Id(post.getId())
+                                )))
                 )
                 .collect(Collectors.toList());
     }

--- a/src/main/java/net/causw/application/inquiry/InquiryService.java
+++ b/src/main/java/net/causw/application/inquiry/InquiryService.java
@@ -58,7 +58,7 @@ public class InquiryService {
         validatorBucket
                 .validate();
 
-        return InquiryResponseDto.from(
+        return InquiryResponseDto.of(
                 inquiryDomainModel,
                 userDomainModel
         );
@@ -89,7 +89,7 @@ public class InquiryService {
                 .consistOf(ConstraintValidator.of(inquiryDomainModel, this.validator))
                 .validate();
 
-        return InquiryResponseDto.from(
+        return InquiryResponseDto.of(
                 this.inquiryPort.create(inquiryDomainModel),
                 creatorDomainModel
         );

--- a/src/main/java/net/causw/application/locker/LockerService.java
+++ b/src/main/java/net/causw/application/locker/LockerService.java
@@ -343,7 +343,7 @@ public class LockerService {
             );
         }
 
-        LockerLocationDomainModel lockerLocationDomainModel = LockerLocationDomainModel.of(
+        LockerLocationDomainModel lockerLocationDomainModel = LockerLocationDomainModel.from(
                 lockerLocationCreateRequestDto.getName()
         );
 

--- a/src/main/java/net/causw/application/locker/LockerService.java
+++ b/src/main/java/net/causw/application/locker/LockerService.java
@@ -66,7 +66,7 @@ public class LockerService {
                 )
         );
 
-        return LockerResponseDto.from(this.lockerPort.findByIdForRead(id).orElseThrow(
+        return LockerResponseDto.of(this.lockerPort.findByIdForRead(id).orElseThrow(
                         () -> new BadRequestException(
                                 ErrorCode.ROW_DOES_NOT_EXIST,
                                 MessageUtil.LOCKER_NOT_FOUND
@@ -127,7 +127,7 @@ public class LockerService {
                             LockerLogAction.ENABLE,
                             MessageUtil.LOCKER_FIRST_CREATED
                     );
-                    return LockerResponseDto.from(resLockerDomainModel, creatorDomainModel);
+                    return LockerResponseDto.of(resLockerDomainModel, creatorDomainModel);
                 })
                 .orElseThrow(() -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
@@ -178,7 +178,7 @@ public class LockerService {
                             LockerLogAction.of(lockerUpdateRequestDto.getAction()),
                             lockerUpdateRequestDto.getMessage().orElse(lockerUpdateRequestDto.getAction())
                     );
-                    return LockerResponseDto.from(resLockerDomainModel, updaterDomainModel);
+                    return LockerResponseDto.of(resLockerDomainModel, updaterDomainModel);
                 })
                 .orElseThrow(() -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
@@ -222,7 +222,7 @@ public class LockerService {
                 .consistOf(ConstraintValidator.of(lockerDomainModel, this.validator))
                 .validate();
 
-        return LockerResponseDto.from(this.lockerPort.updateLocation(lockerId, lockerDomainModel).orElseThrow(
+        return LockerResponseDto.of(this.lockerPort.updateLocation(lockerId, lockerDomainModel).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
                                 MessageUtil.INTERNAL_SERVER_ERROR
@@ -264,7 +264,7 @@ public class LockerService {
                 MessageUtil.LOCKER_DELETED
         );
 
-        return LockerResponseDto.from(lockerDomainModel, deleterDomainModel);
+        return LockerResponseDto.of(lockerDomainModel, deleterDomainModel);
     }
 
     @Transactional(readOnly = true)
@@ -287,7 +287,7 @@ public class LockerService {
                 lockerLocation.getName(),
                 this.lockerPort.findByLocationId(lockerLocation.getId())
                         .stream()
-                        .map(lockerDomainModel -> LockerResponseDto.from(lockerDomainModel, userDomainModel))
+                        .map(lockerDomainModel -> LockerResponseDto.of(lockerDomainModel, userDomainModel))
                         .collect(Collectors.toList())
         );
     }
@@ -304,7 +304,7 @@ public class LockerService {
         LockerResponseDto myLocker = null;
         if (!userDomainModel.getRole().equals(Role.ADMIN))
             myLocker = this.lockerPort.findByUserId(userId)
-                    .map(lockerDomainModel -> LockerResponseDto.from(
+                    .map(lockerDomainModel -> LockerResponseDto.of(
                             lockerDomainModel,
                             userDomainModel,
                             lockerDomainModel.getLockerLocation().getName()
@@ -314,7 +314,7 @@ public class LockerService {
         return LockerLocationsResponseDto.of(
                 this.lockerLocationPort.findAll()
                         .stream()
-                        .map(lockerLocationDomainModel -> LockerLocationResponseDto.from(
+                        .map(lockerLocationDomainModel -> LockerLocationResponseDto.of(
                                 lockerLocationDomainModel,
                                 this.lockerPort.countEnableLockerByLocation(lockerLocationDomainModel.getId()),
                                 this.lockerPort.countByLocation(lockerLocationDomainModel.getId())
@@ -354,7 +354,7 @@ public class LockerService {
                 .consistOf(ConstraintValidator.of(lockerLocationDomainModel, this.validator))
                 .validate();
 
-        return LockerLocationResponseDto.from(
+        return LockerLocationResponseDto.of(
                 this.lockerLocationPort.create(lockerLocationDomainModel),
                 0L,
                 0L
@@ -401,7 +401,7 @@ public class LockerService {
                 .consistOf(ConstraintValidator.of(lockerLocationDomainModel, this.validator))
                 .validate();
 
-        return LockerLocationResponseDto.from(
+        return LockerLocationResponseDto.of(
                 this.lockerLocationPort.update(locationId, lockerLocationDomainModel).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
@@ -444,7 +444,7 @@ public class LockerService {
 
         this.lockerLocationPort.delete(lockerLocationDomainModel);
 
-        return LockerLocationResponseDto.from(lockerLocationDomainModel, 0L, 0L);
+        return LockerLocationResponseDto.of(lockerLocationDomainModel, 0L, 0L);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/net/causw/application/post/PostService.java
+++ b/src/main/java/net/causw/application/post/PostService.java
@@ -105,18 +105,18 @@ public class PostService {
         validatorBucket
                 .validate();
 
-        return PostResponseDto.from(
+        return PostResponseDto.of(
                 postDomainModel,
                 userDomainModel,
                 this.commentPort.findByPostId(postId, 0)
                         .map(
-                                commentDomainModel -> CommentResponseDto.from(
+                                commentDomainModel -> CommentResponseDto.of(
                                         commentDomainModel,
                                         userDomainModel,
                                         postDomainModel.getBoard(),
                                         this.childCommentPort.countByParentComment(commentDomainModel.getId()),
                                         commentDomainModel.getChildCommentList().stream()
-                                                .map(childCommentDomainModel -> ChildCommentResponseDto.from(
+                                                .map(childCommentDomainModel -> ChildCommentResponseDto.of(
                                                         childCommentDomainModel,
                                                         userDomainModel,
                                                         postDomainModel.getBoard()
@@ -195,7 +195,7 @@ public class PostService {
                             .stream()
                             .anyMatch(favoriteBoardDomainModel -> favoriteBoardDomainModel.getBoardDomainModel().getId().equals(boardDomainModel.getId())),
                     this.postPort.findAllPost(boardId, pageNum)
-                            .map(postDomainModel -> PostsResponseDto.from(
+                            .map(postDomainModel -> PostsResponseDto.of(
                                     postDomainModel,
                                     this.postPort.countAllComment(postDomainModel.getId())
                             ))
@@ -209,7 +209,7 @@ public class PostService {
                             .stream()
                             .anyMatch(favoriteBoardDomainModel -> favoriteBoardDomainModel.getBoardDomainModel().getId().equals(boardDomainModel.getId())),
                     this.postPort.findAllPost(boardId, pageNum, false)
-                            .map(postDomainModel -> PostsResponseDto.from(
+                            .map(postDomainModel -> PostsResponseDto.of(
                                     postDomainModel,
                                     this.postPort.countAllComment(postDomainModel.getId())
                             ))
@@ -289,7 +289,7 @@ public class PostService {
                             .stream()
                             .anyMatch(favoriteBoardDomainModel -> favoriteBoardDomainModel.getBoardDomainModel().getId().equals(boardDomainModel.getId())),
                     this.postPort.searchPost(keyword, boardId, pageNum)
-                            .map(postDomainModel -> PostsResponseDto.from(
+                            .map(postDomainModel -> PostsResponseDto.of(
                                     postDomainModel,
                                     this.postPort.countAllComment(postDomainModel.getId())
                             ))
@@ -303,7 +303,7 @@ public class PostService {
                             .stream()
                             .anyMatch(favoriteBoardDomainModel -> favoriteBoardDomainModel.getBoardDomainModel().getId().equals(boardDomainModel.getId())),
                     this.postPort.searchPost(keyword, boardId, pageNum, false)
-                            .map(postDomainModel -> PostsResponseDto.from(
+                            .map(postDomainModel -> PostsResponseDto.of(
                                     postDomainModel,
                                     this.postPort.countAllComment(postDomainModel.getId())
                             ))
@@ -336,7 +336,7 @@ public class PostService {
                         .stream()
                         .anyMatch(favoriteBoardDomainModel -> favoriteBoardDomainModel.getBoardDomainModel().getId().equals(boardDomainModel.getId())),
                 this.postPort.findAllPost(boardDomainModel.getId(), pageNum)
-                        .map(postDomainModel -> PostsResponseDto.from(
+                        .map(postDomainModel -> PostsResponseDto.of(
                                 postDomainModel,
                                 this.postPort.countAllComment(postDomainModel.getId())
                         ))
@@ -430,7 +430,7 @@ public class PostService {
                 .consistOf(ConstraintValidator.of(postDomainModel, this.validator))
                 .validate();
 
-        return PostResponseDto.from(
+        return PostResponseDto.of(
                 this.postPort.createPost(postDomainModel),
                 creatorDomainModel
         );
@@ -518,7 +518,7 @@ public class PostService {
         validatorBucket
                 .validate();
 
-        return PostResponseDto.from(
+        return PostResponseDto.of(
                 this.postPort.deletePost(postId).orElseThrow(
                         () -> new InternalServerException(
                                 ErrorCode.INTERNAL_SERVER,
@@ -612,17 +612,17 @@ public class PostService {
                 )
         );
 
-        return PostResponseDto.from(
+        return PostResponseDto.of(
                 postDomainModel,
                 updaterDomainModel,
                 this.commentPort.findByPostId(postId, 0)
-                        .map(commentDomainModel -> CommentResponseDto.from(
+                        .map(commentDomainModel -> CommentResponseDto.of(
                                 commentDomainModel,
                                 updaterDomainModel,
                                 updatedPostDomainModel.getBoard(),
                                 this.childCommentPort.countByParentComment(commentDomainModel.getId()),
                                 commentDomainModel.getChildCommentList().stream()
-                                        .map(childCommentDomainModel -> ChildCommentResponseDto.from(
+                                        .map(childCommentDomainModel -> ChildCommentResponseDto.of(
                                                 childCommentDomainModel,
                                                 updaterDomainModel,
                                                 postDomainModel.getBoard()
@@ -730,17 +730,17 @@ public class PostService {
                 )
         );
 
-        return PostResponseDto.from(
+        return PostResponseDto.of(
                 postDomainModel,
                 restorerDomainModel,
                 this.commentPort.findByPostId(postId, 0)
-                        .map(commentDomainModel -> CommentResponseDto.from(
+                        .map(commentDomainModel -> CommentResponseDto.of(
                                 commentDomainModel,
                                 restorerDomainModel,
                                 restoredPostDomainModel.getBoard(),
                                 this.childCommentPort.countByParentComment(commentDomainModel.getId()),
                                 commentDomainModel.getChildCommentList().stream()
-                                        .map(childCommentDomainModel -> ChildCommentResponseDto.from(
+                                        .map(childCommentDomainModel -> ChildCommentResponseDto.of(
                                                 childCommentDomainModel,
                                                 restorerDomainModel,
                                                 postDomainModel.getBoard()

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -168,7 +168,7 @@ public class UserService {
                 );
             }
 
-            return UserResponseDto.from(
+            return UserResponseDto.of(
                     requestUser,
                     ownCircles.stream().map(CircleDomainModel::getId).collect(Collectors.toList()),
                     ownCircles.stream().map(CircleDomainModel::getName).collect(Collectors.toList())
@@ -193,9 +193,9 @@ public class UserService {
                 .consistOf(UserStateValidator.of(requestUser.getState()))
                 .validate();
 
-        return UserPostsResponseDto.from(
+        return UserPostsResponseDto.of(
                 requestUser,
-                this.postPort.findPostByUserId(loginUserId, pageNum).map(postDomainModel -> UserPostResponseDto.from(
+                this.postPort.findPostByUserId(loginUserId, pageNum).map(postDomainModel -> UserPostResponseDto.of(
                         postDomainModel,
                         postDomainModel.getBoard().getId(),
                         postDomainModel.getBoard().getName(),
@@ -220,7 +220,7 @@ public class UserService {
                 .consistOf(UserStateValidator.of(requestUser.getState()))
                 .validate();
 
-        return UserCommentsResponseDto.from(
+        return UserCommentsResponseDto.of(
                 requestUser,
                 this.commentPort.findByUserId(loginUserId, pageNum).map(comment -> {
                     PostDomainModel post = this.postPort.findPostById(comment.getPostId()).orElseThrow(
@@ -230,7 +230,7 @@ public class UserService {
                             )
                     );
 
-                    return CommentsOfUserResponseDto.from(
+                    return CommentsOfUserResponseDto.of(
                             comment,
                             post.getBoard().getId(),
                             post.getBoard().getName(),
@@ -279,7 +279,7 @@ public class UserService {
                                                     .map(circleMemberDomainModel ->
                                                             circleMemberDomainModel.getStatus() == CircleMemberStatus.MEMBER)
                                                     .orElse(false)))
-                    .map(userDomainModel -> UserResponseDto.from(
+                    .map(userDomainModel -> UserResponseDto.of(
                             userDomainModel,
                             ownCircles.stream().map(CircleDomainModel::getId).collect(Collectors.toList()),
                             ownCircles.stream().map(CircleDomainModel::getName).collect(Collectors.toList())))
@@ -308,7 +308,7 @@ public class UserService {
                 .consistOf(UserRoleValidator.of(user.getRole(), List.of()))
                 .validate();
 
-        return UserPrivilegedResponseDto.from(
+        return UserPrivilegedResponseDto.of(
                 this.userPort.findByRole("PRESIDENT")
                         .stream()
                         .map(UserResponseDto::from)
@@ -347,7 +347,7 @@ public class UserService {
                                         MessageUtil.NO_ASSIGNED_CIRCLE_FOR_LEADER
                                 );
                             }
-                            return UserResponseDto.from(
+                            return UserResponseDto.of(
                                     userDomainModel,
                                     ownCircles.stream().map(CircleDomainModel::getId).collect(Collectors.toList()),
                                     ownCircles.stream().map(CircleDomainModel::getName).collect(Collectors.toList())
@@ -393,7 +393,7 @@ public class UserService {
                             );
                         }
 
-                        return UserResponseDto.from(
+                        return UserResponseDto.of(
                                 userDomainModel,
                                 ownCircles.stream().map(CircleDomainModel::getId).collect(Collectors.toList()),
                                 ownCircles.stream().map(CircleDomainModel::getName).collect(Collectors.toList())
@@ -529,7 +529,7 @@ public class UserService {
                 );
             }
         }
-        return DuplicatedCheckResponseDto.of(userFoundByEmail.isPresent());
+        return DuplicatedCheckResponseDto.from(userFoundByEmail.isPresent());
     }
 
     /**
@@ -1035,7 +1035,7 @@ public class UserService {
         // Remove the admission
         this.userAdmissionPort.delete(userAdmissionDomainModel);
 
-        return UserAdmissionResponseDto.from(
+        return UserAdmissionResponseDto.of(
                 userAdmissionDomainModel,
                 this.userPort.updateState(userAdmissionDomainModel.getUser().getId(), UserState.ACTIVE).orElseThrow(
                         () -> new InternalServerException(
@@ -1083,7 +1083,7 @@ public class UserService {
 
         this.userAdmissionPort.delete(userAdmissionDomainModel);
 
-        return UserAdmissionResponseDto.from(
+        return UserAdmissionResponseDto.of(
                 userAdmissionDomainModel,
                 this.userPort.updateState(userAdmissionDomainModel.getUser().getId(), UserState.REJECT).orElseThrow(
                         () -> new InternalServerException(

--- a/src/main/java/net/causw/domain/model/board/BoardDomainModel.java
+++ b/src/main/java/net/causw/domain/model/board/BoardDomainModel.java
@@ -1,7 +1,7 @@
 package net.causw.domain.model.board;
 
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 import net.causw.domain.model.circle.CircleDomainModel;
 import net.causw.domain.model.enums.Role;
 
@@ -13,9 +13,10 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Getter
-@Setter
+@Builder
 public class BoardDomainModel {
     private String id;
+
     private String description;
 
     @NotBlank(message = "게시판 이름이 입력되지 않았습니다.")
@@ -32,24 +33,6 @@ public class BoardDomainModel {
 
     private CircleDomainModel circle;
 
-    private BoardDomainModel(
-            String id,
-            String name,
-            String description,
-            List<String> createRoleList,
-            String category,
-            Boolean isDeleted,
-            CircleDomainModel circle
-    ) {
-        this.id = id;
-        this.name = name;
-        this.description = description;
-        this.createRoleList = createRoleList;
-        this.category = category;
-        this.isDeleted = isDeleted;
-        this.circle = circle;
-    }
-
     public static BoardDomainModel of(
             String id,
             String name,
@@ -59,15 +42,15 @@ public class BoardDomainModel {
             Boolean isDeleted,
             CircleDomainModel circle
     ) {
-        return new BoardDomainModel(
-                id,
-                name,
-                description,
-                createRoleList,
-                category,
-                isDeleted,
-                circle
-        );
+        return BoardDomainModel.builder()
+                .id(id)
+                .name(name)
+                .description(description)
+                .createRoleList(createRoleList)
+                .category(category)
+                .isDeleted(isDeleted)
+                .circle(circle)
+                .build();
     }
 
     public static BoardDomainModel of(
@@ -101,15 +84,13 @@ public class BoardDomainModel {
             }
         }
 
-        return new BoardDomainModel(
-                null,
-                name,
-                description,
-                createRoleList,
-                category,
-                false,
-                circle
-        );
+        return BoardDomainModel.builder()
+                .name(name)
+                .description(description)
+                .createRoleList(createRoleList)
+                .category(category)
+                .circle(circle)
+                .build();
     }
 
     public void update(

--- a/src/main/java/net/causw/domain/model/board/FavoriteBoardDomainModel.java
+++ b/src/main/java/net/causw/domain/model/board/FavoriteBoardDomainModel.java
@@ -1,39 +1,29 @@
 package net.causw.domain.model.board;
 
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 import net.causw.domain.model.user.UserDomainModel;
 
 import javax.validation.constraints.NotNull;
 
 @Getter
-@Setter
+@Builder
 public class FavoriteBoardDomainModel {
     private String id;
 
     @NotNull(message = "사용자가 입력되지 않았습니다.")
     private UserDomainModel userDomainModel;
+
     private BoardDomainModel boardDomainModel;
 
-    private FavoriteBoardDomainModel(
-            String id,
-            UserDomainModel userDomainModel,
-            BoardDomainModel boardDomainModel
-    ) {
-        this.id = id;
-        this.userDomainModel = userDomainModel;
-        this.boardDomainModel = boardDomainModel;
-    }
-
     public static FavoriteBoardDomainModel of(
             UserDomainModel userDomainModel,
             BoardDomainModel boardDomainModel
     ) {
-        return new FavoriteBoardDomainModel(
-                null,
-                userDomainModel,
-                boardDomainModel
-        );
+        return FavoriteBoardDomainModel.builder()
+                .userDomainModel(userDomainModel)
+                .boardDomainModel(boardDomainModel)
+                .build();
     }
 
     public static FavoriteBoardDomainModel of(
@@ -41,10 +31,10 @@ public class FavoriteBoardDomainModel {
             UserDomainModel userDomainModel,
             BoardDomainModel boardDomainModel
     ) {
-        return new FavoriteBoardDomainModel(
-                id,
-                userDomainModel,
-                boardDomainModel
-        );
+        return FavoriteBoardDomainModel.builder()
+                .id(id)
+                .userDomainModel(userDomainModel)
+                .boardDomainModel(boardDomainModel)
+                .build();
     }
 }

--- a/src/main/java/net/causw/domain/model/circle/CircleDomainModel.java
+++ b/src/main/java/net/causw/domain/model/circle/CircleDomainModel.java
@@ -1,7 +1,7 @@
 package net.causw.domain.model.circle;
 
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 import net.causw.domain.model.user.UserDomainModel;
 
 import javax.validation.constraints.NotBlank;
@@ -10,10 +10,12 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Getter
-@Setter
+@Builder
 public class CircleDomainModel {
     private String id;
+
     private String description;
+
     private String mainImage;
 
     @NotBlank(message = "소모임 이름이 입력되지 않았습니다.")
@@ -26,28 +28,9 @@ public class CircleDomainModel {
     private UserDomainModel leader;
 
     private LocalDateTime createdAt;
+
     private LocalDateTime updatedAt;
 
-    private CircleDomainModel(
-            String id,
-            String name,
-            String mainImage,
-            String description,
-            Boolean isDeleted,
-            UserDomainModel leader,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt
-    ) {
-        this.id = id;
-        this.name = name;
-        this.mainImage = mainImage;
-        this.description = description;
-        this.isDeleted = isDeleted;
-        this.leader = leader;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-    }
-
     public static CircleDomainModel of(
             String id,
             String name,
@@ -58,36 +41,16 @@ public class CircleDomainModel {
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {
-        return new CircleDomainModel(
-                id,
-                name,
-                mainImage,
-                description,
-                isDeleted,
-                leader,
-                createdAt,
-                updatedAt
-        );
-    }
-
-    public static CircleDomainModel of(
-            String id,
-            String name,
-            String mainImage,
-            String description,
-            Boolean isDeleted,
-            UserDomainModel leader
-    ) {
-        return new CircleDomainModel(
-                id,
-                name,
-                mainImage,
-                description,
-                isDeleted,
-                leader,
-                null,
-                null
-        );
+        return CircleDomainModel.builder()
+                .id(id)
+                .name(name)
+                .mainImage(mainImage)
+                .description(description)
+                .isDeleted(isDeleted)
+                .leader(leader)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .build();
     }
 
     public static CircleDomainModel of(
@@ -96,16 +59,12 @@ public class CircleDomainModel {
             String description,
             UserDomainModel leader
     ) {
-        return new CircleDomainModel(
-                null,
-                name,
-                mainImage,
-                description,
-                false,
-                leader,
-                null,
-                null
-        );
+        return CircleDomainModel.builder()
+                .name(name)
+                .mainImage(mainImage)
+                .description(description)
+                .leader(leader)
+                .build();
     }
 
     public void update(

--- a/src/main/java/net/causw/domain/model/circle/CircleMemberDomainModel.java
+++ b/src/main/java/net/causw/domain/model/circle/CircleMemberDomainModel.java
@@ -1,39 +1,27 @@
 package net.causw.domain.model.circle;
 
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 import net.causw.domain.model.enums.CircleMemberStatus;
 
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
+@Builder
 public class CircleMemberDomainModel {
     private String id;
-    private CircleMemberStatus status;
-    private CircleDomainModel circle;
-    private String userId;
-    private String userName;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
 
-    private CircleMemberDomainModel(
-            String id,
-            CircleMemberStatus status,
-            CircleDomainModel circle,
-            String userId,
-            String userName,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt
-    ) {
-        this.id = id;
-        this.status = status;
-        this.circle = circle;
-        this.userId = userId;
-        this.userName = userName;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-    }
+    private CircleMemberStatus status;
+
+    private CircleDomainModel circle;
+
+    private String userId;
+
+    private String userName;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
 
     public static CircleMemberDomainModel of(
             String id,
@@ -44,15 +32,14 @@ public class CircleMemberDomainModel {
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {
-        return new CircleMemberDomainModel(
-                id,
-                status,
-                circle,
-                userId,
-                userName,
-                createdAt,
-                updatedAt
-        );
+        return CircleMemberDomainModel.builder()
+                .id(id)
+                .status(status)
+                .circle(circle)
+                .userId(userId)
+                .userName(userName)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .build();
     }
-
 }

--- a/src/main/java/net/causw/domain/model/comment/ChildCommentDomainModel.java
+++ b/src/main/java/net/causw/domain/model/comment/ChildCommentDomainModel.java
@@ -1,7 +1,7 @@
 package net.causw.domain.model.comment;
 
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 import net.causw.domain.model.user.UserDomainModel;
 
 import javax.validation.constraints.NotBlank;
@@ -9,7 +9,7 @@ import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
+@Builder
 public class ChildCommentDomainModel {
     private String id;
 
@@ -20,6 +20,7 @@ public class ChildCommentDomainModel {
     private Boolean isDeleted;
 
     private String tagUserName;
+
     private String refChildComment;
 
     @NotNull(message = "작성자가 입력되지 않았습니다.")
@@ -29,29 +30,8 @@ public class ChildCommentDomainModel {
     private CommentDomainModel parentComment;
 
     private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
 
-    private ChildCommentDomainModel(
-            String id,
-            String content,
-            Boolean isDeleted,
-            String tagUserName,
-            String refChildComment,
-            UserDomainModel writer,
-            CommentDomainModel parentComment,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt
-    ) {
-        this.id = id;
-        this.content = content;
-        this.isDeleted = isDeleted;
-        this.tagUserName = tagUserName;
-        this.refChildComment = refChildComment;
-        this.writer = writer;
-        this.parentComment = parentComment;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-    }
+    private LocalDateTime updatedAt;
 
     public static ChildCommentDomainModel of(
             String content,
@@ -60,17 +40,13 @@ public class ChildCommentDomainModel {
             UserDomainModel writer,
             CommentDomainModel parentComment
     ) {
-        return new ChildCommentDomainModel(
-                null,
-                content,
-                false,
-                tagUserName,
-                refChildComment,
-                writer,
-                parentComment,
-                null,
-                null
-        );
+        return ChildCommentDomainModel.builder()
+                .content(content)
+                .tagUserName(tagUserName)
+                .refChildComment(refChildComment)
+                .writer(writer)
+                .parentComment(parentComment)
+                .build();
     }
 
     public static ChildCommentDomainModel of(
@@ -84,17 +60,17 @@ public class ChildCommentDomainModel {
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {
-        return new ChildCommentDomainModel(
-                id,
-                content,
-                isDeleted,
-                tagUserName,
-                refChildComment,
-                writer,
-                parentComment,
-                createdAt,
-                updatedAt
-        );
+        return ChildCommentDomainModel.builder()
+                .id(id)
+                .content(content)
+                .isDeleted(isDeleted)
+                .tagUserName(tagUserName)
+                .refChildComment(refChildComment)
+                .writer(writer)
+                .parentComment(parentComment)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .build();
     }
 
     public void update(

--- a/src/main/java/net/causw/domain/model/comment/CommentDomainModel.java
+++ b/src/main/java/net/causw/domain/model/comment/CommentDomainModel.java
@@ -1,7 +1,7 @@
 package net.causw.domain.model.comment;
 
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 import net.causw.domain.model.user.UserDomainModel;
 
 import javax.validation.constraints.NotBlank;
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-@Setter
+@Builder
 public class CommentDomainModel {
     private String id;
 
@@ -20,7 +20,9 @@ public class CommentDomainModel {
 
     @NotNull(message = "댓글 상태가 입력되지 않았습니다.")
     private Boolean isDeleted;
+
     private LocalDateTime createdAt;
+
     private LocalDateTime updatedAt;
 
     @NotNull(message = "작성자가 입력되지 않았습니다.")
@@ -28,43 +30,19 @@ public class CommentDomainModel {
 
     @NotNull(message = "게시글이 입력되지 않았습니다.")
     private String postId;
+
     private List<ChildCommentDomainModel> childCommentList;
 
-    private CommentDomainModel(
-            String id,
-            String content,
-            Boolean isDeleted,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            UserDomainModel writer,
-            String postId,
-            List<ChildCommentDomainModel> childCommentList
-    ) {
-        this.id = id;
-        this.content = content;
-        this.isDeleted = isDeleted;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.writer = writer;
-        this.postId = postId;
-        this.childCommentList = childCommentList;
-    }
-
     public static CommentDomainModel of(
             String content,
             UserDomainModel writer,
             String postId
     ) {
-        return new CommentDomainModel(
-                null,
-                content,
-                false,
-                null,
-                null,
-                writer,
-                postId,
-                new ArrayList<>()
-        );
+        return CommentDomainModel.builder()
+                .content(content)
+                .writer(writer)
+                .postId(postId)
+                .build();
     }
 
     public static CommentDomainModel of(
@@ -76,43 +54,25 @@ public class CommentDomainModel {
             UserDomainModel writer,
             String postId
     ) {
-        return new CommentDomainModel(
-                id,
-                content,
-                isDeleted,
-                createdAt,
-                updatedAt,
-                writer,
-                postId,
-                new ArrayList<>()
-        );
-    }
-
-    public static CommentDomainModel of(
-            String id,
-            String content,
-            Boolean isDeleted,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            UserDomainModel writer,
-            String postId,
-            List<ChildCommentDomainModel> childCommentList
-    ) {
-        return new CommentDomainModel(
-                id,
-                content,
-                isDeleted,
-                createdAt,
-                updatedAt,
-                writer,
-                postId,
-                childCommentList
-        );
+        return CommentDomainModel.builder()
+                .id(id)
+                .content(content)
+                .isDeleted(isDeleted)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .writer(writer)
+                .postId(postId)
+                .childCommentList(new ArrayList<>())
+                .build();
     }
 
     public void update(
             String content
     ) {
         this.content = content;
+    }
+
+    public void setChildCommentList(List<ChildCommentDomainModel> childCommentList) {
+        this.childCommentList = childCommentList;
     }
 }

--- a/src/main/java/net/causw/domain/model/inquiry/InquiryDomainModel.java
+++ b/src/main/java/net/causw/domain/model/inquiry/InquiryDomainModel.java
@@ -1,7 +1,7 @@
 package net.causw.domain.model.inquiry;
 
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 import net.causw.domain.model.user.UserDomainModel;
 
 import javax.validation.constraints.NotBlank;
@@ -9,13 +9,13 @@ import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
+@Builder
 public class InquiryDomainModel {
-
     private String id;
 
     @NotBlank(message = "문의글 제목이 입력되지 않았습니다.")
     private String title;
+
     private String content;
 
     @NotNull(message = "작성자가 입력되지 않았습니다.")
@@ -28,24 +28,6 @@ public class InquiryDomainModel {
 
     private LocalDateTime updatedAt;
 
-    private InquiryDomainModel(
-            String id,
-            String title,
-            String content,
-            UserDomainModel writer,
-            Boolean isDeleted,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt
-    ) {
-        this.id = id;
-        this.title = title;
-        this.content = content;
-        this.writer = writer;
-        this.isDeleted = isDeleted;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-    }
-
     public static InquiryDomainModel of(
             String id,
             String title,
@@ -55,30 +37,26 @@ public class InquiryDomainModel {
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {
-        return new InquiryDomainModel(
-                id,
-                title,
-                content,
-                writer,
-                isDeleted,
-                createdAt,
-                updatedAt
-        );
+        return InquiryDomainModel.builder()
+                .id(id)
+                .title(title)
+                .content(content)
+                .writer(writer)
+                .isDeleted(isDeleted)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .build();
     }
+
     public static InquiryDomainModel of(
             String title,
             String content,
             UserDomainModel writer
     ) {
-        return new InquiryDomainModel(
-                null,
-                title,
-                content,
-                writer,
-                false,
-                null,
-                null
-        );
+        return InquiryDomainModel.builder()
+                .title(title)
+                .content(content)
+                .writer(writer)
+                .build();
     }
-
 }

--- a/src/main/java/net/causw/domain/model/locker/LockerDomainModel.java
+++ b/src/main/java/net/causw/domain/model/locker/LockerDomainModel.java
@@ -1,7 +1,7 @@
 package net.causw.domain.model.locker;
 
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 import net.causw.domain.model.user.UserDomainModel;
 
 import javax.validation.constraints.NotNull;
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Getter
-@Setter
+@Builder
 public class LockerDomainModel {
     private String id;
 
@@ -22,42 +22,20 @@ public class LockerDomainModel {
     private LocalDateTime expiredAt;
 
     private LocalDateTime updatedAt;
+
     private UserDomainModel user;
 
     @NotNull(message = "사물함 위치가 입력되지 않았습니다.")
     private LockerLocationDomainModel lockerLocation;
 
-    private LockerDomainModel(
-            String id,
-            Long lockerNumber,
-            Boolean isActive,
-            LocalDateTime expiredAt,
-            LocalDateTime updatedAt,
-            UserDomainModel user,
-            LockerLocationDomainModel lockerLocation
-    ) {
-        this.id = id;
-        this.lockerNumber = lockerNumber;
-        this.isActive = isActive;
-        this.expiredAt = expiredAt;
-        this.updatedAt = updatedAt;
-        this.user = user;
-        this.lockerLocation = lockerLocation;
-    }
-
     public static LockerDomainModel of(
             Long lockerNumber,
             LockerLocationDomainModel lockerLocation
     ) {
-        return new LockerDomainModel(
-                null,
-                lockerNumber,
-                true,
-                null,
-                null,
-                null,
-                lockerLocation
-        );
+        return LockerDomainModel.builder()
+                .lockerNumber(lockerNumber)
+                .lockerLocation(lockerLocation)
+                .build();
     }
 
     public static LockerDomainModel of(
@@ -69,15 +47,15 @@ public class LockerDomainModel {
             UserDomainModel user,
             LockerLocationDomainModel lockerLocation
     ) {
-        return new LockerDomainModel(
-                id,
-                lockerNumber,
-                isActive,
-                expiredAt,
-                updatedAt,
-                user,
-                lockerLocation
-        );
+        return LockerDomainModel.builder()
+                .id(id)
+                .lockerNumber(lockerNumber)
+                .isActive(isActive)
+                .expiredAt(expiredAt)
+                .updatedAt(updatedAt)
+                .user(user)
+                .lockerLocation(lockerLocation)
+                .build();
     }
 
     public void register(UserDomainModel user, LocalDateTime expiredAt) {

--- a/src/main/java/net/causw/domain/model/locker/LockerLocationDomainModel.java
+++ b/src/main/java/net/causw/domain/model/locker/LockerLocationDomainModel.java
@@ -23,7 +23,7 @@ public class LockerLocationDomainModel {
                 .build();
     }
 
-    public static LockerLocationDomainModel of(String name) {
+    public static LockerLocationDomainModel from(String name) {
         return LockerLocationDomainModel.builder()
                 .name(name)
                 .build();

--- a/src/main/java/net/causw/domain/model/locker/LockerLocationDomainModel.java
+++ b/src/main/java/net/causw/domain/model/locker/LockerLocationDomainModel.java
@@ -1,41 +1,32 @@
 package net.causw.domain.model.locker;
 
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 import javax.validation.constraints.NotBlank;
 
 @Getter
-@Setter
+@Builder
 public class LockerLocationDomainModel {
     private String id;
 
     @NotBlank(message = "사물함 위치명이 입력되지 않았습니다.")
     private String name;
 
-    private LockerLocationDomainModel(
-            String id,
-            String name
-    ) {
-        this.id = id;
-        this.name = name;
-    }
-
     public static LockerLocationDomainModel of(
             String id,
             String name
     ) {
-        return new LockerLocationDomainModel(
-                id,
-                name
-        );
+        return LockerLocationDomainModel.builder()
+                .id(id)
+                .name(name)
+                .build();
     }
 
     public static LockerLocationDomainModel of(String name) {
-        return new LockerLocationDomainModel(
-                null,
-                name
-        );
+        return LockerLocationDomainModel.builder()
+                .name(name)
+                .build();
     }
 
     public void update(String name) {

--- a/src/main/java/net/causw/domain/model/post/PostDomainModel.java
+++ b/src/main/java/net/causw/domain/model/post/PostDomainModel.java
@@ -1,7 +1,7 @@
 package net.causw.domain.model.post;
 
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 import net.causw.domain.model.user.UserDomainModel;
 import net.causw.domain.model.board.BoardDomainModel;
 
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
-@Setter
+@Builder
 public class PostDomainModel {
     private String id;
 
@@ -31,31 +31,11 @@ public class PostDomainModel {
     private BoardDomainModel board;
 
     private List<String> attachmentList;
+
     private LocalDateTime createdAt;
+
     private LocalDateTime updatedAt;
 
-    private PostDomainModel(
-            String id,
-            String title,
-            String content,
-            UserDomainModel writer,
-            Boolean isDeleted,
-            BoardDomainModel board,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            List<String> attachmentList
-    ) {
-        this.id = id;
-        this.title = title;
-        this.content = content;
-        this.writer = writer;
-        this.isDeleted = isDeleted;
-        this.board = board;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.attachmentList = attachmentList;
-    }
-
     public static PostDomainModel of(
             String id,
             String title,
@@ -67,17 +47,17 @@ public class PostDomainModel {
             LocalDateTime updatedAt,
             List<String> attachmentList
     ) {
-        return new PostDomainModel(
-                id,
-                title,
-                content,
-                writer,
-                isDeleted,
-                board,
-                createdAt,
-                updatedAt,
-                attachmentList
-        );
+        return PostDomainModel.builder()
+                .id(id)
+                .title(title)
+                .content(content)
+                .writer(writer)
+                .isDeleted(isDeleted)
+                .board(board)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .attachmentList(attachmentList)
+                .build();
     }
 
     public static PostDomainModel of(
@@ -87,17 +67,13 @@ public class PostDomainModel {
             BoardDomainModel board,
             List<String> attachmentList
     ) {
-        return new PostDomainModel(
-                null,
-                title,
-                content,
-                writer,
-                false,
-                board,
-                null,
-                null,
-                attachmentList
-        );
+        return PostDomainModel.builder()
+                .title(title)
+                .content(content)
+                .writer(writer)
+                .board(board)
+                .attachmentList(attachmentList)
+                .build();
     }
 
     public void update(

--- a/src/main/java/net/causw/domain/model/user/UserAdmissionDomainModel.java
+++ b/src/main/java/net/causw/domain/model/user/UserAdmissionDomainModel.java
@@ -1,14 +1,14 @@
 package net.causw.domain.model.user;
 
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
+@Builder
 public class UserAdmissionDomainModel {
     private String id;
 
@@ -21,23 +21,8 @@ public class UserAdmissionDomainModel {
     private UserDomainModel user;
 
     private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
 
-    private UserAdmissionDomainModel(
-            String id,
-            UserDomainModel user,
-            String attachImage,
-            String description,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt
-    ) {
-        this.id = id;
-        this.user = user;
-        this.attachImage = attachImage;
-        this.description = description;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-    }
+    private LocalDateTime updatedAt;
 
     public static UserAdmissionDomainModel of(
             String id,
@@ -47,14 +32,14 @@ public class UserAdmissionDomainModel {
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {
-        return new UserAdmissionDomainModel(
-                id,
-                user,
-                attachImage,
-                description,
-                createdAt,
-                updatedAt
-        );
+        return UserAdmissionDomainModel.builder()
+                .id(id)
+                .user(user)
+                .attachImage(attachImage)
+                .description(description)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .build();
     }
 
     public static UserAdmissionDomainModel of(
@@ -62,13 +47,10 @@ public class UserAdmissionDomainModel {
             String attachImage,
             String description
     ) {
-        return new UserAdmissionDomainModel(
-                null,
-                user,
-                attachImage,
-                description,
-                null,
-                null
-        );
+        return UserAdmissionDomainModel.builder()
+                .user(user)
+                .attachImage(attachImage)
+                .description(description)
+                .build();
     }
 }

--- a/src/main/java/net/causw/domain/model/user/UserDomainModel.java
+++ b/src/main/java/net/causw/domain/model/user/UserDomainModel.java
@@ -1,7 +1,7 @@
 package net.causw.domain.model.user;
 
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 import net.causw.domain.model.enums.UserState;
 import net.causw.domain.model.enums.Role;
 
@@ -10,11 +10,14 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 @Getter
-@Setter
+@Builder
 public class UserDomainModel {
     private String id;
+
     private String studentId;
+
     private String profileImage;
+
     private String refreshToken;
 
     @NotBlank(message = "사용자 이름이 입력되지 않았습니다.")
@@ -36,30 +39,6 @@ public class UserDomainModel {
     @NotNull(message = "사용자 상태가 입력되지 않았습니다.")
     private UserState state;
 
-    private UserDomainModel(
-            String id,
-            String email,
-            String name,
-            String password,
-            String studentId,
-            Integer admissionYear,
-            Role role,
-            String profileImage,
-            String refreshToken,
-            UserState state
-    ) {
-        this.id = id;
-        this.email = email;
-        this.name = name;
-        this.password = password;
-        this.studentId = studentId;
-        this.admissionYear = admissionYear;
-        this.role = role;
-        this.profileImage = profileImage;
-        this.refreshToken = refreshToken;
-        this.state = state;
-    }
-
     public static UserDomainModel of(
             String id,
             String email,
@@ -72,18 +51,18 @@ public class UserDomainModel {
             String refreshToken,
             UserState state
     ) {
-        return new UserDomainModel(
-                id,
-                email,
-                name,
-                password,
-                studentId,
-                admissionYear,
-                role,
-                profileImage,
-                refreshToken,
-                state
-        );
+        return UserDomainModel.builder()
+                .id(id)
+                .email(email)
+                .name(name)
+                .password(password)
+                .studentId(studentId)
+                .admissionYear(admissionYear)
+                .role(role)
+                .profileImage(profileImage)
+                .refreshToken(refreshToken)
+                .state(state)
+                .build();
     }
 
     public static UserDomainModel of(
@@ -94,18 +73,14 @@ public class UserDomainModel {
             Integer admissionYear,
             String profileImage
     ) {
-        return new UserDomainModel(
-                null,
-                email,
-                name,
-                password,
-                studentId,
-                admissionYear,
-                Role.NONE,
-                profileImage,
-                null,
-                UserState.AWAIT
-        );
+        return UserDomainModel.builder()
+                .email(email)
+                .name(name)
+                .password(password)
+                .studentId(studentId)
+                .admissionYear(admissionYear)
+                .profileImage(profileImage)
+                .build();
     }
 
     public void update(


### PR DESCRIPTION
### 🚩 관련사항
#545 
직전 PR이 merge되어야 합니다. (구조 개편 관련 코드는 아래 진행사항을 참고하시면 됩니다.)

### 📢 전달사항
* 이제 Service는 Port, DomainModel에 의존하지 않아야 하며, 곧바로 Repository와 직결되어야 합니다.
* Service 메서드는 아래와 같은 구조를 가지게 됩니다.
  * 1. 필요한 Entity를 조회
  * 2. 조회한 Entity에 대한 Validation
  * 3. 추가 비즈니스 로직(수정, 삭제 등)를 실행
  * 4. Dto로 반환
* Service에서는 Entity에 대한 조회 비즈니스 로직은 <private Entity getEntity> 형태로 최하위에 배치합니다.
* Entity는 생성 과정에서 Dto 객체에 직접 의존해서는 안 됩니다.
* 모든 Port/DAO가 Service와 완전히 분리된 것이 확인되면, Port/DAO을 제거하고 패키지를 계층형으로 개편합니다.

### 📸 스크린샷
[코딩 컨벤션과 함께 예시 코드를 참고해주세요.](https://www.notion.so/dustbox-j/2024-78104a49bb394387ae19c191cac7455c?pvs=4)

### 📃 진행사항
- [x] Comment 구조 개편
- [x] ChildComment 구조 개편
- [x] Post 구조 개편
- [x] HomePageService 및 일부 Board Dto 개편
- [x] 노션에 코딩 컨벤션 작성
- [x] updatable/deletable 여부 감별하는 로직 Dto에서 제거하고 StatusUtil에서 관리
- [ ] MapStruct 적용하여 생성 자동화
- [ ] 코드리뷰 및 개선점 반영

### ⚙️ 기타사항

개발기간: 1주