### PR TITLE
refactor: Post & Comment & ChildComment Port 제거 (#545)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,10 @@ dependencies {
 
     // h2
     runtimeOnly 'com.h2database:h2'
+
+    // MapStruct
+    implementation 'org.mapstruct:mapstruct:1.4.2.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.2.Final'
 }
 
 test {

--- a/src/main/java/net/causw/adapter/persistence/comment/ChildComment.java
+++ b/src/main/java/net/causw/adapter/persistence/comment/ChildComment.java
@@ -1,6 +1,7 @@
 package net.causw.adapter.persistence.comment;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.causw.adapter.persistence.user.User;
@@ -18,6 +19,7 @@ import javax.persistence.Table;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "tb_child_comment")
 public class ChildComment extends BaseEntity {
     @Column(name = "content", nullable = false)
@@ -75,13 +77,29 @@ public class ChildComment extends BaseEntity {
         );
     }
 
+    public static ChildComment of(
+            String content,
+            Boolean isDeleted,
+            String tagUserName,
+            String refChildComment,
+            User writer,
+            Comment parentComment
+    ) {
+        return new ChildComment(content, isDeleted, tagUserName, refChildComment, writer, parentComment);
+    }
+
     public void delete(){
         this.isDeleted = true;
     }
 
+    // FIXME: Port 분리가 완전하게 다 끝나면 중복되는 메서드 삭제할 예정
     public void update(String content, String tagUserName, String refChildComment){
         this.content = content;
         this.tagUserName = tagUserName;
         this.refChildComment = refChildComment;
+    }
+
+    public void update(String content){
+        this.content = content;
     }
 }

--- a/src/main/java/net/causw/adapter/persistence/comment/Comment.java
+++ b/src/main/java/net/causw/adapter/persistence/comment/Comment.java
@@ -1,6 +1,7 @@
 package net.causw.adapter.persistence.comment;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.causw.adapter.persistence.post.Post;
@@ -16,11 +17,13 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "tb_comment")
 public class Comment extends BaseEntity {
     @Column(name = "content", nullable = false)
@@ -39,15 +42,9 @@ public class Comment extends BaseEntity {
     private Post post;
 
     @OneToMany(mappedBy = "parentComment")
-    private List<ChildComment> childCommentList;
+    private List<ChildComment> childCommentList = new ArrayList<>(); // 필드 초기화 없으면 NPE
 
-    private Comment(
-            String id,
-            String content,
-            Boolean isDeleted,
-            User writer,
-            Post post
-    ) {
+    private Comment(String id, String content, Boolean isDeleted, User writer, Post post) {
         super(id);
         this.content = content;
         this.isDeleted = isDeleted;
@@ -63,6 +60,14 @@ public class Comment extends BaseEntity {
                 User.from(commentDomainModel.getWriter()),
                 Post.from(postDomainModel)
         );
+    }
+
+    public static Comment of(String content, Boolean isDeleted, User writer, Post post) {
+        return new Comment(content, isDeleted, writer, post, new ArrayList<>());
+    }
+
+    public void setChildCommentList(List<ChildComment> childCommentList) {
+        this.childCommentList = childCommentList;
     }
 
     public void update(String content) {

--- a/src/main/java/net/causw/adapter/persistence/port/mapper/DomainModelMapper.java
+++ b/src/main/java/net/causw/adapter/persistence/port/mapper/DomainModelMapper.java
@@ -68,7 +68,7 @@ public abstract class DomainModelMapper {
                 this.entityToDomainModel(post.getBoard()),
                 post.getCreatedAt(),
                 post.getUpdatedAt(),
-                post.getAttachments().map(attachments -> Arrays.asList(attachments.split(":::"))).orElse(List.of())
+                List.of()
         );
     }
 

--- a/src/main/java/net/causw/adapter/persistence/port/post/PostPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/post/PostPortImpl.java
@@ -54,10 +54,7 @@ public class PostPortImpl extends DomainModelMapper implements PostPort {
     public Optional<PostDomainModel> updatePost(String id, PostDomainModel postDomainModel) {
         return this.postRepository.findById(id).map(
                 srcPost -> {
-                    srcPost.setTitle(postDomainModel.getTitle());
-                    srcPost.setContent(postDomainModel.getContent());
-                    srcPost.setAttachments(String.join(":::", postDomainModel.getAttachmentList()));
-
+                    srcPost.update(postDomainModel.getTitle(), postDomainModel.getContent(), String.join(":::", postDomainModel.getAttachmentList()));
                     return this.entityToDomainModel(this.postRepository.save(srcPost));
                 }
         );

--- a/src/main/java/net/causw/adapter/persistence/post/Post.java
+++ b/src/main/java/net/causw/adapter/persistence/post/Post.java
@@ -13,10 +13,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
-import java.util.Optional;
-
 @Getter
-@Setter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -90,7 +87,7 @@ public class Post extends BaseEntity {
         this.attachments = attachments;
     }
 
-    public Optional<String> getAttachments() {
-        return Optional.ofNullable(this.attachments);
+    public void setIsDeleted(Boolean isDeleted) {
+        this.isDeleted = isDeleted;
     }
 }

--- a/src/main/java/net/causw/adapter/persistence/post/Post.java
+++ b/src/main/java/net/causw/adapter/persistence/post/Post.java
@@ -1,9 +1,6 @@
 package net.causw.adapter.persistence.post;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import net.causw.adapter.persistence.user.User;
 import net.causw.adapter.persistence.base.BaseEntity;
 import net.causw.adapter.persistence.board.Board;
@@ -22,6 +19,7 @@ import java.util.Optional;
 @Setter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "tb_post")
 public class Post extends BaseEntity {
     @Column(name = "title", nullable = false)
@@ -73,6 +71,23 @@ public class Post extends BaseEntity {
                 Board.from(postDomainModel.getBoard()),
                 String.join(":::", postDomainModel.getAttachmentList())
         );
+    }
+
+    public static Post of(
+            String title,
+            String content,
+            User writer,
+            Boolean isDeleted,
+            Board board,
+            String attachments
+    ) {
+        return new Post(title, content, attachments, writer, isDeleted, board);
+    }
+
+    public void update(String title, String content, String attachments) {
+        this.title = title;
+        this.content = content;
+        this.attachments = attachments;
     }
 
     public Optional<String> getAttachments() {

--- a/src/main/java/net/causw/application/comment/ChildCommentService.java
+++ b/src/main/java/net/causw/application/comment/ChildCommentService.java
@@ -11,6 +11,7 @@ import net.causw.adapter.persistence.user.User;
 import net.causw.application.dto.comment.ChildCommentCreateRequestDto;
 import net.causw.application.dto.comment.ChildCommentResponseDto;
 import net.causw.application.dto.comment.ChildCommentUpdateRequestDto;
+import net.causw.application.dto.util.StatusUtil;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
@@ -67,7 +68,11 @@ public class ChildCommentService {
         );
         validatorBucket.validate();
 
-        return ChildCommentResponseDto.of(childCommentRepository.save(childComment), user, post.getBoard());
+        return ChildCommentResponseDto.of(
+                childCommentRepository.save(childComment),
+                StatusUtil.isUpdatable(childComment, user),
+                StatusUtil.isDeletable(childComment, user, post.getBoard())
+        );
     }
 
     @Transactional
@@ -93,7 +98,11 @@ public class ChildCommentService {
                 ));
         validatorBucket.validate();
 
-        return ChildCommentResponseDto.of(childCommentRepository.save(childComment), updater, post.getBoard());
+        return ChildCommentResponseDto.of(
+                childCommentRepository.save(childComment),
+                StatusUtil.isUpdatable(childComment, updater),
+                StatusUtil.isDeletable(childComment, updater, post.getBoard())
+        );
     }
 
     @Transactional
@@ -152,8 +161,8 @@ public class ChildCommentService {
 
         return ChildCommentResponseDto.of(
                 childCommentRepository.save(childComment),
-                deleter,
-                post.getBoard()
+                StatusUtil.isUpdatable(childComment, deleter),
+                StatusUtil.isDeletable(childComment, deleter, post.getBoard())
         );
     }
 

--- a/src/main/java/net/causw/application/comment/ChildCommentService.java
+++ b/src/main/java/net/causw/application/comment/ChildCommentService.java
@@ -11,6 +11,7 @@ import net.causw.adapter.persistence.user.User;
 import net.causw.application.dto.comment.ChildCommentCreateRequestDto;
 import net.causw.application.dto.comment.ChildCommentResponseDto;
 import net.causw.application.dto.comment.ChildCommentUpdateRequestDto;
+import net.causw.application.dto.util.DtoMapper;
 import net.causw.application.dto.util.StatusUtil;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
@@ -68,7 +69,7 @@ public class ChildCommentService {
         );
         validatorBucket.validate();
 
-        return ChildCommentResponseDto.of(
+        return toDto(
                 childCommentRepository.save(childComment),
                 StatusUtil.isUpdatable(childComment, user),
                 StatusUtil.isDeletable(childComment, user, post.getBoard())
@@ -98,7 +99,7 @@ public class ChildCommentService {
                 ));
         validatorBucket.validate();
 
-        return ChildCommentResponseDto.of(
+        return toDto(
                 childCommentRepository.save(childComment),
                 StatusUtil.isUpdatable(childComment, updater),
                 StatusUtil.isDeletable(childComment, updater, post.getBoard())
@@ -159,7 +160,7 @@ public class ChildCommentService {
 
         childComment.delete();
 
-        return ChildCommentResponseDto.of(
+        return toDto(
                 childCommentRepository.save(childComment),
                 StatusUtil.isUpdatable(childComment, deleter),
                 StatusUtil.isDeletable(childComment, deleter, post.getBoard())
@@ -188,6 +189,10 @@ public class ChildCommentService {
                             ));
                 });
         return validatorBucket;
+    }
+
+    private ChildCommentResponseDto toDto(ChildComment comment, Boolean updatable, Boolean deletable) {
+        return DtoMapper.INSTANCE.toChildCommentResponseDto(comment, updatable, deletable);
     }
 
     private User getUser(String userId) {

--- a/src/main/java/net/causw/application/comment/ChildCommentService.java
+++ b/src/main/java/net/causw/application/comment/ChildCommentService.java
@@ -69,7 +69,7 @@ public class ChildCommentService {
         );
         validatorBucket.validate();
 
-        return toDto(
+        return toChildCommentResponseDto(
                 childCommentRepository.save(childComment),
                 StatusUtil.isUpdatable(childComment, user),
                 StatusUtil.isDeletable(childComment, user, post.getBoard())
@@ -99,7 +99,7 @@ public class ChildCommentService {
                 ));
         validatorBucket.validate();
 
-        return toDto(
+        return toChildCommentResponseDto(
                 childCommentRepository.save(childComment),
                 StatusUtil.isUpdatable(childComment, updater),
                 StatusUtil.isDeletable(childComment, updater, post.getBoard())
@@ -160,7 +160,7 @@ public class ChildCommentService {
 
         childComment.delete();
 
-        return toDto(
+        return toChildCommentResponseDto(
                 childCommentRepository.save(childComment),
                 StatusUtil.isUpdatable(childComment, deleter),
                 StatusUtil.isDeletable(childComment, deleter, post.getBoard())
@@ -191,7 +191,7 @@ public class ChildCommentService {
         return validatorBucket;
     }
 
-    private ChildCommentResponseDto toDto(ChildComment comment, Boolean updatable, Boolean deletable) {
+    private ChildCommentResponseDto toChildCommentResponseDto(ChildComment comment, Boolean updatable, Boolean deletable) {
         return DtoMapper.INSTANCE.toChildCommentResponseDto(comment, updatable, deletable);
     }
 

--- a/src/main/java/net/causw/application/comment/CommentService.java
+++ b/src/main/java/net/causw/application/comment/CommentService.java
@@ -51,44 +51,14 @@ public class CommentService {
 
     @Transactional
     public CommentResponseDto createComment(String loginUserId, CommentCreateRequestDto commentCreateDto) {
-        ValidatorBucket validatorBucket = ValidatorBucket.of();
-
         User user = getUser(loginUserId);
         Post post = getPost(commentCreateDto.getPostId());
         Comment comment = Comment.of(commentCreateDto.getContent(), false, user, post);
 
-        validatorBucket
-                .consistOf(UserStateValidator.of(user.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
-                .consistOf(TargetIsDeletedValidator.of(post.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
-                .consistOf(TargetIsDeletedValidator.of(post.getIsDeleted(), StaticValue.DOMAIN_POST))
-                .consistOf(ConstraintValidator.of(comment, this.validator));
-
-        Optional<Circle> circles = Optional.ofNullable(post.getBoard().getCircle());
-        circles
-                .filter(circleDomainModel -> !user.getRole().equals(Role.ADMIN) && !user.getRole().getValue().contains("PRESIDENT"))
-                .ifPresent(
-                        circle -> {
-                            CircleMember member = circleMemberRepository.findByUser_IdAndCircle_Id(
-                                    loginUserId,
-                                    circle.getId()
-                            ).orElseThrow(
-                                    () -> new UnauthorizedException(
-                                            ErrorCode.NOT_MEMBER,
-                                            MessageUtil.CIRCLE_APPLY_INVALID
-                                    )
-                            );
-                            validatorBucket
-                                    .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
-                                    .consistOf(CircleMemberStatusValidator.of(
-                                            member.getStatus(),
-                                            List.of(CircleMemberStatus.MEMBER)
-                                    ));
-                        }
-                );
-
-        validatorBucket
-                .validate();
+        ValidatorBucket validatorBucket = initializeValidator(user, post);
+        validatorBucket.
+                consistOf(ConstraintValidator.of(comment, this.validator));
+        validatorBucket.validate();
 
         return CommentResponseDto.of(
                 commentRepository.save(comment),
@@ -103,70 +73,29 @@ public class CommentService {
 
     @Transactional(readOnly = true)
     public Page<CommentResponseDto> findAllComments(String loginUserId, String postId, Integer pageNum) {
-        ValidatorBucket validatorBucket = ValidatorBucket.of();
-
         User user = getUser(loginUserId);
         Post post = getPost(postId);
 
-        validatorBucket
-                .consistOf(UserStateValidator.of(user.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
-                .consistOf(TargetIsDeletedValidator.of(post.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
-                .consistOf(TargetIsDeletedValidator.of(post.getIsDeleted(), StaticValue.DOMAIN_POST));
-
-        Optional<Circle> circles = Optional.ofNullable(post.getBoard().getCircle());
-        circles
-                .filter(circle -> !user.getRole().equals(Role.ADMIN) && !user.getRole().getValue().contains("PRESIDENT"))
-                .ifPresent(
-                        circle -> {
-                            CircleMember member = circleMemberRepository.findByUser_IdAndCircle_Id(
-                                    loginUserId,
-                                    circle.getId()
-                            ).orElseThrow(
-                                    () -> new UnauthorizedException(
-                                            ErrorCode.NOT_MEMBER,
-                                            MessageUtil.CIRCLE_APPLY_INVALID
-                                    )
-                            );
-
-                            validatorBucket
-                                    .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
-                                    .consistOf(CircleMemberStatusValidator.of(
-                                            member.getStatus(),
-                                            List.of(CircleMemberStatus.MEMBER)
-                                    ));
-                        }
-                );
-
-        validatorBucket
-                .validate();
-
+        ValidatorBucket validatorBucket = initializeValidator(user, post);
+        validatorBucket.validate();
 
         Page<Comment> comments = commentRepository.findByPost_IdOrderByCreatedAt(
                 postId,
-                this.pageableFactory.create(pageNum, StaticValue.DEFAULT_COMMENT_PAGE_SIZE)
+                pageableFactory.create(pageNum, StaticValue.DEFAULT_COMMENT_PAGE_SIZE)
         );
-
-        for (Comment comment : comments) {
-            comment.setChildCommentList(childCommentRepository.findByParentComment_Id(comment.getId()));
-        }
+        comments.forEach(comment -> comment.setChildCommentList(childCommentRepository.findByParentComment_Id(comment.getId())));
 
         return comments.map(comment ->
-                        CommentResponseDto.of(
-                                comment,
-                                user,
-                                post.getBoard(),
-                                childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(comment.getId()),
-                                comment.getChildCommentList().stream()
-                                        .map(childComment -> ChildCommentResponseDto.of(
-                                                childComment,
-                                                user,
-                                                post.getBoard()
-                                        ))
-                                        .collect(Collectors.toList())
-                        )
-                );
-
+                CommentResponseDto.of(
+                        comment,
+                        user,
+                        post.getBoard(),
+                        childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(comment.getId()),
+                        comment.getChildCommentList().stream()
+                                .map(childComment -> ChildCommentResponseDto.of(childComment, user, post.getBoard()))
+                                .collect(Collectors.toList())
+                )
+        );
     }
 
     @Transactional
@@ -175,17 +104,12 @@ public class CommentService {
             String commentId,
             CommentUpdateRequestDto commentUpdateRequestDto
     ) {
-        ValidatorBucket validatorBucket = ValidatorBucket.of();
-
         User user = getUser(loginUserId);
         Comment comment = getComment(commentId);
         Post post = getPost(comment.getPost().getId());
 
+        ValidatorBucket validatorBucket = initializeValidator(user, post);
         validatorBucket
-                .consistOf(UserStateValidator.of(user.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
-                .consistOf(TargetIsDeletedValidator.of(post.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
-                .consistOf(TargetIsDeletedValidator.of(post.getIsDeleted(), StaticValue.DOMAIN_POST))
                 .consistOf(TargetIsDeletedValidator.of(comment.getIsDeleted(), StaticValue.DOMAIN_COMMENT))
                 .consistOf(ConstraintValidator.of(comment, this.validator))
                 .consistOf(ContentsAdminValidator.of(
@@ -194,25 +118,7 @@ public class CommentService {
                         comment.getWriter().getId(),
                         List.of()
                 ));
-
-        Optional<Circle> circles = Optional.ofNullable(post.getBoard().getCircle());
-        circles
-                .filter(circle -> !user.getRole().equals(Role.ADMIN) && !user.getRole().getValue().contains("PRESIDENT"))
-                .ifPresent(
-                        circle -> {
-                            CircleMember member = getCircleMember(loginUserId, circle.getId());
-
-                            validatorBucket
-                                    .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
-                                    .consistOf(CircleMemberStatusValidator.of(
-                                            member.getStatus(),
-                                            List.of(CircleMemberStatus.MEMBER)
-                                    ));
-                        }
-                );
-
-        validatorBucket
-                .validate();
+        validatorBucket.validate();
 
         comment.update(commentUpdateRequestDto.getContent());
 
@@ -230,12 +136,11 @@ public class CommentService {
 
     @Transactional
     public CommentResponseDto deleteComment(String loginUserId, String commentId) {
-        ValidatorBucket validatorBucket = ValidatorBucket.of();
-
         User user = getUser(loginUserId);
         Comment comment = getComment(commentId);
         Post post = getPost(comment.getPost().getId());
 
+        ValidatorBucket validatorBucket = initializeValidator(user, post);
         validatorBucket
                 .consistOf(UserStateValidator.of(user.getState()))
                 .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
@@ -246,15 +151,7 @@ public class CommentService {
                 .filter(circle -> !user.getRole().equals(Role.ADMIN) && !user.getRole().getValue().contains("PRESIDENT"))
                 .ifPresentOrElse(
                         circle -> {
-                            CircleMember member = circleMemberRepository.findByUser_IdAndCircle_Id(
-                                    loginUserId,
-                                    circle.getId()
-                            ).orElseThrow(
-                                    () -> new UnauthorizedException(
-                                            ErrorCode.NOT_MEMBER,
-                                            MessageUtil.CIRCLE_APPLY_INVALID
-                                    )
-                            );
+                            CircleMember member = getCircleMember(user.getId(), circle.getId());
 
                             validatorBucket
                                     .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
@@ -291,9 +188,7 @@ public class CommentService {
                                         List.of()
                                 ))
                 );
-
-        validatorBucket
-                .validate();
+        validatorBucket.validate();
 
         comment.delete();
 
@@ -308,39 +203,63 @@ public class CommentService {
         );
     }
 
-    private User getUser(String userId){
+    private ValidatorBucket initializeValidator(User user, Post post) {
+        ValidatorBucket validatorBucket = ValidatorBucket.of();
+        validatorBucket
+                .consistOf(UserStateValidator.of(user.getState()))
+                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
+                .consistOf(TargetIsDeletedValidator.of(post.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
+                .consistOf(TargetIsDeletedValidator.of(post.getIsDeleted(), StaticValue.DOMAIN_POST));
+
+        Optional<Circle> circles = Optional.ofNullable(post.getBoard().getCircle());
+        circles
+                .filter(circle -> !user.getRole().equals(Role.ADMIN) && !user.getRole().getValue().contains("PRESIDENT"))
+                .ifPresent(circle -> {
+                    CircleMember member = getCircleMember(user.getId(), circle.getId());
+
+                    validatorBucket
+                            .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
+                            .consistOf(CircleMemberStatusValidator.of(
+                                    member.getStatus(),
+                                    List.of(CircleMemberStatus.MEMBER)
+                            ));
+                });
+        return validatorBucket;
+    }
+
+    private User getUser(String userId) {
         return userRepository.findById(userId).orElseThrow(
-            () -> new BadRequestException(
-                    ErrorCode.ROW_DOES_NOT_EXIST,
-                    MessageUtil.USER_NOT_FOUND
-            )
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        MessageUtil.USER_NOT_FOUND
+                )
         );
     }
 
-    private Post getPost(String postId){
+    private Post getPost(String postId) {
         return postRepository.findById(postId).orElseThrow(
-            () -> new BadRequestException(
-                    ErrorCode.ROW_DOES_NOT_EXIST,
-                    MessageUtil.POST_NOT_FOUND
-            )
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        MessageUtil.POST_NOT_FOUND
+                )
         );
     }
 
-    private Comment getComment(String commentId){
+    private Comment getComment(String commentId) {
         return commentRepository.findById(commentId).orElseThrow(
-            () -> new BadRequestException(
-                    ErrorCode.ROW_DOES_NOT_EXIST,
-                    MessageUtil.COMMENT_NOT_FOUND
-            )
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        MessageUtil.COMMENT_NOT_FOUND
+                )
         );
     }
 
-    private CircleMember getCircleMember(String userId, String circleId){
+    private CircleMember getCircleMember(String userId, String circleId) {
         return circleMemberRepository.findByUser_IdAndCircle_Id(userId, circleId).orElseThrow(
-            () -> new BadRequestException(
-                    ErrorCode.ROW_DOES_NOT_EXIST,
-                    MessageUtil.CIRCLE_MEMBER_NOT_FOUND
-            )
+                () -> new UnauthorizedException(
+                        ErrorCode.NOT_MEMBER,
+                        MessageUtil.CIRCLE_APPLY_INVALID
+                )
         );
     }
 }

--- a/src/main/java/net/causw/application/comment/CommentService.java
+++ b/src/main/java/net/causw/application/comment/CommentService.java
@@ -12,6 +12,7 @@ import net.causw.application.dto.comment.ChildCommentResponseDto;
 import net.causw.application.dto.comment.CommentCreateRequestDto;
 import net.causw.application.dto.comment.CommentResponseDto;
 import net.causw.application.dto.comment.CommentUpdateRequestDto;
+import net.causw.application.dto.util.StatusUtil;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
@@ -62,12 +63,12 @@ public class CommentService {
 
         return CommentResponseDto.of(
                 commentRepository.save(comment),
-                user,
-                post.getBoard(),
                 childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(comment.getId()),
                 comment.getChildCommentList().stream()
-                        .map(childComment -> ChildCommentResponseDto.of(childComment, user, post.getBoard()))
-                        .collect(Collectors.toList())
+                        .map(childComment -> ChildCommentResponseDto.of(childComment, StatusUtil.isUpdatable(childComment, user), StatusUtil.isDeletable(childComment, user, post.getBoard())))
+                        .collect(Collectors.toList()),
+                StatusUtil.isUpdatable(comment, user),
+                StatusUtil.isDeletable(comment, user, post.getBoard())
         );
     }
 
@@ -88,12 +89,12 @@ public class CommentService {
         return comments.map(comment ->
                 CommentResponseDto.of(
                         comment,
-                        user,
-                        post.getBoard(),
                         childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(comment.getId()),
                         comment.getChildCommentList().stream()
-                                .map(childComment -> ChildCommentResponseDto.of(childComment, user, post.getBoard()))
-                                .collect(Collectors.toList())
+                                .map(childComment -> ChildCommentResponseDto.of(childComment, StatusUtil.isUpdatable(childComment, user), StatusUtil.isDeletable(childComment, user, post.getBoard())))
+                                .collect(Collectors.toList()),
+                        StatusUtil.isUpdatable(comment, user),
+                        StatusUtil.isDeletable(comment, user, post.getBoard())
                 )
         );
     }
@@ -124,12 +125,12 @@ public class CommentService {
 
         return CommentResponseDto.of(
                 commentRepository.save(comment),
-                user,
-                post.getBoard(),
                 childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(comment.getId()),
                 comment.getChildCommentList().stream()
-                        .map(childComment -> ChildCommentResponseDto.of(childComment, user, post.getBoard()))
-                        .collect(Collectors.toList())
+                        .map(childComment -> ChildCommentResponseDto.of(childComment, StatusUtil.isUpdatable(childComment, user), StatusUtil.isDeletable(childComment, user, post.getBoard())))
+                        .collect(Collectors.toList()),
+                StatusUtil.isUpdatable(comment, user),
+                StatusUtil.isDeletable(comment, user, post.getBoard())
         );
     }
 
@@ -194,12 +195,12 @@ public class CommentService {
 
         return CommentResponseDto.of(
                 commentRepository.save(comment),
-                user,
-                post.getBoard(),
                 childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(commentId),
                 comment.getChildCommentList().stream()
-                        .map(childCommentDomainModel -> ChildCommentResponseDto.of(childCommentDomainModel, user, post.getBoard()))
-                        .collect(Collectors.toList())
+                        .map(childComment -> ChildCommentResponseDto.of(childComment, StatusUtil.isUpdatable(childComment, user), StatusUtil.isDeletable(childComment, user, post.getBoard())))
+                        .collect(Collectors.toList()),
+                StatusUtil.isUpdatable(comment, user),
+                StatusUtil.isDeletable(comment, user, post.getBoard())
         );
     }
 

--- a/src/main/java/net/causw/application/comment/CommentService.java
+++ b/src/main/java/net/causw/application/comment/CommentService.java
@@ -1,23 +1,25 @@
 package net.causw.application.comment;
 
 import lombok.RequiredArgsConstructor;
+import net.causw.adapter.persistence.circle.Circle;
+import net.causw.adapter.persistence.circle.CircleMember;
+import net.causw.adapter.persistence.comment.Comment;
+import net.causw.adapter.persistence.page.PageableFactory;
+import net.causw.adapter.persistence.post.Post;
+import net.causw.adapter.persistence.repository.*;
+import net.causw.adapter.persistence.user.User;
 import net.causw.application.dto.comment.ChildCommentResponseDto;
 import net.causw.application.dto.comment.CommentCreateRequestDto;
 import net.causw.application.dto.comment.CommentResponseDto;
 import net.causw.application.dto.comment.CommentUpdateRequestDto;
-import net.causw.application.spi.*;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
 import net.causw.domain.exceptions.UnauthorizedException;
-import net.causw.domain.model.circle.CircleMemberDomainModel;
 import net.causw.domain.model.enums.CircleMemberStatus;
-import net.causw.domain.model.comment.CommentDomainModel;
-import net.causw.domain.model.post.PostDomainModel;
 import net.causw.domain.model.enums.Role;
 import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
-import net.causw.domain.model.user.UserDomainModel;
 import net.causw.domain.validation.CircleMemberStatusValidator;
 import net.causw.domain.validation.ConstraintValidator;
 import net.causw.domain.validation.ContentsAdminValidator;
@@ -32,58 +34,44 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.validation.Validator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class CommentService {
-    private final CommentPort commentPort;
-    private final UserPort userPort;
-    private final PostPort postPort;
-    private final CircleMemberPort circleMemberPort;
-    private final ChildCommentPort childCommentPort;
+
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final CircleMemberRepository circleMemberRepository;
+    private final ChildCommentRepository childCommentRepository;
+    private final PageableFactory pageableFactory;
     private final Validator validator;
 
     @Transactional
     public CommentResponseDto createComment(String loginUserId, CommentCreateRequestDto commentCreateDto) {
         ValidatorBucket validatorBucket = ValidatorBucket.of();
 
-        UserDomainModel creatorDomainModel = this.userPort.findById(loginUserId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.LOGIN_USER_NOT_FOUND
-                )
-        );
+        User user = getUser(loginUserId);
+        Post post = getPost(commentCreateDto.getPostId());
+        Comment comment = Comment.of(commentCreateDto.getContent(), false, user, post);
 
         validatorBucket
-                .consistOf(UserStateValidator.of(creatorDomainModel.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(creatorDomainModel.getRole()));
+                .consistOf(UserStateValidator.of(user.getState()))
+                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
+                .consistOf(TargetIsDeletedValidator.of(post.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
+                .consistOf(TargetIsDeletedValidator.of(post.getIsDeleted(), StaticValue.DOMAIN_POST))
+                .consistOf(ConstraintValidator.of(comment, this.validator));
 
-        PostDomainModel postDomainModel = this.postPort.findPostById(commentCreateDto.getPostId()).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.POST_NOT_FOUND
-                )
-        );
-
-        CommentDomainModel commentDomainModel = CommentDomainModel.of(
-                commentCreateDto.getContent(),
-                creatorDomainModel,
-                postDomainModel.getId()
-        );
-
-        validatorBucket
-                .consistOf(TargetIsDeletedValidator.of(postDomainModel.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
-                .consistOf(TargetIsDeletedValidator.of(postDomainModel.getIsDeleted(), StaticValue.DOMAIN_POST))
-                .consistOf(ConstraintValidator.of(commentDomainModel, this.validator));
-
-        postDomainModel.getBoard().getCircle()
-                .filter(circleDomainModel -> !creatorDomainModel.getRole().equals(Role.ADMIN) && !creatorDomainModel.getRole().getValue().contains("PRESIDENT"))
+        Optional<Circle> circles = Optional.ofNullable(post.getBoard().getCircle());
+        circles
+                .filter(circleDomainModel -> !user.getRole().equals(Role.ADMIN) && !user.getRole().getValue().contains("PRESIDENT"))
                 .ifPresent(
-                        circleDomainModel -> {
-                            CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
+                        circle -> {
+                            CircleMember member = circleMemberRepository.findByUser_IdAndCircle_Id(
                                     loginUserId,
-                                    circleDomainModel.getId()
+                                    circle.getId()
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
@@ -91,9 +79,9 @@ public class CommentService {
                                     )
                             );
                             validatorBucket
-                                    .consistOf(TargetIsDeletedValidator.of(circleDomainModel.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
+                                    .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
                                     .consistOf(CircleMemberStatusValidator.of(
-                                            circleMemberDomainModel.getStatus(),
+                                            member.getStatus(),
                                             List.of(CircleMemberStatus.MEMBER)
                                     ));
                         }
@@ -103,16 +91,12 @@ public class CommentService {
                 .validate();
 
         return CommentResponseDto.of(
-                this.commentPort.create(commentDomainModel, postDomainModel),
-                creatorDomainModel,
-                postDomainModel.getBoard(),
-                this.childCommentPort.countByParentComment(commentDomainModel.getId()),
-                commentDomainModel.getChildCommentList().stream()
-                        .map(childCommentDomainModel -> ChildCommentResponseDto.of(
-                                childCommentDomainModel,
-                                creatorDomainModel,
-                                postDomainModel.getBoard()
-                        ))
+                commentRepository.save(comment),
+                user,
+                post.getBoard(),
+                childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(comment.getId()),
+                comment.getChildCommentList().stream()
+                        .map(childComment -> ChildCommentResponseDto.of(childComment, user, post.getBoard()))
                         .collect(Collectors.toList())
         );
     }
@@ -121,33 +105,23 @@ public class CommentService {
     public Page<CommentResponseDto> findAllComments(String loginUserId, String postId, Integer pageNum) {
         ValidatorBucket validatorBucket = ValidatorBucket.of();
 
-        UserDomainModel userDomainModel = this.userPort.findById(loginUserId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.LOGIN_USER_NOT_FOUND
-                )
-        );
-
-        PostDomainModel postDomainModel = this.postPort.findPostById(postId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.POST_NOT_FOUND
-                )
-        );
+        User user = getUser(loginUserId);
+        Post post = getPost(postId);
 
         validatorBucket
-                .consistOf(UserStateValidator.of(userDomainModel.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(userDomainModel.getRole()))
-                .consistOf(TargetIsDeletedValidator.of(postDomainModel.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
-                .consistOf(TargetIsDeletedValidator.of(postDomainModel.getIsDeleted(), StaticValue.DOMAIN_POST));
+                .consistOf(UserStateValidator.of(user.getState()))
+                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
+                .consistOf(TargetIsDeletedValidator.of(post.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
+                .consistOf(TargetIsDeletedValidator.of(post.getIsDeleted(), StaticValue.DOMAIN_POST));
 
-        postDomainModel.getBoard().getCircle()
-                .filter(circleDomainModel -> !userDomainModel.getRole().equals(Role.ADMIN) && !userDomainModel.getRole().getValue().contains("PRESIDENT"))
+        Optional<Circle> circles = Optional.ofNullable(post.getBoard().getCircle());
+        circles
+                .filter(circle -> !user.getRole().equals(Role.ADMIN) && !user.getRole().getValue().contains("PRESIDENT"))
                 .ifPresent(
-                        circleDomainModel -> {
-                            CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
+                        circle -> {
+                            CircleMember member = circleMemberRepository.findByUser_IdAndCircle_Id(
                                     loginUserId,
-                                    circleDomainModel.getId()
+                                    circle.getId()
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
@@ -156,9 +130,9 @@ public class CommentService {
                             );
 
                             validatorBucket
-                                    .consistOf(TargetIsDeletedValidator.of(circleDomainModel.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
+                                    .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
                                     .consistOf(CircleMemberStatusValidator.of(
-                                            circleMemberDomainModel.getStatus(),
+                                            member.getStatus(),
                                             List.of(CircleMemberStatus.MEMBER)
                                     ));
                         }
@@ -167,22 +141,32 @@ public class CommentService {
         validatorBucket
                 .validate();
 
-        return this.commentPort.findByPostId(postId, pageNum)
-                .map(commentDomainModel ->
+
+        Page<Comment> comments = commentRepository.findByPost_IdOrderByCreatedAt(
+                postId,
+                this.pageableFactory.create(pageNum, StaticValue.DEFAULT_COMMENT_PAGE_SIZE)
+        );
+
+        for (Comment comment : comments) {
+            comment.setChildCommentList(childCommentRepository.findByParentComment_Id(comment.getId()));
+        }
+
+        return comments.map(comment ->
                         CommentResponseDto.of(
-                                commentDomainModel,
-                                userDomainModel,
-                                postDomainModel.getBoard(),
-                                this.childCommentPort.countByParentComment(commentDomainModel.getId()),
-                                commentDomainModel.getChildCommentList().stream()
-                                        .map(childCommentDomainModel -> ChildCommentResponseDto.of(
-                                                childCommentDomainModel,
-                                                userDomainModel,
-                                                postDomainModel.getBoard()
+                                comment,
+                                user,
+                                post.getBoard(),
+                                childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(comment.getId()),
+                                comment.getChildCommentList().stream()
+                                        .map(childComment -> ChildCommentResponseDto.of(
+                                                childComment,
+                                                user,
+                                                post.getBoard()
                                         ))
                                         .collect(Collectors.toList())
                         )
                 );
+
     }
 
     @Transactional
@@ -193,63 +177,35 @@ public class CommentService {
     ) {
         ValidatorBucket validatorBucket = ValidatorBucket.of();
 
-        UserDomainModel requestUser = this.userPort.findById(loginUserId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.LOGIN_USER_NOT_FOUND
-                )
-        );
-
-        CommentDomainModel commentDomainModel = this.commentPort.findById(commentId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.COMMENT_NOT_FOUND
-                )
-        );
-
-        PostDomainModel postDomainModel = this.postPort.findPostById(commentDomainModel.getPostId()).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.POST_NOT_FOUND
-                )
-        );
-
-        commentDomainModel.update(
-                commentUpdateRequestDto.getContent()
-        );
+        User user = getUser(loginUserId);
+        Comment comment = getComment(commentId);
+        Post post = getPost(comment.getPost().getId());
 
         validatorBucket
-                .consistOf(UserStateValidator.of(requestUser.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(requestUser.getRole()))
-                .consistOf(TargetIsDeletedValidator.of(postDomainModel.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
-                .consistOf(TargetIsDeletedValidator.of(postDomainModel.getIsDeleted(), StaticValue.DOMAIN_POST))
-                .consistOf(TargetIsDeletedValidator.of(commentDomainModel.getIsDeleted(), StaticValue.DOMAIN_COMMENT))
-                .consistOf(ConstraintValidator.of(commentDomainModel, this.validator))
+                .consistOf(UserStateValidator.of(user.getState()))
+                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
+                .consistOf(TargetIsDeletedValidator.of(post.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
+                .consistOf(TargetIsDeletedValidator.of(post.getIsDeleted(), StaticValue.DOMAIN_POST))
+                .consistOf(TargetIsDeletedValidator.of(comment.getIsDeleted(), StaticValue.DOMAIN_COMMENT))
+                .consistOf(ConstraintValidator.of(comment, this.validator))
                 .consistOf(ContentsAdminValidator.of(
-                        requestUser.getRole(),
+                        user.getRole(),
                         loginUserId,
-                        commentDomainModel.getWriter().getId(),
+                        comment.getWriter().getId(),
                         List.of()
                 ));
 
-        postDomainModel.getBoard().getCircle()
-                .filter(circleDomainModel -> !requestUser.getRole().equals(Role.ADMIN) && !requestUser.getRole().getValue().contains("PRESIDENT"))
+        Optional<Circle> circles = Optional.ofNullable(post.getBoard().getCircle());
+        circles
+                .filter(circle -> !user.getRole().equals(Role.ADMIN) && !user.getRole().getValue().contains("PRESIDENT"))
                 .ifPresent(
-                        circleDomainModel -> {
-                            CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
-                                    loginUserId,
-                                    circleDomainModel.getId()
-                            ).orElseThrow(
-                                    () -> new UnauthorizedException(
-                                            ErrorCode.NOT_MEMBER,
-                                            MessageUtil.CIRCLE_APPLY_INVALID
-                                    )
-                            );
+                        circle -> {
+                            CircleMember member = getCircleMember(loginUserId, circle.getId());
 
                             validatorBucket
-                                    .consistOf(TargetIsDeletedValidator.of(circleDomainModel.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
+                                    .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
                                     .consistOf(CircleMemberStatusValidator.of(
-                                            circleMemberDomainModel.getStatus(),
+                                            member.getStatus(),
                                             List.of(CircleMemberStatus.MEMBER)
                                     ));
                         }
@@ -258,63 +214,41 @@ public class CommentService {
         validatorBucket
                 .validate();
 
+        comment.update(commentUpdateRequestDto.getContent());
+
         return CommentResponseDto.of(
-                this.commentPort.update(commentId, commentDomainModel).orElseThrow(
-                        () -> new InternalServerException(
-                                ErrorCode.INTERNAL_SERVER,
-                                MessageUtil.INTERNAL_SERVER_ERROR
-                        )
-                ),
-                requestUser,
-                postDomainModel.getBoard(),
-                this.childCommentPort.countByParentComment(commentId),
-                commentDomainModel.getChildCommentList().stream()
-                        .map(childCommentDomainModel -> ChildCommentResponseDto.of(
-                                childCommentDomainModel,
-                                requestUser,
-                                postDomainModel.getBoard()
-                        ))
+                commentRepository.save(comment),
+                user,
+                post.getBoard(),
+                childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(comment.getId()),
+                comment.getChildCommentList().stream()
+                        .map(childComment -> ChildCommentResponseDto.of(childComment, user, post.getBoard()))
                         .collect(Collectors.toList())
         );
     }
+
 
     @Transactional
     public CommentResponseDto deleteComment(String loginUserId, String commentId) {
         ValidatorBucket validatorBucket = ValidatorBucket.of();
 
-        UserDomainModel deleterDomainModel = this.userPort.findById(loginUserId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.LOGIN_USER_NOT_FOUND
-                )
-        );
-
-        CommentDomainModel commentDomainModel = this.commentPort.findById(commentId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.COMMENT_NOT_FOUND
-                )
-        );
-
-        PostDomainModel postDomainModel = this.postPort.findPostById(commentDomainModel.getPostId()).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.POST_NOT_FOUND
-                )
-        );
+        User user = getUser(loginUserId);
+        Comment comment = getComment(commentId);
+        Post post = getPost(comment.getPost().getId());
 
         validatorBucket
-                .consistOf(UserStateValidator.of(deleterDomainModel.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(deleterDomainModel.getRole()))
-                .consistOf(TargetIsDeletedValidator.of(commentDomainModel.getIsDeleted(), StaticValue.DOMAIN_COMMENT));
+                .consistOf(UserStateValidator.of(user.getState()))
+                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
+                .consistOf(TargetIsDeletedValidator.of(comment.getIsDeleted(), StaticValue.DOMAIN_COMMENT));
 
-        postDomainModel.getBoard().getCircle()
-                .filter(circleDomainModel -> !deleterDomainModel.getRole().equals(Role.ADMIN) && !deleterDomainModel.getRole().getValue().contains("PRESIDENT"))
+        Optional<Circle> circles = Optional.ofNullable(post.getBoard().getCircle());
+        circles
+                .filter(circle -> !user.getRole().equals(Role.ADMIN) && !user.getRole().getValue().contains("PRESIDENT"))
                 .ifPresentOrElse(
-                        circleDomainModel -> {
-                            CircleMemberDomainModel circleMemberDomainModel = this.circleMemberPort.findByUserIdAndCircleId(
+                        circle -> {
+                            CircleMember member = circleMemberRepository.findByUser_IdAndCircle_Id(
                                     loginUserId,
-                                    circleDomainModel.getId()
+                                    circle.getId()
                             ).orElseThrow(
                                     () -> new UnauthorizedException(
                                             ErrorCode.NOT_MEMBER,
@@ -323,25 +257,26 @@ public class CommentService {
                             );
 
                             validatorBucket
-                                    .consistOf(TargetIsDeletedValidator.of(circleDomainModel.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
+                                    .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
                                     .consistOf(CircleMemberStatusValidator.of(
-                                            circleMemberDomainModel.getStatus(),
+                                            member.getStatus(),
                                             List.of(CircleMemberStatus.MEMBER)
                                     ))
                                     .consistOf(ContentsAdminValidator.of(
-                                            deleterDomainModel.getRole(),
+                                            user.getRole(),
                                             loginUserId,
-                                            commentDomainModel.getWriter().getId(),
+                                            comment.getWriter().getId(),
                                             List.of(Role.LEADER_CIRCLE)
                                     ));
 
-                            if (deleterDomainModel.getRole().getValue().contains("LEADER_CIRCLE") && !commentDomainModel.getWriter().getId().equals(loginUserId)) {
+                            if (user.getRole().getValue().contains("LEADER_CIRCLE") && !comment.getWriter().getId().equals(loginUserId)) {
                                 validatorBucket
                                         .consistOf(UserEqualValidator.of(
-                                                circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
+                                                circle.getLeader().map(User::getId).orElseThrow(
                                                         () -> new InternalServerException(
-                                                                ErrorCode.INTERNAL_SERVER,
+                                                                ErrorCode.ROW_DOES_NOT_EXIST,
                                                                 MessageUtil.CIRCLE_WITHOUT_LEADER
+
                                                         )
                                                 ),
                                                 loginUserId
@@ -350,9 +285,9 @@ public class CommentService {
                         },
                         () -> validatorBucket
                                 .consistOf(ContentsAdminValidator.of(
-                                        deleterDomainModel.getRole(),
+                                        user.getRole(),
                                         loginUserId,
-                                        commentDomainModel.getWriter().getId(),
+                                        comment.getWriter().getId(),
                                         List.of()
                                 ))
                 );
@@ -360,23 +295,52 @@ public class CommentService {
         validatorBucket
                 .validate();
 
+        comment.delete();
+
         return CommentResponseDto.of(
-                this.commentPort.delete(commentId).orElseThrow(
-                        () -> new InternalServerException(
-                                ErrorCode.INTERNAL_SERVER,
-                                MessageUtil.INTERNAL_SERVER_ERROR
-                        )
-                ),
-                deleterDomainModel,
-                postDomainModel.getBoard(),
-                this.childCommentPort.countByParentComment(commentId),
-                commentDomainModel.getChildCommentList().stream()
-                        .map(childCommentDomainModel -> ChildCommentResponseDto.of(
-                                childCommentDomainModel,
-                                deleterDomainModel,
-                                postDomainModel.getBoard()
-                        ))
+                commentRepository.save(comment),
+                user,
+                post.getBoard(),
+                childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(commentId),
+                comment.getChildCommentList().stream()
+                        .map(childCommentDomainModel -> ChildCommentResponseDto.of(childCommentDomainModel, user, post.getBoard()))
                         .collect(Collectors.toList())
+        );
+    }
+
+    private User getUser(String userId){
+        return userRepository.findById(userId).orElseThrow(
+            () -> new BadRequestException(
+                    ErrorCode.ROW_DOES_NOT_EXIST,
+                    MessageUtil.USER_NOT_FOUND
+            )
+        );
+    }
+
+    private Post getPost(String postId){
+        return postRepository.findById(postId).orElseThrow(
+            () -> new BadRequestException(
+                    ErrorCode.ROW_DOES_NOT_EXIST,
+                    MessageUtil.POST_NOT_FOUND
+            )
+        );
+    }
+
+    private Comment getComment(String commentId){
+        return commentRepository.findById(commentId).orElseThrow(
+            () -> new BadRequestException(
+                    ErrorCode.ROW_DOES_NOT_EXIST,
+                    MessageUtil.COMMENT_NOT_FOUND
+            )
+        );
+    }
+
+    private CircleMember getCircleMember(String userId, String circleId){
+        return circleMemberRepository.findByUser_IdAndCircle_Id(userId, circleId).orElseThrow(
+            () -> new BadRequestException(
+                    ErrorCode.ROW_DOES_NOT_EXIST,
+                    MessageUtil.CIRCLE_MEMBER_NOT_FOUND
+            )
         );
     }
 }

--- a/src/main/java/net/causw/application/comment/CommentService.java
+++ b/src/main/java/net/causw/application/comment/CommentService.java
@@ -62,7 +62,7 @@ public class CommentService {
                 consistOf(ConstraintValidator.of(comment, this.validator));
         validatorBucket.validate();
 
-        return toDto(commentRepository.save(comment), user, post.getBoard());
+        return toCommentResponseDto(commentRepository.save(comment), user, post.getBoard());
     }
 
     @Transactional(readOnly = true)
@@ -79,7 +79,7 @@ public class CommentService {
         );
         comments.forEach(comment -> comment.setChildCommentList(childCommentRepository.findByParentComment_Id(comment.getId())));
 
-        return comments.map(comment -> toDto(comment, user, post.getBoard()));
+        return comments.map(comment -> toCommentResponseDto(comment, user, post.getBoard()));
     }
 
     @Transactional
@@ -106,7 +106,7 @@ public class CommentService {
 
         comment.update(commentUpdateRequestDto.getContent());
 
-        return toDto(commentRepository.save(comment), user, post.getBoard());
+        return toCommentResponseDto(commentRepository.save(comment), user, post.getBoard());
     }
 
 
@@ -168,10 +168,10 @@ public class CommentService {
 
         comment.delete();
 
-        return toDto(commentRepository.save(comment), user, post.getBoard());
+        return toCommentResponseDto(commentRepository.save(comment), user, post.getBoard());
     }
 
-    private CommentResponseDto toDto(Comment comment, User user, Board board) {
+    private CommentResponseDto toCommentResponseDto(Comment comment, User user, Board board) {
         return DtoMapper.INSTANCE.toCommentResponseDto(
                 comment,
                 childCommentRepository.countByParentComment_IdAndIsDeletedIsFalse(comment.getId()),

--- a/src/main/java/net/causw/application/dto/board/BoardResponseDto.java
+++ b/src/main/java/net/causw/application/dto/board/BoardResponseDto.java
@@ -4,11 +4,16 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import net.causw.adapter.persistence.board.Board;
+import net.causw.adapter.persistence.circle.Circle;
 import net.causw.domain.model.board.BoardDomainModel;
 import net.causw.domain.model.circle.CircleDomainModel;
 import net.causw.domain.model.enums.Role;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 @Getter
 @Setter
@@ -41,6 +46,7 @@ public class BoardResponseDto {
     @ApiModelProperty(value = "속한 동아리 이름", example = "circleName_example")
     private String circleName;
 
+    // FIXME: Port 분리 후 삭제 필요
     public static BoardResponseDto from(BoardDomainModel boardDomainModel, Role userRole) {
         String circleId = boardDomainModel.getCircle().map(CircleDomainModel::getId).orElse(null);
         String circleName = boardDomainModel.getCircle().map(CircleDomainModel::getName).orElse(null);
@@ -53,6 +59,24 @@ public class BoardResponseDto {
                 .category(boardDomainModel.getCategory())
                 .writable(boardDomainModel.getCreateRoleList().stream().anyMatch(str -> userRole.getValue().contains(str)))
                 .isDeleted(boardDomainModel.getIsDeleted())
+                .circleId(circleId)
+                .circleName(circleName)
+                .build();
+    }
+
+    public static BoardResponseDto of(Board board, Role userRole) {
+        List<String> roles = new ArrayList<>(Arrays.asList(board.getCreateRoles().split(",")));
+        String circleId = Optional.ofNullable(board.getCircle()).map(Circle::getId).orElse(null);
+        String circleName = Optional.ofNullable(board.getCircle()).map(Circle::getName).orElse(null);
+
+        return BoardResponseDto.builder()
+                .id(board.getId())
+                .name(board.getName())
+                .description(board.getDescription())
+                .createRoleList(roles)
+                .category(board.getCategory())
+                .writable(roles.stream().anyMatch(str -> userRole.getValue().contains(str)))
+                .isDeleted(board.getIsDeleted())
                 .circleId(circleId)
                 .circleName(circleName)
                 .build();

--- a/src/main/java/net/causw/application/dto/comment/ChildCommentResponseDto.java
+++ b/src/main/java/net/causw/application/dto/comment/ChildCommentResponseDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.comment;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -10,6 +11,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @Builder
+@AllArgsConstructor
 public class ChildCommentResponseDto {
     private String id;
     private String content;

--- a/src/main/java/net/causw/application/dto/comment/ChildCommentResponseDto.java
+++ b/src/main/java/net/causw/application/dto/comment/ChildCommentResponseDto.java
@@ -3,11 +3,7 @@ package net.causw.application.dto.comment;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import net.causw.adapter.persistence.board.Board;
 import net.causw.adapter.persistence.comment.ChildComment;
-import net.causw.adapter.persistence.user.User;
-import net.causw.domain.model.enums.Role;
-import net.causw.domain.model.util.StaticValue;
 
 import java.time.LocalDateTime;
 
@@ -30,16 +26,12 @@ public class ChildCommentResponseDto {
 
     public static ChildCommentResponseDto of(
             ChildComment comment,
-            User user,
-            Board board
+            boolean updatable,
+            boolean deletable
     ) {
-        String content = comment.getIsDeleted() ? StaticValue.CONTENT_DELETED_COMMENT : comment.getContent();
-        boolean updatable = determineUpdatable(comment, user);
-        boolean deletable = determineDeletable(comment, user, board);
-
         return ChildCommentResponseDto.builder()
                 .id(comment.getId())
-                .content(content)
+                .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
                 .updatedAt(comment.getUpdatedAt())
                 .isDeleted(comment.getIsDeleted())
@@ -51,19 +43,5 @@ public class ChildCommentResponseDto {
                 .updatable(updatable)
                 .deletable(deletable)
                 .build();
-    }
-
-    private static boolean determineUpdatable(ChildComment comment, User user) {
-        if (comment.getIsDeleted()) return false;
-        return user.getRole() == Role.ADMIN || comment.getWriter().getId().equals(user.getId());
-    }
-
-    private static boolean determineDeletable(ChildComment comment, User user, Board board) {
-        if (comment.getIsDeleted()) return false;
-        if (user.getRole() == Role.ADMIN || user.getRole().getValue().contains("PRESIDENT") || comment.getWriter().getId().equals(user.getId())) {
-            return true;
-        }
-        return board.getCircle() != null && user.getRole().getValue().contains("LEADER_CIRCLE")
-                && board.getCircle().getLeader().map(leader -> leader.getId().equals(user.getId())).orElse(false);
     }
 }

--- a/src/main/java/net/causw/application/dto/comment/ChildCommentResponseDto.java
+++ b/src/main/java/net/causw/application/dto/comment/ChildCommentResponseDto.java
@@ -26,6 +26,7 @@ public class ChildCommentResponseDto {
     private Boolean updatable;
     private Boolean deletable;
 
+    // FIXME: 리팩토링 후 삭제예정
     public static ChildCommentResponseDto of(
             ChildComment comment,
             boolean updatable,

--- a/src/main/java/net/causw/application/dto/comment/CommentResponseDto.java
+++ b/src/main/java/net/causw/application/dto/comment/CommentResponseDto.java
@@ -3,11 +3,7 @@ package net.causw.application.dto.comment;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import net.causw.adapter.persistence.board.Board;
 import net.causw.adapter.persistence.comment.Comment;
-import net.causw.adapter.persistence.user.User;
-import net.causw.domain.model.enums.Role;
-import net.causw.domain.model.util.StaticValue;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -32,18 +28,14 @@ public class CommentResponseDto {
 
     public static CommentResponseDto of(
             Comment comment,
-            User user,
-            Board board,
             Long numChildComment,
-            List<ChildCommentResponseDto> childCommentList
-    ) {
-        String content = comment.getIsDeleted() ? StaticValue.CONTENT_DELETED_COMMENT : comment.getContent();
-        boolean updatable = determineUpdatable(comment, user);
-        boolean deletable = determineDeletable(comment, user, board);
-
+            List<ChildCommentResponseDto> childCommentList,
+            boolean updatable,
+            boolean deletable
+    ){
         return CommentResponseDto.builder()
                 .id(comment.getId())
-                .content(content)
+                .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
                 .updatedAt(comment.getUpdatedAt())
                 .isDeleted(comment.getIsDeleted())
@@ -56,19 +48,5 @@ public class CommentResponseDto {
                 .numChildComment(numChildComment)
                 .childCommentList(childCommentList)
                 .build();
-    }
-
-    private static boolean determineUpdatable(Comment comment, User user) {
-        if (comment.getIsDeleted()) return false;
-        return user.getRole() == Role.ADMIN || comment.getWriter().getId().equals(user.getId());
-    }
-
-    private static boolean determineDeletable(Comment comment, User user, Board board) {
-        if (comment.getIsDeleted()) return false;
-        if (user.getRole() == Role.ADMIN || user.getRole().getValue().contains("PRESIDENT") || comment.getWriter().getId().equals(user.getId())) {
-            return true;
-        }
-        return board.getCircle() != null && user.getRole().getValue().contains("LEADER_CIRCLE")
-                && board.getCircle().getLeader().map(leader -> leader.getId().equals(user.getId())).orElse(false);
     }
 }

--- a/src/main/java/net/causw/application/dto/comment/CommentResponseDto.java
+++ b/src/main/java/net/causw/application/dto/comment/CommentResponseDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.comment;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -11,6 +12,7 @@ import java.util.List;
 @Getter
 @Setter
 @Builder
+@AllArgsConstructor
 public class CommentResponseDto {
     private String id;
     private String content;

--- a/src/main/java/net/causw/application/dto/comment/CommentResponseDto.java
+++ b/src/main/java/net/causw/application/dto/comment/CommentResponseDto.java
@@ -3,11 +3,11 @@ package net.causw.application.dto.comment;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import net.causw.domain.model.board.BoardDomainModel;
-import net.causw.domain.model.comment.CommentDomainModel;
+import net.causw.adapter.persistence.board.Board;
+import net.causw.adapter.persistence.comment.Comment;
+import net.causw.adapter.persistence.user.User;
 import net.causw.domain.model.enums.Role;
 import net.causw.domain.model.util.StaticValue;
-import net.causw.domain.model.user.UserDomainModel;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -31,38 +31,15 @@ public class CommentResponseDto {
     private List<ChildCommentResponseDto> childCommentList;
 
     public static CommentResponseDto of(
-            CommentDomainModel comment,
-            UserDomainModel user,
-            BoardDomainModel board,
+            Comment comment,
+            User user,
+            Board board,
             Long numChildComment,
             List<ChildCommentResponseDto> childCommentList
     ) {
-        boolean updatable = false;
-        boolean deletable = false;
-        String content = comment.getContent();
-
-        if (user.getRole() == Role.ADMIN || comment.getWriter().getId().equals(user.getId())) {
-            updatable = true;
-            deletable = true;
-        } else if (user.getRole().getValue().contains("PRESIDENT")) {
-            deletable = true;
-        } else {
-            if (board.getCircle().isPresent()) {
-                boolean isLeader = user.getRole().getValue().contains("LEADER_CIRCLE")
-                        && board.getCircle().get().getLeader()
-                        .map(leader -> leader.getId().equals(user.getId()))
-                        .orElse(false);
-                if (isLeader) {
-                    deletable = true;
-                }
-            }
-        }
-
-        if (comment.getIsDeleted()) {
-            updatable = false;
-            deletable = false;
-            content = StaticValue.CONTENT_DELETED_COMMENT;
-        }
+        String content = comment.getIsDeleted() ? StaticValue.CONTENT_DELETED_COMMENT : comment.getContent();
+        boolean updatable = determineUpdatable(comment, user);
+        boolean deletable = determineDeletable(comment, user, board);
 
         return CommentResponseDto.builder()
                 .id(comment.getId())
@@ -70,7 +47,7 @@ public class CommentResponseDto {
                 .createdAt(comment.getCreatedAt())
                 .updatedAt(comment.getUpdatedAt())
                 .isDeleted(comment.getIsDeleted())
-                .postId(comment.getPostId())
+                .postId(comment.getPost().getId())
                 .writerName(comment.getWriter().getName())
                 .writerAdmissionYear(comment.getWriter().getAdmissionYear())
                 .writerProfileImage(comment.getWriter().getProfileImage())
@@ -79,5 +56,19 @@ public class CommentResponseDto {
                 .numChildComment(numChildComment)
                 .childCommentList(childCommentList)
                 .build();
+    }
+
+    private static boolean determineUpdatable(Comment comment, User user) {
+        if (comment.getIsDeleted()) return false;
+        return user.getRole() == Role.ADMIN || comment.getWriter().getId().equals(user.getId());
+    }
+
+    private static boolean determineDeletable(Comment comment, User user, Board board) {
+        if (comment.getIsDeleted()) return false;
+        if (user.getRole() == Role.ADMIN || user.getRole().getValue().contains("PRESIDENT") || comment.getWriter().getId().equals(user.getId())) {
+            return true;
+        }
+        return board.getCircle() != null && user.getRole().getValue().contains("LEADER_CIRCLE")
+                && board.getCircle().getLeader().map(leader -> leader.getId().equals(user.getId())).orElse(false);
     }
 }

--- a/src/main/java/net/causw/application/dto/post/BoardPostsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/BoardPostsResponseDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.post;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -15,6 +16,7 @@ import java.util.List;
 @Getter
 @Setter
 @Builder
+@AllArgsConstructor
 public class BoardPostsResponseDto {
 
     @ApiModelProperty(value = "게시판 id", example = "uuid 형식의 String 값입니다.")
@@ -32,6 +34,7 @@ public class BoardPostsResponseDto {
     @ApiModelProperty(value = "게시글 정보입니다", example = "게시글 정보입니다")
     private Page<PostsResponseDto> post;
 
+    // FIXME: 리팩토링 후 삭제예정
     public static BoardPostsResponseDto of(
             Board board,
             Role userRole,

--- a/src/main/java/net/causw/application/dto/post/BoardPostsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/BoardPostsResponseDto.java
@@ -4,9 +4,13 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import net.causw.domain.model.board.BoardDomainModel;
+import net.causw.adapter.persistence.board.Board;
 import net.causw.domain.model.enums.Role;
 import org.springframework.data.domain.Page;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 @Getter
 @Setter
@@ -28,16 +32,17 @@ public class BoardPostsResponseDto {
     @ApiModelProperty(value = "게시글 정보입니다", example = "게시글 정보입니다")
     private Page<PostsResponseDto> post;
 
-    public static BoardPostsResponseDto from(
-            BoardDomainModel boardDomainModel,
+    public static BoardPostsResponseDto of(
+            Board board,
             Role userRole,
             Boolean isFavorite,
             Page<PostsResponseDto> post
     ) {
+        List<String> roles = new ArrayList<>(Arrays.asList(board.getCreateRoles().split(",")));
         return BoardPostsResponseDto.builder()
-                .boardId(boardDomainModel.getId())
-                .boardName(boardDomainModel.getName())
-                .writable(boardDomainModel.getCreateRoleList().stream().anyMatch(str -> userRole.getValue().contains(str)))
+                .boardId(board.getId())
+                .boardName(board.getName())
+                .writable(roles.stream().anyMatch(str -> userRole.getValue().contains(str)))
                 .isFavorite(isFavorite)
                 .post(post)
                 .build();

--- a/src/main/java/net/causw/application/dto/post/PostResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/PostResponseDto.java
@@ -4,12 +4,9 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import net.causw.adapter.persistence.board.Board;
 import net.causw.adapter.persistence.post.Post;
-import net.causw.adapter.persistence.user.User;
 import net.causw.application.dto.file.FileResponseDto;
 import net.causw.application.dto.comment.CommentResponseDto;
-import net.causw.domain.model.enums.Role;
 import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
@@ -68,12 +65,10 @@ public class PostResponseDto {
 
     public static PostResponseDto of(
             Post post,
-            User user
+            boolean updatable,
+            boolean deletable
     ) {
-        boolean updatable = determineUpdatable(post, user);
-        boolean deletable = determineDeletable(post, user, post.getBoard());
         List<String> attachmentList = post.getAttachments().map(attachments -> Arrays.asList(attachments.split(":::"))).orElse(List.of());
-
         return PostResponseDto.builder()
                 .id(post.getId())
                 .title(post.getTitle())
@@ -93,12 +88,11 @@ public class PostResponseDto {
 
     public static PostResponseDto of(
             Post post,
-            User user,
             Page<CommentResponseDto> commentList,
-            Long numComment
+            Long numComment,
+            boolean updatable,
+            boolean deletable
     ) {
-        boolean updatable = determineUpdatable(post, user);
-        boolean deletable = determineDeletable(post, user, post.getBoard());
         List<String> attachmentList = post.getAttachments().map(attachments -> Arrays.asList(attachments.split(":::"))).orElse(List.of());
 
         return PostResponseDto.builder()
@@ -118,20 +112,5 @@ public class PostResponseDto {
                 .commentList(commentList)
                 .boardName(post.getBoard().getName())
                 .build();
-    }
-
-    // FIXME: 일종의 비즈니스 및 유효성 검사 로직이 Dto에 존재하는 상황은 바람직하지 않음. 수정 필요
-    private static boolean determineUpdatable(Post post, User user) {
-        if (post.getIsDeleted()) return false;
-        return user.getRole() == Role.ADMIN || post.getWriter().getId().equals(user.getId());
-    }
-
-    private static boolean determineDeletable(Post post, User user, Board board) {
-        if (post.getIsDeleted()) return false;
-        if (user.getRole() == Role.ADMIN || user.getRole().getValue().contains("PRESIDENT") || post.getWriter().getId().equals(user.getId())) {
-            return true;
-        }
-        return board.getCircle() != null && user.getRole().getValue().contains("LEADER_CIRCLE")
-                && board.getCircle().getLeader().map(leader -> leader.getId().equals(user.getId())).orElse(false);
     }
 }

--- a/src/main/java/net/causw/application/dto/post/PostResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/PostResponseDto.java
@@ -64,6 +64,7 @@ public class PostResponseDto {
     @ApiModelProperty(value = "게시판 이름", example =  "게시판 이름입니다.")
     private String boardName;
 
+    // FIXME: 리팩토링 후 삭제예정
     // 생성, 삭제
     public static PostResponseDto of(
             Post post,

--- a/src/main/java/net/causw/application/dto/post/PostResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/PostResponseDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.post;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -10,13 +11,12 @@ import net.causw.application.dto.comment.CommentResponseDto;
 import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @Setter
 @Builder
+@AllArgsConstructor
 public class PostResponseDto {
     @ApiModelProperty(value = "게시글 id", example = "uuid 형식의 String 값입니다.")
     private String id;
@@ -43,7 +43,8 @@ public class PostResponseDto {
     private List<FileResponseDto> attachmentList;
 
     @ApiModelProperty(value = "답글 개수", example = "13")
-    private Long numComment;
+    @Builder.Default // 기본값 0
+    private Long numComment = 0L;
 
     @ApiModelProperty(value = "게시글 업데이트 가능여부", example = "true")
     private Boolean updatable;
@@ -63,12 +64,13 @@ public class PostResponseDto {
     @ApiModelProperty(value = "게시판 이름", example =  "게시판 이름입니다.")
     private String boardName;
 
+    // 생성, 삭제
     public static PostResponseDto of(
             Post post,
             boolean updatable,
             boolean deletable
     ) {
-        List<String> attachmentList = post.getAttachments().map(attachments -> Arrays.asList(attachments.split(":::"))).orElse(List.of());
+        //List<String> attachmentList = post.getAttachments().map(attachments -> Arrays.asList(attachments.split(":::"))).orElse(List.of());
         return PostResponseDto.builder()
                 .id(post.getId())
                 .title(post.getTitle())
@@ -77,7 +79,7 @@ public class PostResponseDto {
                 .writerName(post.getWriter().getName())
                 .writerAdmissionYear(post.getWriter().getAdmissionYear())
                 .writerProfileImage(post.getWriter().getProfileImage())
-                .attachmentList(attachmentList.stream().map(FileResponseDto::from).collect(Collectors.toList()))
+                //.attachmentList(attachmentList.stream().map(FileResponseDto::from).collect(Collectors.toList()))
                 .numComment(0L)
                 .updatable(updatable)
                 .deletable(deletable)
@@ -86,6 +88,7 @@ public class PostResponseDto {
                 .build();
     }
 
+    // 조회, 수정, 복원
     public static PostResponseDto of(
             Post post,
             Page<CommentResponseDto> commentList,
@@ -93,8 +96,7 @@ public class PostResponseDto {
             boolean updatable,
             boolean deletable
     ) {
-        List<String> attachmentList = post.getAttachments().map(attachments -> Arrays.asList(attachments.split(":::"))).orElse(List.of());
-
+        //List<String> attachmentList = post.getAttachments().map(attachments -> Arrays.asList(attachments.split(":::"))).orElse(List.of());
         return PostResponseDto.builder()
                 .id(post.getId())
                 .title(post.getTitle())
@@ -103,7 +105,7 @@ public class PostResponseDto {
                 .writerName(post.getWriter().getName())
                 .writerAdmissionYear(post.getWriter().getAdmissionYear())
                 .writerProfileImage(post.getWriter().getProfileImage())
-                .attachmentList(attachmentList.stream().map(FileResponseDto::from).collect(Collectors.toList()))
+                //.attachmentList(attachmentList.stream().map(FileResponseDto::from).collect(Collectors.toList()))
                 .numComment(numComment)
                 .updatable(updatable)
                 .deletable(deletable)

--- a/src/main/java/net/causw/application/dto/post/PostsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/PostsResponseDto.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import net.causw.adapter.persistence.post.Post;
 import net.causw.domain.model.post.PostDomainModel;
 
 import java.time.LocalDateTime;
@@ -36,8 +37,25 @@ public class PostsResponseDto {
     @ApiModelProperty(value = "게시글 삭제여부", example = "false")
     private Boolean isDeleted;
 
+    // FIXME: Domain model 사용하는 생성메서드 삭제 필요 (컴파일 에러 방지 목적으로 일단 대기)
     public static PostsResponseDto of(
             PostDomainModel post,
+            Long numComment
+    ) {
+        return PostsResponseDto.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .writerName(post.getWriter().getName())
+                .writerAdmissionYear(post.getWriter().getAdmissionYear())
+                .numComment(numComment)
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .isDeleted(post.getIsDeleted())
+                .build();
+    }
+
+    public static PostsResponseDto of(
+            Post post,
             Long numComment
     ) {
         return PostsResponseDto.builder()

--- a/src/main/java/net/causw/application/dto/post/PostsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/PostsResponseDto.java
@@ -39,7 +39,7 @@ public class PostsResponseDto {
     @ApiModelProperty(value = "게시글 삭제여부", example = "false")
     private Boolean isDeleted;
 
-    // FIXME: Domain model 사용하는 생성메서드 삭제 필요 (컴파일 에러 방지 목적으로 일단 대기)
+    // FIXME: 리팩토링 후 삭제예정
     public static PostsResponseDto of(
             PostDomainModel post,
             Long numComment

--- a/src/main/java/net/causw/application/dto/post/PostsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/PostsResponseDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.post;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @Builder
+@AllArgsConstructor
 public class PostsResponseDto {
     @ApiModelProperty(value = "게시글 id", example = "uuid 형식의 String 값입니다.")
     private String id;

--- a/src/main/java/net/causw/application/dto/util/DtoMapper.java
+++ b/src/main/java/net/causw/application/dto/util/DtoMapper.java
@@ -1,0 +1,81 @@
+package net.causw.application.dto.util;
+
+import net.causw.adapter.persistence.board.Board;
+import net.causw.adapter.persistence.comment.ChildComment;
+import net.causw.adapter.persistence.comment.Comment;
+import net.causw.adapter.persistence.post.Post;
+import net.causw.application.dto.comment.ChildCommentResponseDto;
+import net.causw.application.dto.comment.CommentResponseDto;
+import net.causw.application.dto.file.FileResponseDto;
+import net.causw.application.dto.post.BoardPostsResponseDto;
+import net.causw.application.dto.post.PostResponseDto;
+import net.causw.application.dto.post.PostsResponseDto;
+import net.causw.domain.model.enums.Role;
+import org.mapstruct.*;
+import org.mapstruct.factory.Mappers;
+import org.springframework.data.domain.Page;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+// Custom Annotation을 사용하여 중복되는 @Mapping을 줄일 수 있습니다.
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD})
+@Mapping(target = "writerName", source = "entity.writer.name")
+@Mapping(target = "writerAdmissionYear", source = "entity.writer.admissionYear")
+@Mapping(target = "writerProfileImage", source = "entity.writer.profileImage")
+@interface CommonWriterMappings {}
+
+@Mapper(componentModel = "spring")
+public interface DtoMapper{
+
+    DtoMapper INSTANCE = Mappers.getMapper(DtoMapper.class);
+
+    // 자료형 변환 등이 필요하다면 아래 형식으로 메서드를 작성합니다.
+    // 이 메서드는 post.attachment를 attachmentsToStringList 메서드로 List<FileResponseDto>로 변환합니다.
+    // 메서드 수가 많아지면 별도의 Converter 클래스를 만들어 상속받는 식으로 처리해도 좋습니다.
+    @Named("attachmentsToStringList")
+    default List<FileResponseDto> attachmentsToStringList(String attachments) {
+        if(attachments == null || attachments.isEmpty()) return List.of();
+        return Arrays.stream(attachments.split(":::"))
+                .map(FileResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    // Dto writerName 필드에 post.writer.name을 삽입한다는 의미입니다.
+    @Mapping(target = "writerName", source = "entity.writer.name")
+    @Mapping(target = "writerAdmissionYear", source = "entity.writer.admissionYear")
+    PostsResponseDto toPostsResponseDto(Post entity, Long numComment);
+
+    @CommonWriterMappings
+    @Mapping(target = "boardName", source = "entity.board.name")
+    @Mapping(target = "attachmentList", source = "entity.attachments", qualifiedByName = "attachmentsToStringList")
+    PostResponseDto toPostResponseDto(Post entity, Boolean updatable, Boolean deletable);
+
+    @CommonWriterMappings
+    @Mapping(target = "boardName", source = "entity.board.name")
+    @Mapping(target = "attachmentList", source = "entity.attachments", qualifiedByName = "attachmentsToStringList")
+    @Mapping(target = "content", source = "entity.content")
+    PostResponseDto toPostResponseDtoExtended(Post entity, Page<CommentResponseDto> commentList, Long numComment, Boolean updatable, Boolean deletable);
+
+    @CommonWriterMappings
+    @Mapping(target = "postId", source = "entity.post.id")
+    CommentResponseDto toCommentResponseDto(Comment entity, Long numChildComment, List<ChildCommentResponseDto> childCommentList, Boolean updatable, Boolean deletable);
+
+    @CommonWriterMappings
+    ChildCommentResponseDto toChildCommentResponseDto(ChildComment entity, Boolean updatable, Boolean deletable);
+
+    @Mapping(target = "boardId", source = "entity.id")
+    @Mapping(target = "boardName", source = "entity.name")
+    BoardPostsResponseDto toBoardPostsResponseDto(Board entity, Role userRole, Boolean writable, Boolean isFavorite, Page<PostsResponseDto> post);
+
+    // TODO: 각자 역할분담한 부분의 Dto 채우기
+
+
+
+}

--- a/src/main/java/net/causw/application/dto/util/DtoMapper.java
+++ b/src/main/java/net/causw/application/dto/util/DtoMapper.java
@@ -74,8 +74,21 @@ public interface DtoMapper{
     @Mapping(target = "boardName", source = "entity.name")
     BoardPostsResponseDto toBoardPostsResponseDto(Board entity, Role userRole, Boolean writable, Boolean isFavorite, Page<PostsResponseDto> post);
 
-    // TODO: 각자 역할분담한 부분의 Dto 채우기
+    /** TODO: 각자 역할분담한 부분의 Dto를 위를 참고하여 아래 작성하시면 됩니다.
+     *  기존에 Dto에 존재하던 of 메서드를 DtoMapper.INSTANCE.toDtoName(entity)로 대체하시면 됩니다.
+     *  컴파일 후 DtoMapperImpl 파일을 확인하여 필드별로 제대로 매핑이 되었는지 확인해야 합니다.
+     */
 
+    // User
+
+
+    // Board
+
+
+    // Circle
+
+
+    // Locker
 
 
 }

--- a/src/main/java/net/causw/application/dto/util/StatusUtil.java
+++ b/src/main/java/net/causw/application/dto/util/StatusUtil.java
@@ -1,0 +1,56 @@
+package net.causw.application.dto.util;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import net.causw.adapter.persistence.board.Board;
+import net.causw.adapter.persistence.comment.ChildComment;
+import net.causw.adapter.persistence.comment.Comment;
+import net.causw.adapter.persistence.post.Post;
+import net.causw.adapter.persistence.user.User;
+import net.causw.domain.model.enums.Role;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class StatusUtil {
+
+    public static boolean isUpdatable(Comment comment, User user) {
+        if (comment.getIsDeleted()) return false;
+        return user.getRole() == Role.ADMIN || comment.getWriter().getId().equals(user.getId());
+    }
+
+    public static boolean isDeletable(Comment comment, User user, Board board) {
+        if (comment.getIsDeleted()) return false;
+        if (user.getRole() == Role.ADMIN || user.getRole().getValue().contains("PRESIDENT") || comment.getWriter().getId().equals(user.getId())) {
+            return true;
+        }
+        return board.getCircle() != null && user.getRole().getValue().contains("LEADER_CIRCLE")
+                && board.getCircle().getLeader().map(leader -> leader.getId().equals(user.getId())).orElse(false);
+    }
+
+    public static boolean isUpdatable(ChildComment comment, User user) {
+        if (comment.getIsDeleted()) return false;
+        return user.getRole() == Role.ADMIN || comment.getWriter().getId().equals(user.getId());
+    }
+
+    public static boolean isDeletable(ChildComment comment, User user, Board board) {
+        if (comment.getIsDeleted()) return false;
+        if (user.getRole() == Role.ADMIN || user.getRole().getValue().contains("PRESIDENT") || comment.getWriter().getId().equals(user.getId())) {
+            return true;
+        }
+        return board.getCircle() != null && user.getRole().getValue().contains("LEADER_CIRCLE")
+                && board.getCircle().getLeader().map(leader -> leader.getId().equals(user.getId())).orElse(false);
+    }
+
+    public static boolean isUpdatable(Post post, User user) {
+        if (post.getIsDeleted()) return false;
+        return user.getRole() == Role.ADMIN || post.getWriter().getId().equals(user.getId());
+    }
+
+    public static boolean isDeletable(Post post, User user, Board board) {
+        if (post.getIsDeleted()) return false;
+        if (user.getRole() == Role.ADMIN || user.getRole().getValue().contains("PRESIDENT") || post.getWriter().getId().equals(user.getId())) {
+            return true;
+        }
+        return board.getCircle() != null && user.getRole().getValue().contains("LEADER_CIRCLE")
+                && board.getCircle().getLeader().map(leader -> leader.getId().equals(user.getId())).orElse(false);
+    }
+}

--- a/src/main/java/net/causw/application/homepage/HomePageService.java
+++ b/src/main/java/net/causw/application/homepage/HomePageService.java
@@ -9,7 +9,7 @@ import net.causw.adapter.persistence.repository.UserRepository;
 import net.causw.adapter.persistence.user.User;
 import net.causw.application.dto.homepage.HomePageResponseDto;
 import net.causw.application.dto.board.BoardResponseDto;
-import net.causw.application.dto.post.PostsResponseDto;
+import net.causw.application.dto.util.DtoMapper;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.model.util.MessageUtil;
@@ -55,7 +55,7 @@ public class HomePageService {
                 .map(board -> HomePageResponseDto.of(
                         BoardResponseDto.of(board, user.getRole()),
                         postRepository.findAllByBoard_IdAndIsDeletedIsFalseOrderByCreatedAtDesc(board.getId(), pageableFactory.create(0, StaticValue.HOME_POST_PAGE_SIZE))
-                                .map(post -> PostsResponseDto.of(
+                                .map(post -> DtoMapper.INSTANCE.toPostsResponseDto(
                                         post,
                                         postRepository.countAllCommentByPost_Id(post.getId())
                                 )))

--- a/src/main/java/net/causw/application/homepage/HomePageService.java
+++ b/src/main/java/net/causw/application/homepage/HomePageService.java
@@ -1,20 +1,19 @@
 package net.causw.application.homepage;
 
 import lombok.RequiredArgsConstructor;
+import net.causw.adapter.persistence.board.Board;
+import net.causw.adapter.persistence.page.PageableFactory;
+import net.causw.adapter.persistence.repository.BoardRepository;
+import net.causw.adapter.persistence.repository.PostRepository;
+import net.causw.adapter.persistence.repository.UserRepository;
+import net.causw.adapter.persistence.user.User;
 import net.causw.application.dto.homepage.HomePageResponseDto;
 import net.causw.application.dto.board.BoardResponseDto;
 import net.causw.application.dto.post.PostsResponseDto;
-import net.causw.application.spi.BoardPort;
-import net.causw.application.spi.CommentPort;
-import net.causw.application.spi.FavoriteBoardPort;
-import net.causw.application.spi.PostPort;
-import net.causw.application.spi.UserPort;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
-import net.causw.domain.model.board.BoardDomainModel;
 import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
-import net.causw.domain.model.user.UserDomainModel;
 import net.causw.domain.validation.UserRoleIsNoneValidator;
 import net.causw.domain.validation.UserStateValidator;
 import net.causw.domain.validation.ValidatorBucket;
@@ -26,45 +25,40 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class HomePageService {
-    private final FavoriteBoardPort favoriteBoardPort;
-    private final UserPort userPort;
-    private final BoardPort boardPort;
-    private final PostPort postPort;
-    private final CommentPort commentPort;
+
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final BoardRepository boardRepository;
+    private final PageableFactory pageableFactory;
 
     public List<HomePageResponseDto> getHomePage(String userId) {
-        UserDomainModel userDomainModel = this.userPort.findById(userId).orElseThrow(
-                () -> new BadRequestException(
+        User user = this.userRepository.findById(userId)
+                .orElseThrow(() -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.LOGIN_USER_NOT_FOUND
-                )
-        );
+                        MessageUtil.USER_NOT_FOUND));
 
         ValidatorBucket.of()
-                .consistOf(UserStateValidator.of(userDomainModel.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(userDomainModel.getRole()))
+                .consistOf(UserStateValidator.of(user.getState()))
+                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
                 .validate();
 
-
-        List<BoardDomainModel> boardDomainModelList = this.boardPort.findAllBoard(false);
-        if(boardDomainModelList.isEmpty()){
+        List<Board> boards = boardRepository.findByCircle_IdIsNullAndIsDeletedOrderByCreatedAtAsc(false);
+        if (boards.isEmpty()) {
             throw new BadRequestException(
                     ErrorCode.ROW_DOES_NOT_EXIST,
                     MessageUtil.BOARD_NOT_FOUND
             );
         }
-        return boardDomainModelList
+
+        return boards
                 .stream()
-                .map(boardDomainModel -> HomePageResponseDto.of(
-                        BoardResponseDto.from(boardDomainModel, userDomainModel.getRole()),
-                        this.postPort.findAllPost(
-                                boardDomainModel.getId(),
-                                0,
-                                StaticValue.HOME_POST_PAGE_SIZE
-                        ).map(postDomainModel -> PostsResponseDto.of(
-                                postDomainModel,
-                                this.postPort.countAllComment(postDomainModel.getId())
-                        )))
+                .map(board -> HomePageResponseDto.of(
+                        BoardResponseDto.of(board, user.getRole()),
+                        postRepository.findAllByBoard_IdAndIsDeletedIsFalseOrderByCreatedAtDesc(board.getId(), pageableFactory.create(0, StaticValue.HOME_POST_PAGE_SIZE))
+                                .map(post -> PostsResponseDto.of(
+                                        post,
+                                        postRepository.countAllCommentByPost_Id(post.getId())
+                                )))
                 )
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
### 🚩 관련사항
#545 
직전 PR에 대한 충돌 이슈 해결 후 다시 올리는 PR입니다.

### 📢 전달사항
* Service는 Port, DomainModel에 의존하지 않고 Repository와 직결되어야 합니다.
* Service 메서드는 아래와 같은 구조를 가지게 됩니다.
  * 1. 필요한 Entity를 조회
  * 2. 조회한 Entity에 대한 Validation
  * 3. 추가 비즈니스 로직(수정, 삭제 등)
  * 4. Dto로 반환
* MapStruct 라이브러리를 통해 Dto의 생성 과정을 from/of 없이 컴파일 타임에 자동화합니다. 
<img width="929" alt="image" src="https://github.com/CAUCSE/CAUSW_backend/assets/53044069/d9062bbf-71a9-4685-841a-64c93a62778a">
* 실제 Dto를 생성하는 코드는 build/classes/java/main/net/causw/application/dto/util에서 확인하실 수 있습니다.
<img width="917" alt="image" src="https://github.com/CAUCSE/CAUSW_backend/assets/53044069/19dd08ce-5f21-47bf-83bf-c4fa322e88d8">
<img width="808" alt="image" src="https://github.com/CAUCSE/CAUSW_backend/assets/53044069/8e5378c0-75c4-45d2-ad32-8bbf67fdb36b">

특이사항으로는, DtoMapper를 수정한 직후 첫 컴파일된 Impl의 경우엔 getter로 필드에 접근하고, 그 이후부턴 빌더패턴으로 접근하고 있는 것으로 확인했습니다.

### 📸 스크린샷
[코딩 컨벤션과 함께 예시 코드를 참고해주세요.](https://www.notion.so/dustbox-j/2024-78104a49bb394387ae19c191cac7455c?pvs=4)

### 📃 진행사항
- [x] Comment 구조 개편
- [x] ChildComment 구조 개편
- [x] Post 구조 개편
- [x] HomePageService 및 일부 Board Dto 개편
- [x] 노션에 코딩 컨벤션 작성
- [x] 일부 Dto 내에서 updatable/deletable 여부 감별하는 로직 제거하고 StatusUtil에서 관리
- [x] MapStruct 적용하여 생성 자동화
- [ ] 코드리뷰 및 개선점 반영

### ⚙️ 기타사항
* Dto에 수정/삭제 가능 여부를 판정하던 비즈니스 로직을 StatusUtil에서 관리하도록 수정했습니다. (일반적으로 비즈니스 로직은 Dto 내부에 배치하지 않아야 합니다.)
* Dto에 존재하는 from, of 메서드는 더 이상 사용되지 않고, 모든 Dto 생성은 DtoMapper가 통제하게 됩니다. (다만 리팩토링 완료 전까지는 아직 PortImpl 등과의 의존성이 남아있는 것을 감안하여 삭제하지는 않았습니다.)
* DtoMapper가 Dto 필드에 접근하기 위해 AllArgsConstructor가 요구됩니다.
* Service에 DtoMapper를 사용하는 로직이 반복된다면 별도의 private toDto() 메서드로 분리하고 중복을 제거하는 것을 권장드립니다.
* 추가적으로 DtoMapper에 대해 알고 싶으시면 이 [링크](https://medium.com/naver-cloud-platform/%EA%B8%B0%EC%88%A0-%EC%BB%A8%ED%85%90%EC%B8%A0-%EB%AC%B8%EC%9E%90-%EC%95%8C%EB%A6%BC-%EB%B0%9C%EC%86%A1-%EC%84%9C%EB%B9%84%EC%8A%A4-sens%EC%9D%98-mapstruct-%EC%A0%81%EC%9A%A9%EA%B8%B0-8fd2bc2bc33b)를 참고하시면 됩니다.
* 일부 Entity와 Dto 간 필드 타입이 달라서 PortImpl, DomainModelMapper 등에 컴파일에러가 발생했습니다. 의미 없는 부분으로 대체해두고, 추후 완전 삭제할 예정입니다.
* Entity의 최초 생성 전략은 of 메서드로 통일하며, 이때 매개변수엔 id나 컬렉션이 필요없습니다.

개발기간: 1주