### PR TITLE
refactor : BoardService port 제거 및 구조 재정비

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/board/Board.java
+++ b/src/main/java/net/causw/adapter/persistence/board/Board.java
@@ -5,6 +5,7 @@ import net.causw.adapter.persistence.circle.Circle;
 import net.causw.adapter.persistence.post.Post;
 import net.causw.adapter.persistence.base.BaseEntity;
 import net.causw.domain.model.board.BoardDomainModel;
+import net.causw.domain.model.enums.Role;
 import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.CascadeType;
@@ -14,8 +15,11 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Getter
 @Entity
@@ -81,12 +85,33 @@ public class Board extends BaseEntity {
     public static Board of(
             String name,
             String description,
-            String createRoles,
+            List<String> createRoleList,
             String category,
-            Boolean isDeleted,
             Circle circle
     ) {
-        return new Board(name, description, createRoles, category, isDeleted, circle, new HashSet<>());
+        if (createRoleList != null) {
+            if (createRoleList.isEmpty()) {
+                createRoleList.add(Role.ADMIN.getValue());
+                createRoleList.add(Role.PRESIDENT.getValue());
+            } else if (createRoleList.contains("ALL")) {
+                createRoleList.addAll(
+                        Arrays.stream(Role.values())
+                                .map(Role::getValue)
+                                .collect(Collectors.toList())
+                );
+                createRoleList.remove(Role.NONE.getValue());
+                createRoleList.remove("ALL");
+            } else {
+                createRoleList = createRoleList
+                        .stream()
+                        .map(Role::of)
+                        .map(Role::getValue)
+                        .collect(Collectors.toList());
+                createRoleList.add(Role.ADMIN.getValue());
+                createRoleList.add(Role.PRESIDENT.getValue());
+            }
+        }
+        return new Board(name, description, String.join(",", createRoleList), category, false, circle, new HashSet<>());
     }
 
     public void setIsDeleted(boolean isDeleted){

--- a/src/main/java/net/causw/adapter/persistence/board/Board.java
+++ b/src/main/java/net/causw/adapter/persistence/board/Board.java
@@ -14,11 +14,13 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import java.util.HashSet;
 import java.util.Set;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "tb_board")
 public class Board extends BaseEntity {
     @Column(name = "name", nullable = false)
@@ -74,6 +76,17 @@ public class Board extends BaseEntity {
                 boardDomainModel.getIsDeleted(),
                 circle
         );
+    }
+
+    public static Board of(
+            String name,
+            String description,
+            String createRoles,
+            String category,
+            Boolean isDeleted,
+            Circle circle
+    ) {
+        return new Board(name, description, createRoles, category, isDeleted, circle, new HashSet<>());
     }
 
     public void setIsDeleted(boolean isDeleted){

--- a/src/main/java/net/causw/adapter/persistence/board/FavoriteBoard.java
+++ b/src/main/java/net/causw/adapter/persistence/board/FavoriteBoard.java
@@ -1,6 +1,7 @@
 package net.causw.adapter.persistence.board;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.causw.adapter.persistence.user.User;
@@ -15,6 +16,7 @@ import javax.persistence.Table;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "TB_FAVORITE_BOARD")
 public class FavoriteBoard extends BaseEntity {
     @OneToOne
@@ -41,5 +43,12 @@ public class FavoriteBoard extends BaseEntity {
                 User.from(favoriteBoardDomainModel.getUserDomainModel()),
                 Board.from(favoriteBoardDomainModel.getBoardDomainModel())
         );
+    }
+
+    public static FavoriteBoard of(
+            User user,
+            Board board
+    ) {
+        return new FavoriteBoard(user, board);
     }
 }

--- a/src/main/java/net/causw/application/board/BoardService.java
+++ b/src/main/java/net/causw/application/board/BoardService.java
@@ -134,9 +134,8 @@ public class BoardService {
         Board board = Board.of(
                 boardCreateRequestDto.getName(),
                 boardCreateRequestDto.getDescription(),
-                String.join(",", boardCreateRequestDto.getCreateRoleList()),
+                boardCreateRequestDto.getCreateRoleList(),
                 boardCreateRequestDto.getCategory(),
-                false,
                 circle
         );
 

--- a/src/main/java/net/causw/application/board/BoardService.java
+++ b/src/main/java/net/causw/application/board/BoardService.java
@@ -1,23 +1,25 @@
 package net.causw.application.board;
 
 import lombok.RequiredArgsConstructor;
+import net.causw.adapter.persistence.board.Board;
+import net.causw.adapter.persistence.circle.Circle;
+import net.causw.adapter.persistence.circle.CircleMember;
+import net.causw.adapter.persistence.repository.BoardRepository;
+import net.causw.adapter.persistence.repository.CircleMemberRepository;
+import net.causw.adapter.persistence.repository.CircleRepository;
+import net.causw.adapter.persistence.repository.UserRepository;
+import net.causw.adapter.persistence.user.User;
 import net.causw.application.dto.board.BoardCreateRequestDto;
 import net.causw.application.dto.board.BoardResponseDto;
 import net.causw.application.dto.board.BoardUpdateRequestDto;
-import net.causw.application.spi.BoardPort;
-import net.causw.application.spi.CircleMemberPort;
-import net.causw.application.spi.CirclePort;
-import net.causw.application.spi.UserPort;
+import net.causw.application.dto.util.DtoMapper;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
-import net.causw.domain.exceptions.InternalServerException;
 import net.causw.domain.exceptions.UnauthorizedException;
-import net.causw.domain.model.board.BoardDomainModel;
-import net.causw.domain.model.circle.CircleDomainModel;
+import net.causw.domain.model.enums.CircleMemberStatus;
 import net.causw.domain.model.enums.Role;
 import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
-import net.causw.domain.model.user.UserDomainModel;
 import net.causw.domain.validation.ConstraintValidator;
 import net.causw.domain.validation.TargetIsDeletedValidator;
 import net.causw.domain.validation.UserEqualValidator;
@@ -30,90 +32,85 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.validation.Validator;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
 public class BoardService {
-    private final BoardPort boardPort;
-    private final UserPort userPort;
-    private final CirclePort circlePort;
-    private final CircleMemberPort circleMemberPort;
+    private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
+    private final CircleRepository circleRepository;
+    private final CircleMemberRepository circleMemberRepository;
     private final Validator validator;
 
     @Transactional(readOnly = true)
-    public List<BoardResponseDto> findAllBoard(String loginUserId) {
-        UserDomainModel userDomainModel = this.userPort.findById(loginUserId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.LOGIN_USER_NOT_FOUND
-                )
-        );
+    public List<BoardResponseDto> findAllBoard(
+            String loginUserId
+    ) {
+        User user = getUser(loginUserId);
 
         ValidatorBucket.of()
-                .consistOf(UserStateValidator.of(userDomainModel.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(userDomainModel.getRole()))
+                .consistOf(UserStateValidator.of(user.getState()))
+                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
                 .validate();
 
-        if (userDomainModel.getRole().equals(Role.ADMIN) || userDomainModel.getRole().getValue().contains("PRESIDENT")) {
-            return this.boardPort.findAllBoard()
-                    .stream()
-                    .map(boardDomainModel -> BoardResponseDto.from(boardDomainModel, userDomainModel.getRole()))
+        if (user.getRole().equals(Role.ADMIN) || user.getRole().getValue().contains("PRESIDENT")) {
+            return boardRepository.findByOrderByCreatedAtAsc().stream()
+                    .map(board -> toBoardResponseDto(board, user.getRole()))
                     .collect(Collectors.toList());
         } else {
-            List<CircleDomainModel> joinCircles = this.circleMemberPort.getCircleListByUserId(loginUserId);
+            List<Circle> joinCircles = circleMemberRepository.findByUser_Id(user.getId()).stream()
+                    .filter(circleMember -> circleMember.getStatus() == CircleMemberStatus.MEMBER)
+                    .map(CircleMember::getCircle)
+                    .collect(Collectors.toList());
             if (joinCircles.isEmpty()) {
-                return this.boardPort.findAllBoard(false)
-                        .stream()
-                        .map(boardDomainModel -> BoardResponseDto.from(boardDomainModel, userDomainModel.getRole()))
+                return boardRepository.findByCircle_IdIsNullAndIsDeletedOrderByCreatedAtAsc(false).stream()
+                        .map(board -> toBoardResponseDto(board, user.getRole()))
                         .collect(Collectors.toList());
             } else {
                 List<String> circleIdList = joinCircles.stream()
-                        .map(CircleDomainModel::getId)
+                        .map(Circle::getId)
                         .collect(Collectors.toList());
 
-                return this.boardPort.findAllBoard(circleIdList)
-                        .stream()
-                        .map(boardDomainModel -> BoardResponseDto.from(boardDomainModel, userDomainModel.getRole()))
+                return Stream.concat(
+                                this.boardRepository.findByCircle_IdIsNullAndIsDeletedOrderByCreatedAtAsc(false).stream(),
+                                this.boardRepository.findByCircle_IdInAndIsDeletedFalseOrderByCreatedAtAsc(circleIdList).stream())
+                        .map(board -> toBoardResponseDto(board, user.getRole()))
                         .collect(Collectors.toList());
             }
         }
     }
 
     @Transactional
-    public BoardResponseDto createBoard(String loginUserId, BoardCreateRequestDto boardCreateRequestDto) {
+    public BoardResponseDto createBoard(
+            String loginUserId,
+            BoardCreateRequestDto boardCreateRequestDto
+    ) {
+        User creator = getUser(loginUserId);
+
         ValidatorBucket validatorBucket = ValidatorBucket.of();
-
-        UserDomainModel creatorDomainModel = this.userPort.findById(loginUserId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.LOGIN_USER_NOT_FOUND
-                )
-        );
-
         validatorBucket
-                .consistOf(UserStateValidator.of(creatorDomainModel.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(creatorDomainModel.getRole()));
+                .consistOf(UserStateValidator.of(creator.getState()))
+                .consistOf(UserRoleIsNoneValidator.of(creator.getRole()));
 
-        CircleDomainModel circleDomainModel = boardCreateRequestDto.getCircleId().map(
+        Circle circle = boardCreateRequestDto.getCircleId().map(
                 circleId -> {
-                    CircleDomainModel circle = this.circlePort.findById(circleId).orElseThrow(
-                            () -> new BadRequestException(
-                                    ErrorCode.ROW_DOES_NOT_EXIST,
-                                    MessageUtil.SMALL_CLUB_NOT_FOUND
-                            )
-                    );
+                    Circle newCircle = getCircle(circleId);
 
                     validatorBucket
-                            .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
-                            .consistOf(UserRoleValidator.of(creatorDomainModel.getRole(),
+                            .consistOf(TargetIsDeletedValidator.of(newCircle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
+                            .consistOf(UserRoleValidator.of(creator.getRole(),
                                     List.of(Role.LEADER_CIRCLE)));
 
-                    if (creatorDomainModel.getRole().getValue().contains("LEADER_CIRCLE") && !creatorDomainModel.getRole().getValue().contains("PRESIDENT")) {
+                    if (creator.getRole().getValue().contains("LEADER_CIRCLE") && !creator.getRole().getValue().contains("PRESIDENT")) {
                         validatorBucket
                                 .consistOf(UserEqualValidator.of(
-                                        circle.getLeader().map(UserDomainModel::getId).orElseThrow(
+                                        newCircle.getLeader().map(User::getId).orElseThrow(
                                                 () -> new UnauthorizedException(
                                                         ErrorCode.API_NOT_ALLOWED,
                                                         MessageUtil.NOT_CIRCLE_LEADER
@@ -123,30 +120,31 @@ public class BoardService {
                                 ));
                     }
 
-                    return circle;
+                    return newCircle;
                 }
         ).orElseGet(
                 () -> {
                     validatorBucket
-                            .consistOf(UserRoleValidator.of(creatorDomainModel.getRole(), List.of()));
+                            .consistOf(UserRoleValidator.of(creator.getRole(), List.of()));
 
                     return null;
                 }
         );
 
-        BoardDomainModel boardDomainModel = BoardDomainModel.of(
+        Board board = Board.of(
                 boardCreateRequestDto.getName(),
                 boardCreateRequestDto.getDescription(),
-                boardCreateRequestDto.getCreateRoleList(),
+                String.join(",", boardCreateRequestDto.getCreateRoleList()),
                 boardCreateRequestDto.getCategory(),
-                circleDomainModel
+                false,
+                circle
         );
 
         validatorBucket
-                .consistOf(ConstraintValidator.of(boardDomainModel, this.validator))
+                .consistOf(ConstraintValidator.of(board, this.validator))
                 .validate();
 
-        return BoardResponseDto.from(this.boardPort.createBoard(boardDomainModel), creatorDomainModel.getRole());
+        return toBoardResponseDto(boardRepository.save(board), creator.getRole());
     }
 
     @Transactional
@@ -155,71 +153,23 @@ public class BoardService {
             String boardId,
             BoardUpdateRequestDto boardUpdateRequestDto
     ) {
-        ValidatorBucket validatorBucket = ValidatorBucket.of();
+        User updater = getUser(loginUserId);
+        Board board = getBoard(boardId);
 
-        UserDomainModel updaterDomainModel = this.userPort.findById(loginUserId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.LOGIN_USER_NOT_FOUND
-                )
-        );
+        ValidatorBucket validatorBucket = initializeValidatorBucket(updater, board);
 
-        BoardDomainModel boardDomainModel = this.boardPort.findById(boardId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.BOARD_NOT_FOUND
-                )
-        );
-
-        validatorBucket
-                .consistOf(UserStateValidator.of(updaterDomainModel.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(updaterDomainModel.getRole()))
-                .consistOf(TargetIsDeletedValidator.of(boardDomainModel.getIsDeleted(), StaticValue.DOMAIN_BOARD));
-
-        boardDomainModel.getCircle().ifPresentOrElse(
-                circleDomainModel -> {
-                    validatorBucket
-                            .consistOf(TargetIsDeletedValidator.of(circleDomainModel.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
-                            .consistOf(UserRoleValidator.of(updaterDomainModel.getRole(),
-                                    List.of(Role.LEADER_CIRCLE)));
-
-                    if (updaterDomainModel.getRole().getValue().contains("LEADER_CIRCLE") && !updaterDomainModel.getRole().getValue().contains("PRESIDENT")) {
-                        validatorBucket
-                                .consistOf(UserEqualValidator.of(
-                                        circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
-                                                () -> new UnauthorizedException(
-                                                        ErrorCode.API_NOT_ALLOWED,
-                                                        MessageUtil.NOT_CIRCLE_LEADER
-                                                )
-                                        ),
-                                        loginUserId
-                                ));
-                    }
-                },
-                () -> validatorBucket
-                        .consistOf(UserRoleValidator.of(updaterDomainModel.getRole(), List.of()))
-        );
-
-        boardDomainModel.update(
+        board.update(
                 boardUpdateRequestDto.getName(),
                 boardUpdateRequestDto.getDescription(),
-                boardUpdateRequestDto.getCreateRoleList(),
+                String.join(",", boardUpdateRequestDto.getCreateRoleList()),
                 boardUpdateRequestDto.getCategory()
         );
 
         validatorBucket
-                .consistOf(ConstraintValidator.of(boardDomainModel, this.validator))
+                .consistOf(ConstraintValidator.of(board, this.validator))
                 .validate();
 
-        return BoardResponseDto.from(
-                this.boardPort.updateBoard(boardId, boardDomainModel).orElseThrow(
-                        () -> new InternalServerException(
-                                ErrorCode.INTERNAL_SERVER,
-                                MessageUtil.INTERNAL_SERVER_ERROR
-                        )
-                ),
-                updaterDomainModel.getRole()
-        );
+        return toBoardResponseDto(boardRepository.save(board), updater.getRole());
     }
 
     @Transactional
@@ -227,71 +177,21 @@ public class BoardService {
             String loginUserId,
             String boardId
     ) {
-        ValidatorBucket validatorBucket = ValidatorBucket.of();
+        User deleter = getUser(loginUserId);
+        Board board = getBoard(boardId);
 
-        UserDomainModel deleterDomainModel = this.userPort.findById(loginUserId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.LOGIN_USER_NOT_FOUND
-                )
-        );
-
-        BoardDomainModel boardDomainModel = this.boardPort.findById(boardId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.BOARD_NOT_FOUND
-                )
-        );
-
-        if (boardDomainModel.getCategory().equals(StaticValue.BOARD_NAME_APP_NOTICE)) {
+        ValidatorBucket validatorBucket = initializeValidatorBucket(deleter, board);
+        if (board.getCategory().equals(StaticValue.BOARD_NAME_APP_NOTICE)) {
             validatorBucket
                     .consistOf(UserRoleValidator.of(
-                            deleterDomainModel.getRole(),
+                            deleter.getRole(),
                             List.of()
                     ));
         }
+        validatorBucket.validate();
 
-        validatorBucket
-                .consistOf(UserStateValidator.of(deleterDomainModel.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(deleterDomainModel.getRole()))
-                .consistOf(TargetIsDeletedValidator.of(boardDomainModel.getIsDeleted(), StaticValue.DOMAIN_BOARD));
-
-        boardDomainModel.getCircle().ifPresentOrElse(
-                circleDomainModel -> {
-                    validatorBucket
-                            .consistOf(TargetIsDeletedValidator.of(circleDomainModel.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
-                            .consistOf(UserRoleValidator.of(deleterDomainModel.getRole(),
-                                    List.of(Role.LEADER_CIRCLE)));
-
-                    if (deleterDomainModel.getRole().getValue().contains("LEADER_CIRCLE") && !deleterDomainModel.getRole().getValue().contains("PRESIDENT")) {
-                        validatorBucket
-                                .consistOf(UserEqualValidator.of(
-                                        circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
-                                                () -> new UnauthorizedException(
-                                                        ErrorCode.API_NOT_ALLOWED,
-                                                        MessageUtil.NOT_CIRCLE_LEADER
-                                                )
-                                        ),
-                                        loginUserId
-                                ));
-                    }
-                },
-                () -> validatorBucket
-                        .consistOf(UserRoleValidator.of(deleterDomainModel.getRole(), List.of()))
-        );
-
-        validatorBucket
-                .validate();
-
-        return BoardResponseDto.from(
-                this.boardPort.deleteBoard(boardId).orElseThrow(
-                        () -> new InternalServerException(
-                                ErrorCode.INTERNAL_SERVER,
-                                MessageUtil.INTERNAL_SERVER_ERROR
-                        )
-                ),
-                deleterDomainModel.getRole()
-        );
+        board.setIsDeleted(true);
+        return toBoardResponseDto(boardRepository.save(board), deleter.getRole());
     }
 
     @Transactional
@@ -299,70 +199,127 @@ public class BoardService {
             String loginUserId,
             String boardId
     ) {
+        User restorer = getUser(loginUserId);
+        Board board = getBoard(boardId);
+
         ValidatorBucket validatorBucket = ValidatorBucket.of();
 
-        UserDomainModel restorerDomainModel = this.userPort.findById(loginUserId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.LOGIN_USER_NOT_FOUND
-                )
-        );
-
-        BoardDomainModel boardDomainModel = this.boardPort.findById(boardId).orElseThrow(
-                () -> new BadRequestException(
-                        ErrorCode.ROW_DOES_NOT_EXIST,
-                        MessageUtil.BOARD_NOT_FOUND
-                )
-        );
-
-        if (boardDomainModel.getCategory().equals(StaticValue.BOARD_NAME_APP_NOTICE)) {
-            validatorBucket
-                    .consistOf(UserRoleValidator.of(
-                            restorerDomainModel.getRole(),
-                            List.of()
-                    ));
-        }
-
         validatorBucket
-                .consistOf(UserStateValidator.of(restorerDomainModel.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(restorerDomainModel.getRole()))
-                .consistOf(TargetIsNotDeletedValidator.of(boardDomainModel.getIsDeleted(), StaticValue.DOMAIN_BOARD));
+                .consistOf(UserStateValidator.of(restorer.getState()))
+                .consistOf(UserRoleIsNoneValidator.of(restorer.getRole()))
+                .consistOf(TargetIsNotDeletedValidator.of(board.getIsDeleted(), StaticValue.DOMAIN_BOARD));
 
-        boardDomainModel.getCircle().ifPresentOrElse(
-                circleDomainModel -> {
+        Optional<Circle> circles = Optional.ofNullable(board.getCircle());
+        circles.ifPresentOrElse(
+                circle -> {
                     validatorBucket
-                            .consistOf(TargetIsDeletedValidator.of(circleDomainModel.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
-                            .consistOf(UserRoleValidator.of(restorerDomainModel.getRole(),
+                            .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
+                            .consistOf(UserRoleValidator.of(restorer.getRole(),
                                     List.of(Role.LEADER_CIRCLE)));
 
-                    if (restorerDomainModel.getRole().getValue().contains("LEADER_CIRCLE") && !restorerDomainModel.getRole().getValue().contains("PRESIDENT")) {
+                    if (restorer.getRole().getValue().contains("LEADER_CIRCLE") && !restorer.getRole().getValue().contains("PRESIDENT")) {
                         validatorBucket
                                 .consistOf(UserEqualValidator.of(
-                                        circleDomainModel.getLeader().map(UserDomainModel::getId).orElseThrow(
+                                        circle.getLeader().map(User::getId).orElseThrow(
                                                 () -> new UnauthorizedException(
                                                         ErrorCode.API_NOT_ALLOWED,
                                                         MessageUtil.NOT_CIRCLE_LEADER
                                                 )
                                         ),
-                                        loginUserId
+                                        restorer.getId()
                                 ));
                     }
                 },
                 () -> validatorBucket
-                        .consistOf(UserRoleValidator.of(restorerDomainModel.getRole(), List.of()))
+                        .consistOf(UserRoleValidator.of(restorer.getRole(), List.of()))
         );
 
-        validatorBucket
-                .validate();
+        if (board.getCategory().equals(StaticValue.BOARD_NAME_APP_NOTICE)) {
+            validatorBucket
+                    .consistOf(UserRoleValidator.of(
+                            restorer.getRole(),
+                            List.of()
+                    ));
+        }
+        validatorBucket.validate();
 
-        return BoardResponseDto.from(
-                this.boardPort.restoreBoard(boardId).orElseThrow(
-                        () -> new InternalServerException(
-                                ErrorCode.INTERNAL_SERVER,
-                                MessageUtil.INTERNAL_SERVER_ERROR
-                        )
-                ),
-                restorerDomainModel.getRole()
+        board.setIsDeleted(false);
+        return toBoardResponseDto(boardRepository.save(board), restorer.getRole());
+    }
+
+    private ValidatorBucket initializeValidatorBucket(User user, Board board) {
+        ValidatorBucket validatorBucket = ValidatorBucket.of();
+
+        validatorBucket
+                .consistOf(UserStateValidator.of(user.getState()))
+                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
+                .consistOf(TargetIsDeletedValidator.of(board.getIsDeleted(), StaticValue.DOMAIN_BOARD));
+
+        Optional<Circle> circles = Optional.ofNullable(board.getCircle());
+        circles.ifPresentOrElse(
+                circle -> {
+                    validatorBucket
+                            .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
+                            .consistOf(UserRoleValidator.of(user.getRole(),
+                                    List.of(Role.LEADER_CIRCLE)));
+
+                    if (user.getRole().getValue().contains("LEADER_CIRCLE") && !user.getRole().getValue().contains("PRESIDENT")) {
+                        validatorBucket
+                                .consistOf(UserEqualValidator.of(
+                                        circle.getLeader().map(User::getId).orElseThrow(
+                                                () -> new UnauthorizedException(
+                                                        ErrorCode.API_NOT_ALLOWED,
+                                                        MessageUtil.NOT_CIRCLE_LEADER
+                                                )
+                                        ),
+                                        user.getId()
+                                ));
+                    }
+                },
+                () -> validatorBucket
+                        .consistOf(UserRoleValidator.of(user.getRole(), List.of()))
+        );
+        return validatorBucket;
+    }
+
+    private BoardResponseDto toBoardResponseDto(Board board, Role userRole) {
+        List<String> roles = new ArrayList<>(Arrays.asList(board.getCreateRoles().split(",")));
+        Boolean writable = roles.stream().anyMatch(str -> userRole.getValue().contains(str));
+        String circleId = Optional.ofNullable(board.getCircle()).map(Circle::getId).orElse(null);
+        String circleName = Optional.ofNullable(board.getCircle()).map(Circle::getName).orElse(null);
+        return DtoMapper.INSTANCE.toBoardResponseDto(
+                board,
+                roles,
+                writable,
+                circleId,
+                circleName
+        );
+    }
+
+    private User getUser(String userId) {
+        return userRepository.findById(userId).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        MessageUtil.USER_NOT_FOUND
+                )
+        );
+    }
+
+    private Board getBoard(String boardId) {
+        return boardRepository.findById(boardId).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        MessageUtil.BOARD_NOT_FOUND
+                )
+        );
+    }
+
+    private Circle getCircle(String circleId) {
+        return circleRepository.findById(circleId).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        MessageUtil.SMALL_CLUB_NOT_FOUND
+                )
         );
     }
 }

--- a/src/main/java/net/causw/application/comment/ChildCommentService.java
+++ b/src/main/java/net/causw/application/comment/ChildCommentService.java
@@ -49,7 +49,7 @@ public class ChildCommentService {
 
     @Transactional
     public ChildCommentResponseDto createChildComment(String creatorId, ChildCommentCreateRequestDto childCommentCreateRequestDto) {
-        User user = getUser(creatorId);
+        User creator = getUser(creatorId);
         Comment parentComment = getComment(childCommentCreateRequestDto.getParentCommentId());
         Post post = getPost(parentComment.getPost().getId());
         Optional<ChildComment> refChildComment = childCommentCreateRequestDto.getRefChildComment().map(this::getChildComment);
@@ -58,11 +58,11 @@ public class ChildCommentService {
                 false,
                 refChildComment.map(refChild -> refChild.getWriter().getName()).orElse(null),
                 childCommentCreateRequestDto.getRefChildComment().orElse(null),
-                user,
+                creator,
                 parentComment
         );
 
-        ValidatorBucket validatorBucket = initializeValidator(user, post);
+        ValidatorBucket validatorBucket = initializeValidator(creator, post);
         validatorBucket.consistOf(ConstraintValidator.of(childComment, this.validator));
         refChildComment.ifPresent(
                 refChild -> validatorBucket.consistOf(TargetIsDeletedValidator.of(refChild.getIsDeleted(), StaticValue.DOMAIN_CHILD_COMMENT))
@@ -71,8 +71,8 @@ public class ChildCommentService {
 
         return toChildCommentResponseDto(
                 childCommentRepository.save(childComment),
-                StatusUtil.isUpdatable(childComment, user),
-                StatusUtil.isDeletable(childComment, user, post.getBoard())
+                StatusUtil.isUpdatable(childComment, creator),
+                StatusUtil.isDeletable(childComment, creator, post.getBoard())
         );
     }
 

--- a/src/main/java/net/causw/application/comment/CommentService.java
+++ b/src/main/java/net/causw/application/comment/CommentService.java
@@ -53,16 +53,16 @@ public class CommentService {
 
     @Transactional
     public CommentResponseDto createComment(String loginUserId, CommentCreateRequestDto commentCreateDto) {
-        User user = getUser(loginUserId);
+        User creator = getUser(loginUserId);
         Post post = getPost(commentCreateDto.getPostId());
-        Comment comment = Comment.of(commentCreateDto.getContent(), false, user, post);
+        Comment comment = Comment.of(commentCreateDto.getContent(), false, creator, post);
 
-        ValidatorBucket validatorBucket = initializeValidator(user, post);
+        ValidatorBucket validatorBucket = initializeValidator(creator, post);
         validatorBucket.
                 consistOf(ConstraintValidator.of(comment, this.validator));
         validatorBucket.validate();
 
-        return toCommentResponseDto(commentRepository.save(comment), user, post.getBoard());
+        return toCommentResponseDto(commentRepository.save(comment), creator, post.getBoard());
     }
 
     @Transactional(readOnly = true)
@@ -88,16 +88,16 @@ public class CommentService {
             String commentId,
             CommentUpdateRequestDto commentUpdateRequestDto
     ) {
-        User user = getUser(loginUserId);
+        User updater = getUser(loginUserId);
         Comment comment = getComment(commentId);
         Post post = getPost(comment.getPost().getId());
 
-        ValidatorBucket validatorBucket = initializeValidator(user, post);
+        ValidatorBucket validatorBucket = initializeValidator(updater, post);
         validatorBucket
                 .consistOf(TargetIsDeletedValidator.of(comment.getIsDeleted(), StaticValue.DOMAIN_COMMENT))
                 .consistOf(ConstraintValidator.of(comment, this.validator))
                 .consistOf(ContentsAdminValidator.of(
-                        user.getRole(),
+                        updater.getRole(),
                         loginUserId,
                         comment.getWriter().getId(),
                         List.of()
@@ -106,28 +106,28 @@ public class CommentService {
 
         comment.update(commentUpdateRequestDto.getContent());
 
-        return toCommentResponseDto(commentRepository.save(comment), user, post.getBoard());
+        return toCommentResponseDto(commentRepository.save(comment), updater, post.getBoard());
     }
 
 
     @Transactional
     public CommentResponseDto deleteComment(String loginUserId, String commentId) {
-        User user = getUser(loginUserId);
+        User deleter = getUser(loginUserId);
         Comment comment = getComment(commentId);
         Post post = getPost(comment.getPost().getId());
 
-        ValidatorBucket validatorBucket = initializeValidator(user, post);
+        ValidatorBucket validatorBucket = initializeValidator(deleter, post);
         validatorBucket
-                .consistOf(UserStateValidator.of(user.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(user.getRole()))
+                .consistOf(UserStateValidator.of(deleter.getState()))
+                .consistOf(UserRoleIsNoneValidator.of(deleter.getRole()))
                 .consistOf(TargetIsDeletedValidator.of(comment.getIsDeleted(), StaticValue.DOMAIN_COMMENT));
 
         Optional<Circle> circles = Optional.ofNullable(post.getBoard().getCircle());
         circles
-                .filter(circle -> !user.getRole().equals(Role.ADMIN) && !user.getRole().getValue().contains("PRESIDENT"))
+                .filter(circle -> !deleter.getRole().equals(Role.ADMIN) && !deleter.getRole().getValue().contains("PRESIDENT"))
                 .ifPresentOrElse(
                         circle -> {
-                            CircleMember member = getCircleMember(user.getId(), circle.getId());
+                            CircleMember member = getCircleMember(deleter.getId(), circle.getId());
 
                             validatorBucket
                                     .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
@@ -136,13 +136,13 @@ public class CommentService {
                                             List.of(CircleMemberStatus.MEMBER)
                                     ))
                                     .consistOf(ContentsAdminValidator.of(
-                                            user.getRole(),
+                                            deleter.getRole(),
                                             loginUserId,
                                             comment.getWriter().getId(),
                                             List.of(Role.LEADER_CIRCLE)
                                     ));
 
-                            if (user.getRole().getValue().contains("LEADER_CIRCLE") && !comment.getWriter().getId().equals(loginUserId)) {
+                            if (deleter.getRole().getValue().contains("LEADER_CIRCLE") && !comment.getWriter().getId().equals(loginUserId)) {
                                 validatorBucket
                                         .consistOf(UserEqualValidator.of(
                                                 circle.getLeader().map(User::getId).orElseThrow(
@@ -158,7 +158,7 @@ public class CommentService {
                         },
                         () -> validatorBucket
                                 .consistOf(ContentsAdminValidator.of(
-                                        user.getRole(),
+                                        deleter.getRole(),
                                         loginUserId,
                                         comment.getWriter().getId(),
                                         List.of()
@@ -168,7 +168,7 @@ public class CommentService {
 
         comment.delete();
 
-        return toCommentResponseDto(commentRepository.save(comment), user, post.getBoard());
+        return toCommentResponseDto(commentRepository.save(comment), deleter, post.getBoard());
     }
 
     private CommentResponseDto toCommentResponseDto(Comment comment, User user, Board board) {

--- a/src/main/java/net/causw/application/dto/board/BoardOfCircleResponseDto.java
+++ b/src/main/java/net/causw/application/dto/board/BoardOfCircleResponseDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.board;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -13,6 +14,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @Builder
+@AllArgsConstructor
 public class BoardOfCircleResponseDto {
 
     @ApiModelProperty(value = "게시판 id 값", example = "uuid 형식의 String 값입니다.")
@@ -45,6 +47,7 @@ public class BoardOfCircleResponseDto {
     @ApiModelProperty(value = "게시글 댓글 개수", example =  "12")
     private Long postNumComment;
 
+    // FIXME: Port 분리 후 삭제 필요
     public static BoardOfCircleResponseDto from(
             BoardDomainModel boardDomainModel,
             Role userRole,

--- a/src/main/java/net/causw/application/dto/board/BoardResponseDto.java
+++ b/src/main/java/net/causw/application/dto/board/BoardResponseDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.board;
 
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -18,6 +19,7 @@ import java.util.Optional;
 @Getter
 @Setter
 @Builder
+@AllArgsConstructor
 public class BoardResponseDto {
     @ApiModelProperty(value = "게시판 id 값", example = "uuid 형식의 String 값입니다.")
     private String id;

--- a/src/main/java/net/causw/application/dto/util/DtoMapper.java
+++ b/src/main/java/net/causw/application/dto/util/DtoMapper.java
@@ -4,6 +4,7 @@ import net.causw.adapter.persistence.board.Board;
 import net.causw.adapter.persistence.comment.ChildComment;
 import net.causw.adapter.persistence.comment.Comment;
 import net.causw.adapter.persistence.post.Post;
+import net.causw.application.dto.board.BoardResponseDto;
 import net.causw.application.dto.comment.ChildCommentResponseDto;
 import net.causw.application.dto.comment.CommentResponseDto;
 import net.causw.application.dto.file.FileResponseDto;
@@ -83,7 +84,7 @@ public interface DtoMapper{
 
 
     // Board
-
+    BoardResponseDto toBoardResponseDto(Board entity, List<String> createRoleList, Boolean writable, String circleId, String circleName);
 
     // Circle
 

--- a/src/main/java/net/causw/application/dto/util/DtoMapper.java
+++ b/src/main/java/net/causw/application/dto/util/DtoMapper.java
@@ -4,6 +4,7 @@ import net.causw.adapter.persistence.board.Board;
 import net.causw.adapter.persistence.comment.ChildComment;
 import net.causw.adapter.persistence.comment.Comment;
 import net.causw.adapter.persistence.post.Post;
+import net.causw.application.dto.board.BoardOfCircleResponseDto;
 import net.causw.application.dto.board.BoardResponseDto;
 import net.causw.application.dto.comment.ChildCommentResponseDto;
 import net.causw.application.dto.comment.CommentResponseDto;
@@ -85,6 +86,22 @@ public interface DtoMapper{
 
     // Board
     BoardResponseDto toBoardResponseDto(Board entity, List<String> createRoleList, Boolean writable, String circleId, String circleName);
+
+    @Mapping(target = "id", source = "board.id")
+    @Mapping(target = "name", source = "board.name")
+    @Mapping(target = "writable", source = "writable")
+    @Mapping(target = "isDeleted", source = "board.isDeleted")
+    @Mapping(target = "postId", source = "post.id")
+    @Mapping(target = "postTitle", source = "post.title")
+    @Mapping(target = "postWriterName", source = "post.writer.name")
+    @Mapping(target = "postWriterStudentId", source = "post.writer.studentId")
+    @Mapping(target = "postCreatedAt", source = "post.createdAt")
+    @Mapping(target = "postNumComment", source = "numComment")
+    BoardOfCircleResponseDto toBoardOfCircleResponseDto(Board board, Post post, Long numComment, boolean writable);
+
+    @Mapping(target = "writable", source = "writable")
+    @Mapping(target = "postNumComment", source = "numComment")
+    BoardOfCircleResponseDto toBoardOfCircleResponseDto(Board entity, Long numComment, boolean writable);
 
     // Circle
 


### PR DESCRIPTION
### 🚩 관련사항

#545 

### 📢 전달사항
- UserService, CircleService 그리고 HomaPageService에서 BoardPort 제거 및 Board 관련 Dto에서의 of/from 메서드를 DtoMapper를 적용하여 Dto 생성을 자동화하였습니다.
- BoardOfCircleResponseDto의 경우, board와 post의 두 entity를 입력으로 받는 toBoardOfCircleResponseDto에서 하나의 entity에 대해 매핑할 때와 다르게 모든 타겟에 매핑하지 않은 경우 모호성(ex. BoardOfCircleResponseDto의 id에 2개의 entity 중에서 어떤 entity의 id가 매핑될 것인지)이 발생하여 사진과 같이 모두 매핑해 주었습니다.


### 📸 스크린샷
![스크린샷 2024-05-25 오전 1 32 57](https://github.com/CAUCSE/CAUSW_backend/assets/49549887/291655a2-b5f7-43fe-ad65-a881c8ca8b06)

실행을 통해 모든 타켓에 매핑되는 것을 확인하였습니다.

![스크린샷 2024-05-25 오전 1 43 32](https://github.com/CAUCSE/CAUSW_backend/assets/49549887/58f376ad-0e56-4645-af70-03ca97d0ec5f)


### 📃 진행사항
- [x] Board/FavoriteBoard of 메서드 추가
- [x] Dto들의 of/from 메서드를 MapStruct를 적용하여 매핑
- [x] BoardService 리팩토링
- [x] HomePageService 일부 리팩토링
- [x] UserService 일부 리팩토링
- [x] CircleService 일부 리팩토링
- [ ] 수정 사항 반영


### ⚙️ 기타사항
수정해야 할 사항이 있다면 알려주세요.

개발기간: 2주