### PR TITLE
refactor : dto valid 검증 및 validation bucket 제거

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/base/BaseEntity.java
+++ b/src/main/java/net/causw/adapter/persistence/base/BaseEntity.java
@@ -2,14 +2,13 @@ package net.causw.adapter.persistence.base;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.UuidGenerator;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
@@ -20,8 +19,7 @@ import java.time.LocalDateTime;
 @EntityListeners(value = {AuditingEntityListener.class})
 public class BaseEntity {
     @Id
-    @GeneratedValue(generator = "uuid")
-    @GenericGenerator(name = "uuid", strategy = "uuid")
+    @UuidGenerator
     @Column(name = "id", nullable = false, unique = true)
     private String id;
 

--- a/src/main/java/net/causw/adapter/persistence/inquiry/Inquiry.java
+++ b/src/main/java/net/causw/adapter/persistence/inquiry/Inquiry.java
@@ -49,6 +49,17 @@ public class Inquiry extends BaseEntity {
         this.isDeleted = isDeleted;
     }
 
+    private Inquiry(
+            String title,
+            String content,
+            User writer
+    ) {
+        this.title = title;
+        this.content = content;
+        this.writer = writer;
+        this.isDeleted = false;
+    }
+
     public static Inquiry from(InquiryDomainModel inquiryDomainModel) {
         return new Inquiry(
                 inquiryDomainModel.getId(),
@@ -57,5 +68,13 @@ public class Inquiry extends BaseEntity {
                 User.from(inquiryDomainModel.getWriter()),
                 inquiryDomainModel.getIsDeleted()
         );
+    }
+
+    public static Inquiry of(
+            String title,
+            String content,
+            User writer
+    ) {
+        return new Inquiry(title, content, writer);
     }
 }

--- a/src/main/java/net/causw/adapter/web/BoardController.java
+++ b/src/main/java/net/causw/adapter/web/BoardController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import net.causw.application.board.BoardService;
 import net.causw.application.dto.board.BoardCreateRequestDto;
@@ -74,7 +75,7 @@ public class BoardController {
             @ApiResponse(responseCode = "5000", description = "The board has circle without circle leader", content = @Content(mediaType = "application/json", schema = @Schema(implementation = InternalServerException.class)))
     })
     public BoardResponseDto createBoard(
-            @RequestBody BoardCreateRequestDto boardCreateRequestDto,
+            @Valid @RequestBody BoardCreateRequestDto boardCreateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
 
@@ -100,7 +101,7 @@ public class BoardController {
     })
     public BoardResponseDto updateBoard(
             @PathVariable("id") String id,
-            @RequestBody BoardUpdateRequestDto boardUpdateRequestDto,
+            @Valid @RequestBody BoardUpdateRequestDto boardUpdateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         return this.boardService.updateBoard(userDetails.getUser(), id, boardUpdateRequestDto);

--- a/src/main/java/net/causw/adapter/web/ChildCommentController.java
+++ b/src/main/java/net/causw/adapter/web/ChildCommentController.java
@@ -16,6 +16,7 @@ import net.causw.config.security.userdetails.CustomUserDetails;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.UnauthorizedException;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -58,12 +59,8 @@ public class ChildCommentController {
             @ApiResponse(responseCode = "4004", description = "삭제된 동아리입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
     })
     public ChildCommentResponseDto createChildComment(
-<<<<<<< HEAD
-            @RequestBody ChildCommentCreateRequestDto childCommentCreateRequestDto,
+            @Valid @RequestBody ChildCommentCreateRequestDto childCommentCreateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
-=======
-            @Valid @RequestBody ChildCommentCreateRequestDto childCommentCreateRequestDto
->>>>>>> 2063aa8 (refactor: Comment 관련 dto에 Valid 적용)
     ) {
 
         return this.childCommentService.createChildComment(userDetails.getUser(), childCommentCreateRequestDto);
@@ -96,14 +93,9 @@ public class ChildCommentController {
             @ApiResponse(responseCode = "5000", description = "Comment id checked, but exception occurred", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
     })
     public ChildCommentResponseDto updateChildComment(
-<<<<<<< HEAD
             @PathVariable("id") String id,
-            @RequestBody ChildCommentUpdateRequestDto childCommentUpdateRequestDto,
+            @Valid @RequestBody ChildCommentUpdateRequestDto childCommentUpdateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
-=======
-            @PathVariable String id,
-            @Valid @RequestBody ChildCommentUpdateRequestDto childCommentUpdateRequestDto
->>>>>>> 2063aa8 (refactor: Comment 관련 dto에 Valid 적용)
     ) {
         return this.childCommentService.updateChildComment(userDetails.getUser(), id, childCommentUpdateRequestDto);
     }

--- a/src/main/java/net/causw/adapter/web/ChildCommentController.java
+++ b/src/main/java/net/causw/adapter/web/ChildCommentController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import net.causw.application.comment.ChildCommentService;
 import net.causw.application.dto.comment.ChildCommentCreateRequestDto;
@@ -15,10 +16,8 @@ import net.causw.config.security.userdetails.CustomUserDetails;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.UnauthorizedException;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -59,8 +58,12 @@ public class ChildCommentController {
             @ApiResponse(responseCode = "4004", description = "삭제된 동아리입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
     })
     public ChildCommentResponseDto createChildComment(
+<<<<<<< HEAD
             @RequestBody ChildCommentCreateRequestDto childCommentCreateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
+=======
+            @Valid @RequestBody ChildCommentCreateRequestDto childCommentCreateRequestDto
+>>>>>>> 2063aa8 (refactor: Comment 관련 dto에 Valid 적용)
     ) {
 
         return this.childCommentService.createChildComment(userDetails.getUser(), childCommentCreateRequestDto);
@@ -93,9 +96,14 @@ public class ChildCommentController {
             @ApiResponse(responseCode = "5000", description = "Comment id checked, but exception occurred", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
     })
     public ChildCommentResponseDto updateChildComment(
+<<<<<<< HEAD
             @PathVariable("id") String id,
             @RequestBody ChildCommentUpdateRequestDto childCommentUpdateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
+=======
+            @PathVariable String id,
+            @Valid @RequestBody ChildCommentUpdateRequestDto childCommentUpdateRequestDto
+>>>>>>> 2063aa8 (refactor: Comment 관련 dto에 Valid 적용)
     ) {
         return this.childCommentService.updateChildComment(userDetails.getUser(), id, childCommentUpdateRequestDto);
     }

--- a/src/main/java/net/causw/adapter/web/CircleController.java
+++ b/src/main/java/net/causw/adapter/web/CircleController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import net.causw.application.circle.CircleService;
 import net.causw.application.dto.circle.CirclesResponseDto;
@@ -226,7 +227,7 @@ public class CircleController {
             @ApiResponse(responseCode = "5000", description = "Circle id immediately can be used, but exception occured", content = @Content(mediaType = "application/json", schema = @Schema(implementation = InternalServerException.class)))
     })
     public CircleResponseDto create(
-            @RequestBody CircleCreateRequestDto circleCreateRequestDto,
+            @Valid @RequestBody CircleCreateRequestDto circleCreateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         return this.circleService.create(userDetails.getUser(), circleCreateRequestDto);
@@ -275,7 +276,7 @@ public class CircleController {
     })
     public CircleResponseDto update(
             @PathVariable(name = "circleId") String circleId,
-            @RequestBody CircleUpdateRequestDto circleUpdateRequestDto,
+            @Valid @RequestBody CircleUpdateRequestDto circleUpdateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         return this.circleService.update(userDetails.getUser(), circleId, circleUpdateRequestDto);

--- a/src/main/java/net/causw/adapter/web/CommentController.java
+++ b/src/main/java/net/causw/adapter/web/CommentController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import net.causw.application.comment.CommentService;
 import net.causw.application.dto.comment.CommentCreateRequestDto;
@@ -88,7 +89,7 @@ public class CommentController {
             @ApiResponse(responseCode = "4004", description = "삭제된 동아리입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
     })
     public CommentResponseDto createComment(
-            @RequestBody CommentCreateRequestDto commentCreateRequestDto,
+            @Valid @RequestBody CommentCreateRequestDto commentCreateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         return this.commentService.createComment(userDetails.getUser(), commentCreateRequestDto);
@@ -121,7 +122,7 @@ public class CommentController {
     })
     public CommentResponseDto updateComment(
             @PathVariable("id") String id,
-            @RequestBody CommentUpdateRequestDto commentUpdateRequestDto,
+            @Valid @RequestBody CommentUpdateRequestDto commentUpdateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         return this.commentService.updateComment(

--- a/src/main/java/net/causw/adapter/web/GlobalExceptionHandler.java
+++ b/src/main/java/net/causw/adapter/web/GlobalExceptionHandler.java
@@ -54,7 +54,7 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ExceptionDto handleMethodArgumentNotValidException(MethodArgumentNotValidException exception) {
         GlobalExceptionHandler.log.error("error message", exception);
-        return ExceptionDto.of(ErrorCode.VALIDATE_FAILURE, exception.getMessage());
+        return ExceptionDto.of(ErrorCode.VALIDATE_FAILURE, exception.getBindingResult().getAllErrors().get(0).getDefaultMessage());
     }
 
     @ExceptionHandler(value = {UnauthorizedException.class})

--- a/src/main/java/net/causw/adapter/web/GlobalExceptionHandler.java
+++ b/src/main/java/net/causw/adapter/web/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import net.causw.domain.exceptions.ServiceUnavailableException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -47,6 +48,13 @@ public class GlobalExceptionHandler {
     public ExceptionDto handleBadHttpRequestMethodException(HttpRequestMethodNotSupportedException exception) {
         GlobalExceptionHandler.log.error("error message", exception);
         return ExceptionDto.of(ErrorCode.INVALID_HTTP_METHOD, "Invalid request http method (GET, POST, PUT, DELETE)");
+    }
+
+    @ExceptionHandler(value = {MethodArgumentNotValidException.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ExceptionDto handleMethodArgumentNotValidException(MethodArgumentNotValidException exception) {
+        GlobalExceptionHandler.log.error("error message", exception);
+        return ExceptionDto.of(ErrorCode.VALIDATE_FAILURE, exception.getMessage());
     }
 
     @ExceptionHandler(value = {UnauthorizedException.class})

--- a/src/main/java/net/causw/adapter/web/InquiryController.java
+++ b/src/main/java/net/causw/adapter/web/InquiryController.java
@@ -1,5 +1,6 @@
 package net.causw.adapter.web;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import net.causw.application.inquiry.InquiryService;
 import net.causw.application.dto.inquiry.InquiryCreateRequestDto;
@@ -27,7 +28,7 @@ public class InquiryController {
     @ResponseStatus(value = HttpStatus.CREATED)
     public InquiryResponseDto create(
             @AuthenticationPrincipal String requestUserId,
-            @RequestBody InquiryCreateRequestDto inquiryCreateRequestDto
+            @Valid @RequestBody InquiryCreateRequestDto inquiryCreateRequestDto
     ) {
         return this.inquiryService.create(requestUserId, inquiryCreateRequestDto);
     }

--- a/src/main/java/net/causw/adapter/web/InquiryController.java
+++ b/src/main/java/net/causw/adapter/web/InquiryController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import net.causw.application.inquiry.InquiryService;
 import net.causw.application.dto.inquiry.InquiryCreateRequestDto;
 import net.causw.application.dto.inquiry.InquiryResponseDto;
+import net.causw.config.security.userdetails.CustomUserDetails;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -18,18 +19,18 @@ public class InquiryController {
     @GetMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.OK)
     public InquiryResponseDto findById(
-            @AuthenticationPrincipal String requestUserId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("id") String id
     ) {
-        return this.inquiryService.findById(requestUserId,id);
+        return this.inquiryService.findById(userDetails.getUser(), id);
     }
 
     @PostMapping
     @ResponseStatus(value = HttpStatus.CREATED)
     public InquiryResponseDto create(
-            @AuthenticationPrincipal String requestUserId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody InquiryCreateRequestDto inquiryCreateRequestDto
     ) {
-        return this.inquiryService.create(requestUserId, inquiryCreateRequestDto);
+        return this.inquiryService.create(userDetails.getUser(), inquiryCreateRequestDto);
     }
 }

--- a/src/main/java/net/causw/adapter/web/LockerController.java
+++ b/src/main/java/net/causw/adapter/web/LockerController.java
@@ -1,6 +1,7 @@
 package net.causw.adapter.web;
 
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import net.causw.application.locker.LockerService;
 import net.causw.application.dto.locker.LockerExpiredAtRequestDto;
@@ -50,8 +51,12 @@ public class LockerController {
     @Operation(summary = "사물함 생성 Api(완료)", description = "사물함을 생성하는 Api입니다.")
     @ResponseStatus(value = HttpStatus.CREATED)
     public LockerResponseDto create(
+<<<<<<< HEAD
             @RequestBody LockerCreateRequestDto lockerCreateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
+=======
+            @Valid @RequestBody LockerCreateRequestDto lockerCreateRequestDto
+>>>>>>> acda2f5 (refactor: Locker 관련 dto에 Valid 적용)
     ) {
         return this.lockerService.create(userDetails.getUser(), lockerCreateRequestDto);
     }
@@ -60,9 +65,14 @@ public class LockerController {
     @ResponseStatus(value = HttpStatus.OK)
     @Operation(summary = "사물함 상태 update Api", description = "사물함 상태를 변경하는 Api입니다.")
     public LockerResponseDto update(
+<<<<<<< HEAD
             @PathVariable("id") String id,
             @RequestBody LockerUpdateRequestDto lockerUpdateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
+=======
+            @PathVariable String id,
+            @Valid @RequestBody LockerUpdateRequestDto lockerUpdateRequestDto
+>>>>>>> acda2f5 (refactor: Locker 관련 dto에 Valid 적용)
     ) {
         return this.lockerService.update(
                 userDetails.getUser(),
@@ -75,9 +85,14 @@ public class LockerController {
     @ResponseStatus(value = HttpStatus.OK)
     @Operation(summary = "사물함 위치 이동 Api(완료)", description = "사물함의 위치를 이동시키는 Api입니다.")
     public LockerResponseDto move(
+<<<<<<< HEAD
             @PathVariable("id") String id,
             @RequestBody LockerMoveRequestDto lockerMoveRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
+=======
+            @PathVariable String id,
+            @Valid @RequestBody LockerMoveRequestDto lockerMoveRequestDto
+>>>>>>> acda2f5 (refactor: Locker 관련 dto에 Valid 적용)
     ) {
         return this.lockerService.move(
                 userDetails.getUser(),
@@ -117,8 +132,12 @@ public class LockerController {
     @Operation(summary = "사물함 위치 생성 API(완료)", description = "사물함 특정 층 생성 API 입니다.")
     @ResponseStatus(value = HttpStatus.CREATED)
     public LockerLocationResponseDto createLocation(
+<<<<<<< HEAD
             @RequestBody LockerLocationCreateRequestDto lockerLocationCreateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
+=======
+            @Valid @RequestBody LockerLocationCreateRequestDto lockerLocationCreateRequestDto
+>>>>>>> acda2f5 (refactor: Locker 관련 dto에 Valid 적용)
     ) {
         return this.lockerService.createLocation(userDetails.getUser(), lockerLocationCreateRequestDto);
     }
@@ -127,9 +146,14 @@ public class LockerController {
     @Operation(summary = "사물함 위치 업데이트 API(완료)", description = "사물함 특정 층 업데이트 API 입니다.")
     @ResponseStatus(value = HttpStatus.OK)
     public LockerLocationResponseDto updateLocation(
+<<<<<<< HEAD
             @PathVariable("locationId") String locationId,
             @RequestBody LockerLocationUpdateRequestDto lockerLocationUpdateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
+=======
+            @PathVariable String locationId,
+            @Valid @RequestBody LockerLocationUpdateRequestDto lockerLocationUpdateRequestDto
+>>>>>>> acda2f5 (refactor: Locker 관련 dto에 Valid 적용)
     ) {
         return this.lockerService.updateLocation(
                 userDetails.getUser(),
@@ -158,8 +182,12 @@ public class LockerController {
     @Operation(summary = "사물함 만료 기한 설정 Api(완료)", description = "사물함 만료 기한을 설정하는 API입니다.(학생회장만 가능)")
     @ResponseStatus(value = HttpStatus.OK)
     public void setExpireDate(
+<<<<<<< HEAD
             @RequestBody LockerExpiredAtRequestDto lockerExpiredAtRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
+=======
+            @Valid @RequestBody LockerExpiredAtRequestDto lockerExpiredAtRequestDto
+>>>>>>> acda2f5 (refactor: Locker 관련 dto에 Valid 적용)
     ) {
         this.lockerService.setExpireAt(userDetails.getUser(), lockerExpiredAtRequestDto);
     }

--- a/src/main/java/net/causw/adapter/web/LockerController.java
+++ b/src/main/java/net/causw/adapter/web/LockerController.java
@@ -3,6 +3,7 @@ package net.causw.adapter.web;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import net.causw.adapter.persistence.locker.Locker;
 import net.causw.application.locker.LockerService;
 import net.causw.application.dto.locker.LockerExpiredAtRequestDto;
 import net.causw.application.dto.locker.LockerLocationsResponseDto;
@@ -51,12 +52,8 @@ public class LockerController {
     @Operation(summary = "사물함 생성 Api(완료)", description = "사물함을 생성하는 Api입니다.")
     @ResponseStatus(value = HttpStatus.CREATED)
     public LockerResponseDto create(
-<<<<<<< HEAD
-            @RequestBody LockerCreateRequestDto lockerCreateRequestDto,
+            @Valid @RequestBody LockerCreateRequestDto lockerCreateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
-=======
-            @Valid @RequestBody LockerCreateRequestDto lockerCreateRequestDto
->>>>>>> acda2f5 (refactor: Locker 관련 dto에 Valid 적용)
     ) {
         return this.lockerService.create(userDetails.getUser(), lockerCreateRequestDto);
     }
@@ -65,14 +62,9 @@ public class LockerController {
     @ResponseStatus(value = HttpStatus.OK)
     @Operation(summary = "사물함 상태 update Api", description = "사물함 상태를 변경하는 Api입니다.")
     public LockerResponseDto update(
-<<<<<<< HEAD
             @PathVariable("id") String id,
-            @RequestBody LockerUpdateRequestDto lockerUpdateRequestDto,
+            @Valid @RequestBody LockerUpdateRequestDto lockerUpdateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
-=======
-            @PathVariable String id,
-            @Valid @RequestBody LockerUpdateRequestDto lockerUpdateRequestDto
->>>>>>> acda2f5 (refactor: Locker 관련 dto에 Valid 적용)
     ) {
         return this.lockerService.update(
                 userDetails.getUser(),
@@ -85,14 +77,9 @@ public class LockerController {
     @ResponseStatus(value = HttpStatus.OK)
     @Operation(summary = "사물함 위치 이동 Api(완료)", description = "사물함의 위치를 이동시키는 Api입니다.")
     public LockerResponseDto move(
-<<<<<<< HEAD
             @PathVariable("id") String id,
-            @RequestBody LockerMoveRequestDto lockerMoveRequestDto,
+            @Valid @RequestBody LockerMoveRequestDto lockerMoveRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
-=======
-            @PathVariable String id,
-            @Valid @RequestBody LockerMoveRequestDto lockerMoveRequestDto
->>>>>>> acda2f5 (refactor: Locker 관련 dto에 Valid 적용)
     ) {
         return this.lockerService.move(
                 userDetails.getUser(),
@@ -132,12 +119,8 @@ public class LockerController {
     @Operation(summary = "사물함 위치 생성 API(완료)", description = "사물함 특정 층 생성 API 입니다.")
     @ResponseStatus(value = HttpStatus.CREATED)
     public LockerLocationResponseDto createLocation(
-<<<<<<< HEAD
-            @RequestBody LockerLocationCreateRequestDto lockerLocationCreateRequestDto,
+            @Valid @RequestBody LockerLocationCreateRequestDto lockerLocationCreateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
-=======
-            @Valid @RequestBody LockerLocationCreateRequestDto lockerLocationCreateRequestDto
->>>>>>> acda2f5 (refactor: Locker 관련 dto에 Valid 적용)
     ) {
         return this.lockerService.createLocation(userDetails.getUser(), lockerLocationCreateRequestDto);
     }
@@ -146,14 +129,9 @@ public class LockerController {
     @Operation(summary = "사물함 위치 업데이트 API(완료)", description = "사물함 특정 층 업데이트 API 입니다.")
     @ResponseStatus(value = HttpStatus.OK)
     public LockerLocationResponseDto updateLocation(
-<<<<<<< HEAD
             @PathVariable("locationId") String locationId,
-            @RequestBody LockerLocationUpdateRequestDto lockerLocationUpdateRequestDto,
+            @Valid @RequestBody LockerLocationUpdateRequestDto lockerLocationUpdateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
-=======
-            @PathVariable String locationId,
-            @Valid @RequestBody LockerLocationUpdateRequestDto lockerLocationUpdateRequestDto
->>>>>>> acda2f5 (refactor: Locker 관련 dto에 Valid 적용)
     ) {
         return this.lockerService.updateLocation(
                 userDetails.getUser(),
@@ -182,12 +160,8 @@ public class LockerController {
     @Operation(summary = "사물함 만료 기한 설정 Api(완료)", description = "사물함 만료 기한을 설정하는 API입니다.(학생회장만 가능)")
     @ResponseStatus(value = HttpStatus.OK)
     public void setExpireDate(
-<<<<<<< HEAD
-            @RequestBody LockerExpiredAtRequestDto lockerExpiredAtRequestDto,
+            @Valid @RequestBody LockerExpiredAtRequestDto lockerExpiredAtRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
-=======
-            @Valid @RequestBody LockerExpiredAtRequestDto lockerExpiredAtRequestDto
->>>>>>> acda2f5 (refactor: Locker 관련 dto에 Valid 적용)
     ) {
         this.lockerService.setExpireAt(userDetails.getUser(), lockerExpiredAtRequestDto);
     }

--- a/src/main/java/net/causw/adapter/web/PostController.java
+++ b/src/main/java/net/causw/adapter/web/PostController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import net.causw.adapter.persistence.post.Post;
 import net.causw.application.post.PostService;
 import net.causw.application.dto.post.BoardPostsResponseDto;
 import net.causw.application.dto.post.PostCreateRequestDto;
@@ -158,12 +159,8 @@ public class PostController {
             @ApiResponse(responseCode = "4107", description = "사용자가 해당 동아리의 동아리장이 아닙니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class)))
     })
     public PostResponseDto createPost(
-<<<<<<< HEAD
-            @RequestBody PostCreateRequestDto postCreateRequestDto,
+            @Valid @RequestBody PostCreateRequestDto postCreateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
-=======
-            @Valid @RequestBody PostCreateRequestDto postCreateRequestDto
->>>>>>> 2251d02 (refactor: Post 관련 dto에 Valid 적용)
     ) {
         return this.postService.createPost(userDetails.getUser(), postCreateRequestDto);
     }
@@ -227,14 +224,9 @@ public class PostController {
             @ApiResponse(responseCode = "5000", description = "Post id checked, but exception occurred", content = @Content(mediaType = "application/json", schema = @Schema(implementation = InternalServerException.class)))
     })
     public PostResponseDto updatePost(
-<<<<<<< HEAD
             @PathVariable("id") String id,
-            @RequestBody PostUpdateRequestDto postUpdateRequestDto,
+            @Valid @RequestBody PostUpdateRequestDto postUpdateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
-=======
-            @PathVariable String id,
-            @Valid @RequestBody PostUpdateRequestDto postUpdateRequestDto
->>>>>>> 2251d02 (refactor: Post 관련 dto에 Valid 적용)
     ) {
 
         return this.postService.updatePost(

--- a/src/main/java/net/causw/adapter/web/PostController.java
+++ b/src/main/java/net/causw/adapter/web/PostController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import net.causw.application.post.PostService;
 import net.causw.application.dto.post.BoardPostsResponseDto;
@@ -157,8 +158,12 @@ public class PostController {
             @ApiResponse(responseCode = "4107", description = "사용자가 해당 동아리의 동아리장이 아닙니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class)))
     })
     public PostResponseDto createPost(
+<<<<<<< HEAD
             @RequestBody PostCreateRequestDto postCreateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
+=======
+            @Valid @RequestBody PostCreateRequestDto postCreateRequestDto
+>>>>>>> 2251d02 (refactor: Post 관련 dto에 Valid 적용)
     ) {
         return this.postService.createPost(userDetails.getUser(), postCreateRequestDto);
     }
@@ -222,9 +227,14 @@ public class PostController {
             @ApiResponse(responseCode = "5000", description = "Post id checked, but exception occurred", content = @Content(mediaType = "application/json", schema = @Schema(implementation = InternalServerException.class)))
     })
     public PostResponseDto updatePost(
+<<<<<<< HEAD
             @PathVariable("id") String id,
             @RequestBody PostUpdateRequestDto postUpdateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
+=======
+            @PathVariable String id,
+            @Valid @RequestBody PostUpdateRequestDto postUpdateRequestDto
+>>>>>>> 2251d02 (refactor: Post 관련 dto에 Valid 적용)
     ) {
 
         return this.postService.updatePost(

--- a/src/main/java/net/causw/adapter/web/UserController.java
+++ b/src/main/java/net/causw/adapter/web/UserController.java
@@ -16,6 +16,7 @@ import net.causw.domain.exceptions.BadRequestException;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -154,13 +155,9 @@ public class UserController {
             @ApiResponse(responseCode = "4003", description = "비밀번호 형식이 잘못되었습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
             @ApiResponse(responseCode = "4003", description = "입학년도를 다시 확인해주세요.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
     })
-<<<<<<< HEAD
     public UserResponseDto signUp(
-            @RequestBody UserCreateRequestDto userCreateDto
+            @Valid @RequestBody UserCreateRequestDto userCreateDto
     ) {
-=======
-    public UserResponseDto signUp(@Valid @RequestBody UserCreateRequestDto userCreateDto) {
->>>>>>> fd3bc17 (refactor: User 관련 dto에 Valid 적용)
         return this.userService.signUp(userCreateDto);
     }
 
@@ -222,19 +219,12 @@ public class UserController {
             @ApiResponse(responseCode = "4003", description = "입학년도를 다시 확인해주세요.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
             @ApiResponse(responseCode = "5000", description = "User id checked, but exception occurred", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
     })
-<<<<<<< HEAD
     public UserResponseDto update(
-            @RequestBody UserUpdateRequestDto userUpdateDto,
+            @Valid @RequestBody UserUpdateRequestDto userUpdateDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
 
         return this.userService.update(userDetails.getUser(), userUpdateDto);
-=======
-    public UserResponseDto update(@Valid @RequestBody UserUpdateRequestDto userUpdateDto) {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String loginUserId = ((String) principal);
-        return this.userService.update(loginUserId, userUpdateDto);
->>>>>>> fd3bc17 (refactor: User 관련 dto에 Valid 적용)
     }
 
     /**
@@ -263,30 +253,15 @@ public class UserController {
             @ApiResponse(responseCode = "5000", description = "동문회장이 존재하지 않습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
             @ApiResponse(responseCode = "5001", description = "User id checked, but exception occurred", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
     })
-<<<<<<< HEAD
     public UserResponseDto updateRole(
             @PathVariable("granteeId") String granteeId,
-            @RequestBody UserUpdateRoleRequestDto userUpdateRoleRequestDto,
+            @Valid @RequestBody UserUpdateRoleRequestDto userUpdateRoleRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
 
         return this.userService.updateUserRole(userDetails.getUser(), granteeId, userUpdateRoleRequestDto);
     }
 
-
-=======
-    public UserResponseDto updateRole(@PathVariable String granteeId, @Valid @RequestBody UserUpdateRoleRequestDto userUpdateRoleRequestDto) {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String loginUserId = ((String) principal);
-        return this.userService.updateUserRole(loginUserId, granteeId, userUpdateRoleRequestDto);
-    }
-
-    /**
-     * 비밀번호 찾기 API
-     * @param userFindPasswordRequestDto
-     * @return
-     */
->>>>>>> fd3bc17 (refactor: User 관련 dto에 Valid 적용)
     @PutMapping(value = "/password/find")
     @ResponseStatus(value = HttpStatus.OK)
     @Operation(summary = "비밀번호 찾기 API (완료)", description = "비밀번호 재설정 이메일 전송 API입니다.")
@@ -297,18 +272,11 @@ public class UserController {
     @PutMapping(value = "/password")
     @ResponseStatus(value = HttpStatus.OK)
     @Operation(summary = "비밀번호 업데이트 API (완료)")
-<<<<<<< HEAD
     public UserResponseDto updatePassword(
-            @RequestBody UserUpdatePasswordRequestDto userUpdatePasswordRequestDto,
+            @Valid @RequestBody UserUpdatePasswordRequestDto userUpdatePasswordRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         return this.userService.updatePassword(userDetails.getUser(), userUpdatePasswordRequestDto);
-=======
-    public UserResponseDto updatePassword(@Valid @RequestBody UserUpdatePasswordRequestDto userUpdatePasswordRequestDto) {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String loginUserId = ((String) principal);
-        return this.userService.updatePassword(loginUserId, userUpdatePasswordRequestDto);
->>>>>>> fd3bc17 (refactor: User 관련 dto에 Valid 적용)
     }
 
     /**

--- a/src/main/java/net/causw/adapter/web/UserController.java
+++ b/src/main/java/net/causw/adapter/web/UserController.java
@@ -223,7 +223,6 @@ public class UserController {
             @Valid @RequestBody UserUpdateRequestDto userUpdateDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-
         return this.userService.update(userDetails.getUser(), userUpdateDto);
     }
 

--- a/src/main/java/net/causw/adapter/web/UserController.java
+++ b/src/main/java/net/causw/adapter/web/UserController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import net.causw.application.dto.user.*;
 import net.causw.application.user.UserService;
@@ -153,9 +154,13 @@ public class UserController {
             @ApiResponse(responseCode = "4003", description = "비밀번호 형식이 잘못되었습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
             @ApiResponse(responseCode = "4003", description = "입학년도를 다시 확인해주세요.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
     })
+<<<<<<< HEAD
     public UserResponseDto signUp(
             @RequestBody UserCreateRequestDto userCreateDto
     ) {
+=======
+    public UserResponseDto signUp(@Valid @RequestBody UserCreateRequestDto userCreateDto) {
+>>>>>>> fd3bc17 (refactor: User 관련 dto에 Valid 적용)
         return this.userService.signUp(userCreateDto);
     }
 
@@ -177,7 +182,7 @@ public class UserController {
             @ApiResponse(responseCode = "4104", description = "대기 중인 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
             @ApiResponse(responseCode = "4109", description = "가입이 거절된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
     })
-    public UserSignInResponseDto signIn(@RequestBody UserSignInRequestDto userSignInRequestDto) {
+    public UserSignInResponseDto signIn(@Valid @RequestBody UserSignInRequestDto userSignInRequestDto) {
         return this.userService.signIn(userSignInRequestDto);
     }
 
@@ -217,12 +222,19 @@ public class UserController {
             @ApiResponse(responseCode = "4003", description = "입학년도를 다시 확인해주세요.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
             @ApiResponse(responseCode = "5000", description = "User id checked, but exception occurred", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
     })
+<<<<<<< HEAD
     public UserResponseDto update(
             @RequestBody UserUpdateRequestDto userUpdateDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
 
         return this.userService.update(userDetails.getUser(), userUpdateDto);
+=======
+    public UserResponseDto update(@Valid @RequestBody UserUpdateRequestDto userUpdateDto) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String loginUserId = ((String) principal);
+        return this.userService.update(loginUserId, userUpdateDto);
+>>>>>>> fd3bc17 (refactor: User 관련 dto에 Valid 적용)
     }
 
     /**
@@ -251,6 +263,7 @@ public class UserController {
             @ApiResponse(responseCode = "5000", description = "동문회장이 존재하지 않습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
             @ApiResponse(responseCode = "5001", description = "User id checked, but exception occurred", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
     })
+<<<<<<< HEAD
     public UserResponseDto updateRole(
             @PathVariable("granteeId") String granteeId,
             @RequestBody UserUpdateRoleRequestDto userUpdateRoleRequestDto,
@@ -261,21 +274,41 @@ public class UserController {
     }
 
 
+=======
+    public UserResponseDto updateRole(@PathVariable String granteeId, @Valid @RequestBody UserUpdateRoleRequestDto userUpdateRoleRequestDto) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String loginUserId = ((String) principal);
+        return this.userService.updateUserRole(loginUserId, granteeId, userUpdateRoleRequestDto);
+    }
+
+    /**
+     * 비밀번호 찾기 API
+     * @param userFindPasswordRequestDto
+     * @return
+     */
+>>>>>>> fd3bc17 (refactor: User 관련 dto에 Valid 적용)
     @PutMapping(value = "/password/find")
     @ResponseStatus(value = HttpStatus.OK)
     @Operation(summary = "비밀번호 찾기 API (완료)", description = "비밀번호 재설정 이메일 전송 API입니다.")
-    public UserResponseDto findPassword(@RequestBody UserFindPasswordRequestDto userFindPasswordRequestDto) {
+    public UserResponseDto findPassword(@Valid @RequestBody UserFindPasswordRequestDto userFindPasswordRequestDto) {
         return this.userService.findPassword(userFindPasswordRequestDto);
     }
 
     @PutMapping(value = "/password")
     @ResponseStatus(value = HttpStatus.OK)
     @Operation(summary = "비밀번호 업데이트 API (완료)")
+<<<<<<< HEAD
     public UserResponseDto updatePassword(
             @RequestBody UserUpdatePasswordRequestDto userUpdatePasswordRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         return this.userService.updatePassword(userDetails.getUser(), userUpdatePasswordRequestDto);
+=======
+    public UserResponseDto updatePassword(@Valid @RequestBody UserUpdatePasswordRequestDto userUpdatePasswordRequestDto) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String loginUserId = ((String) principal);
+        return this.userService.updatePassword(loginUserId, userUpdatePasswordRequestDto);
+>>>>>>> fd3bc17 (refactor: User 관련 dto에 Valid 적용)
     }
 
     /**
@@ -351,7 +384,7 @@ public class UserController {
             @ApiResponse(responseCode = "4107", description = "이미 등록된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
     })
     public UserAdmissionResponseDto createAdmission(
-            @ModelAttribute UserAdmissionCreateRequestDto userAdmissionCreateRequestDto
+            @Valid @ModelAttribute UserAdmissionCreateRequestDto userAdmissionCreateRequestDto
     ) {
         return this.userService.createAdmission(userAdmissionCreateRequestDto);
     }

--- a/src/main/java/net/causw/adapter/web/UserController.java
+++ b/src/main/java/net/causw/adapter/web/UserController.java
@@ -257,7 +257,6 @@ public class UserController {
             @Valid @RequestBody UserUpdateRoleRequestDto userUpdateRoleRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-
         return this.userService.updateUserRole(userDetails.getUser(), granteeId, userUpdateRoleRequestDto);
     }
 

--- a/src/main/java/net/causw/application/circle/CircleService.java
+++ b/src/main/java/net/causw/application/circle/CircleService.java
@@ -12,7 +12,6 @@ import net.causw.application.dto.circle.*;
 import net.causw.application.dto.duplicate.DuplicatedCheckResponseDto;
 import net.causw.application.dto.user.UserResponseDto;
 import net.causw.application.dto.util.CircleServiceDtoMapper;
-import net.causw.application.dto.util.DtoMapper;
 import net.causw.application.dto.util.StatusUtil;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
@@ -45,9 +44,10 @@ public class CircleService {
     private final PostRepository postRepository;
 
     @Transactional(readOnly = true)
-    public CircleResponseDto findById(String circleId) {
+    public CircleResponseDto findById(
+            String circleId
+    ) {
         Circle circle = getCircle(circleId);
-
         initializeValidator(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE).validate();
 
         return this.toCircleResponseDtoExtended(circle, getCircleNumMember(circleId));
@@ -58,7 +58,6 @@ public class CircleService {
         Set<Role> roles = user.getRoles();
 
         initializeUserValidator(user.getState(), roles).validate();
-
         Map<String, CircleMember> joinedCircleMap = circleMemberRepository.findByUser_Id(user.getId())
                 .stream()
                 .filter(circleMember -> circleMember.getStatus().equals(CircleMemberStatus.MEMBER))
@@ -114,7 +113,6 @@ public class CircleService {
                             MessageUtil.CIRCLE_APPLY_INVALID
                     )
             );
-
             ValidatorBucket.of()
                     .consistOf(CircleMemberStatusValidator.of(
                             circleMember.getStatus(),
@@ -122,7 +120,6 @@ public class CircleService {
                     ))
                     .validate();
         }
-
         return this.toCircleBoardsResponseDto(
                 circle,
                 getCircleNumMember(circleId),
@@ -144,7 +141,9 @@ public class CircleService {
     }
 
     @Transactional(readOnly = true)
-    public Long getNumMember(String id) {
+    public Long getNumMember(
+            String id
+    ) {
         return getCircleNumMember(getCircle(id).getId());
     }
 
@@ -155,9 +154,7 @@ public class CircleService {
             CircleMemberStatus status
     ) {
         Set<Role> roles = user.getRoles();
-
         Circle circle = getCircle(circleId);
-
         User circleLeader = getCircleLeader(circle);
 
         ValidatorBucket.of()
@@ -187,7 +184,6 @@ public class CircleService {
     @Transactional
     public CircleResponseDto create(User requestUser, CircleCreateRequestDto circleCreateRequestDto) {
         Set<Role> roles = requestUser.getRoles();
-
         User leader = userRepository.findById(circleCreateRequestDto.getLeaderId())
                 .orElseThrow(() -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
@@ -360,7 +356,6 @@ public class CircleService {
                         MessageUtil.INTERNAL_SERVER_ERROR
                 )
         ));
-
         deleteAllCircleBoard(circleId);
 
         return circleResponseDto;
@@ -398,7 +393,9 @@ public class CircleService {
     }
 
     @Transactional(readOnly = true)
-    public DuplicatedCheckResponseDto isDuplicatedName(String name) {
+    public DuplicatedCheckResponseDto isDuplicatedName(
+            String name
+    ) {
         return this.toDuplicatedCheckResponseDto(circleRepository.findByName(name).isPresent());
     }
 
@@ -445,9 +442,7 @@ public class CircleService {
         Set<Role> roles = requestUser.getRoles();
 
         User user = getUser(userId);
-
         Circle circle = getCircle(circleId);
-
         CircleMember circleMember = circleMemberRepository.findByUser_IdAndCircle_Id(userId, circleId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
@@ -519,7 +514,6 @@ public class CircleService {
                         MessageUtil.USER_APPLY_NOT_FOUND
                 )
         );
-
         User user = getUser(circleMember.getUser().getId());
 
         ValidatorBucket validatorBucket = ValidatorBucket.of();
@@ -556,9 +550,7 @@ public class CircleService {
         Set<Role> roles = loginUser.getRoles();
 
         User targetUser = getUser(targetUserId);
-
         Circle circle = getCircle(circleId);
-
         CircleMember restoreTargetMember = circleMemberRepository.findByUser_IdAndCircle_Id(targetUserId, circleId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,

--- a/src/main/java/net/causw/application/circle/CircleService.java
+++ b/src/main/java/net/causw/application/circle/CircleService.java
@@ -190,13 +190,8 @@ public class CircleService {
                 }
         );
 
-        // user Role이 Common이 아니면 아예 안 됨. -> 권한의 중첩이 필요하다. User Role에 대한 새로운 table 생성 어떤지?
-        // https://www.inflearn.com/questions/21303/enum%EC%9D%84-list%EB%A1%9C-%EC%96%B4%EB%96%BB%EA%B2%8C-%EB%B0%9B%EB%8A%94%EC%A7%80-%EA%B6%81%EA%B8%88%ED%95%A9%EB%8B%88%EB%8B%A4
-        // User Role Table 분리 필요하다고 봅니다...
-        ValidatorBucket.of()
-                .consistOf(ConstraintValidator.of(circle, this.validator))
-//                .consistOf(GrantableRoleValidator.of(roles, Role.LEADER_CIRCLE, leader.getRoles()))
-                .validate();
+        new GrantableRoleValidator().validate(roles, Role.LEADER_CIRCLE, leader.getRoles());
+        new ConstraintValidator<Circle>().validate(circle, validator);
 
         // Grant role to the LEADER
         leader = updateRole(leader, Role.LEADER_CIRCLE);
@@ -263,10 +258,8 @@ public class CircleService {
                 circleUpdateRequestDto.getDescription()
         );
 
-        ValidatorBucket validatorBucket = ValidatorBucket.of();
-        validatorBucket
-                .consistOf(ConstraintValidator.of(circle, this.validator));
         new TargetIsDeletedValidator().validate(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE);
+        new ConstraintValidator<Circle>().validate(circle, validator);
 
         return this.toCircleResponseDto(updateCircle(circleId, circle));
     }

--- a/src/main/java/net/causw/application/circle/CircleService.java
+++ b/src/main/java/net/causw/application/circle/CircleService.java
@@ -302,16 +302,16 @@ public class CircleService {
     }
 
     @Transactional
-    public CircleMemberResponseDto userApply(@UserValid User user, String circleId) {
+    public CircleMemberResponseDto userApply(@UserValid(StudentIsNullValidator = true) User user, String circleId) {
         Circle circle = getCircle(circleId);
 
         ValidatorBucket.of()
                 .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
-                .consistOf(StudentIdIsNullValidator.of(user.getStudentId()))
                 .validate();
 
         CircleMember circleMember = serviceProxy.getCircleMemberOrCreate(user, circle, List.of(CircleMemberStatus.LEAVE, CircleMemberStatus.REJECT));
         updateCircleMemberStatus(circleMember.getId(), CircleMemberStatus.AWAIT);
+        circleMemberRepository.save(circleMember);
 
         return this.toCircleMemberResponseDto(
                 circleMember,

--- a/src/main/java/net/causw/application/dto/board/BoardCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/board/BoardCreateRequestDto.java
@@ -2,6 +2,7 @@ package net.causw.application.dto.board;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,7 +25,7 @@ public class BoardCreateRequestDto {
     private String description;
 
     @Schema(description = "게시판에 글을 작성할 수 있는 권한 명단", example = "[ 'ADMIN' ]")
-    @NotBlank(message = "게시판 글에 작성할 수 있는 권한 명단을 입력해 주세요.")
+    @NotEmpty(message = "게시판 글에 작성할 수 있는 권한 명단을 입력해 주세요.")
     private List<String> createRoleList;
 
     @Schema(description = "게시판 카테고리", example = "APP_NOTICE")

--- a/src/main/java/net/causw/application/dto/board/BoardCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/board/BoardCreateRequestDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.board;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,15 +17,18 @@ import java.util.Optional;
 public class BoardCreateRequestDto {
 
     @Schema(description = "게시판 이름", example = "board_name")
+    @NotNull(message = "게시판 이름은 필수 입력값입니다.")
     private String name;
 
     @Schema(description = "게시판 설명", example = "board_description")
     private String description;
 
     @Schema(description = "게시판에 글을 작성할 수 있는 권한 명단", example = "[ 'ADMIN' ]")
+    @NotNull(message = "게시판 글에 작성할 수 있는 권한 명단은 필수 입력값입니다.")
     private List<String> createRoleList;
 
     @Schema(description = "게시판 카테고리", example = "APP_NOTICE")
+    @NotNull(message = "게시판 카테고리는 필수 입력값입니다.")
     private String category;
 
     @Schema(description = "게시판이 속한 동아리 id", example = "uuid 형식의 String 값입니다(nullable).")

--- a/src/main/java/net/causw/application/dto/board/BoardCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/board/BoardCreateRequestDto.java
@@ -1,7 +1,7 @@
 package net.causw.application.dto.board;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,18 +17,18 @@ import java.util.Optional;
 public class BoardCreateRequestDto {
 
     @Schema(description = "게시판 이름", example = "board_name")
-    @NotNull(message = "게시판 이름은 필수 입력값입니다.")
+    @NotBlank(message = "게시판 이름을 입력해 주세요.")
     private String name;
 
     @Schema(description = "게시판 설명", example = "board_description")
     private String description;
 
     @Schema(description = "게시판에 글을 작성할 수 있는 권한 명단", example = "[ 'ADMIN' ]")
-    @NotNull(message = "게시판 글에 작성할 수 있는 권한 명단은 필수 입력값입니다.")
+    @NotBlank(message = "게시판 글에 작성할 수 있는 권한 명단을 입력해 주세요.")
     private List<String> createRoleList;
 
     @Schema(description = "게시판 카테고리", example = "APP_NOTICE")
-    @NotNull(message = "게시판 카테고리는 필수 입력값입니다.")
+    @NotBlank(message = "게시판 카테고리를 선택해 주세요.")
     private String category;
 
     @Schema(description = "게시판이 속한 동아리 id", example = "uuid 형식의 String 값입니다(nullable).")

--- a/src/main/java/net/causw/application/dto/board/BoardUpdateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/board/BoardUpdateRequestDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.board;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,14 +16,17 @@ import java.util.List;
 public class BoardUpdateRequestDto {
 
     @Schema(description = "게시판 이름", example = "board_example")
+    @NotBlank(message = "게시판 이름은 필수 입력값입니다.")
     private String name;
 
     @Schema(description = "게시판 설명", example = "board_description")
     private String description;
 
     @Schema(description = "게시판에 글을 작성할 수 있는 권한 명단", example = "[ 'ADMIN' ]")
+    @NotBlank(message = "게시판 글에 작성할 수 있는 권한 명단은 필수 입력값입니다.")
     private List<String> createRoleList;
 
     @Schema(description = "게시판 카테고리", example = "APP_NOTICE")
+    @NotBlank(message = "게시판 카테고리는 필수 입력값입니다.")
     private String category;
 }

--- a/src/main/java/net/causw/application/dto/board/BoardUpdateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/board/BoardUpdateRequestDto.java
@@ -2,6 +2,7 @@ package net.causw.application.dto.board;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,29 +17,17 @@ import java.util.List;
 public class BoardUpdateRequestDto {
 
     @Schema(description = "게시판 이름", example = "board_example")
-<<<<<<< HEAD
-    @NotBlank(message = "게시판 이름은 필수 입력값입니다.")
-=======
     @NotBlank(message = "게시판 이름을 입력해 주세요.")
->>>>>>> 8b8cf77 (refactor: @NotBlank로 변경)
     private String name;
 
     @Schema(description = "게시판 설명", example = "board_description")
     private String description;
 
     @Schema(description = "게시판에 글을 작성할 수 있는 권한 명단", example = "[ 'ADMIN' ]")
-<<<<<<< HEAD
-    @NotBlank(message = "게시판 글에 작성할 수 있는 권한 명단은 필수 입력값입니다.")
-    private List<String> createRoleList;
-
-    @Schema(description = "게시판 카테고리", example = "APP_NOTICE")
-    @NotBlank(message = "게시판 카테고리는 필수 입력값입니다.")
-=======
-    @NotBlank(message = "게시판 글에 작성할 수 있는 권한 명단을 입력해 주세요.")
+    @NotEmpty(message = "게시판 글에 작성할 수 있는 권한 명단을 입력해 주세요.")
     private List<String> createRoleList;
 
     @Schema(description = "게시판 카테고리", example = "APP_NOTICE")
     @NotBlank(message = "게시판 카테고리를 선택해 주세요.")
->>>>>>> 8b8cf77 (refactor: @NotBlank로 변경)
     private String category;
 }

--- a/src/main/java/net/causw/application/dto/board/BoardUpdateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/board/BoardUpdateRequestDto.java
@@ -16,17 +16,29 @@ import java.util.List;
 public class BoardUpdateRequestDto {
 
     @Schema(description = "게시판 이름", example = "board_example")
+<<<<<<< HEAD
     @NotBlank(message = "게시판 이름은 필수 입력값입니다.")
+=======
+    @NotBlank(message = "게시판 이름을 입력해 주세요.")
+>>>>>>> 8b8cf77 (refactor: @NotBlank로 변경)
     private String name;
 
     @Schema(description = "게시판 설명", example = "board_description")
     private String description;
 
     @Schema(description = "게시판에 글을 작성할 수 있는 권한 명단", example = "[ 'ADMIN' ]")
+<<<<<<< HEAD
     @NotBlank(message = "게시판 글에 작성할 수 있는 권한 명단은 필수 입력값입니다.")
     private List<String> createRoleList;
 
     @Schema(description = "게시판 카테고리", example = "APP_NOTICE")
     @NotBlank(message = "게시판 카테고리는 필수 입력값입니다.")
+=======
+    @NotBlank(message = "게시판 글에 작성할 수 있는 권한 명단을 입력해 주세요.")
+    private List<String> createRoleList;
+
+    @Schema(description = "게시판 카테고리", example = "APP_NOTICE")
+    @NotBlank(message = "게시판 카테고리를 선택해 주세요.")
+>>>>>>> 8b8cf77 (refactor: @NotBlank로 변경)
     private String category;
 }

--- a/src/main/java/net/causw/application/dto/circle/CircleCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/circle/CircleCreateRequestDto.java
@@ -14,7 +14,11 @@ import lombok.Setter;
 public class CircleCreateRequestDto {
 
     @Schema(description = "동아리 이름", example = "소프트웨어학부 특별기구 ICT위원회 동문네트워크")
+<<<<<<< HEAD
     @NotBlank(message = "동아리 이름은 필수 입력값입니다.")
+=======
+    @NotBlank(message = "동아리 이름을 입력해 주세요.")
+>>>>>>> 8b8cf77 (refactor: @NotBlank로 변경)
     private String name;
 
     @Schema(description = "동아리 메인 이미지, 없애기 가능(nullable)", example = "string")

--- a/src/main/java/net/causw/application/dto/circle/CircleCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/circle/CircleCreateRequestDto.java
@@ -14,11 +14,7 @@ import lombok.Setter;
 public class CircleCreateRequestDto {
 
     @Schema(description = "동아리 이름", example = "소프트웨어학부 특별기구 ICT위원회 동문네트워크")
-<<<<<<< HEAD
-    @NotBlank(message = "동아리 이름은 필수 입력값입니다.")
-=======
     @NotBlank(message = "동아리 이름을 입력해 주세요.")
->>>>>>> 8b8cf77 (refactor: @NotBlank로 변경)
     private String name;
 
     @Schema(description = "동아리 메인 이미지, 없애기 가능(nullable)", example = "string")

--- a/src/main/java/net/causw/application/dto/circle/CircleCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/circle/CircleCreateRequestDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.circle;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +14,7 @@ import lombok.Setter;
 public class CircleCreateRequestDto {
 
     @Schema(description = "동아리 이름", example = "소프트웨어학부 특별기구 ICT위원회 동문네트워크")
+    @NotBlank(message = "동아리 이름은 필수 입력값입니다.")
     private String name;
 
     @Schema(description = "동아리 메인 이미지, 없애기 가능(nullable)", example = "string")

--- a/src/main/java/net/causw/application/dto/circle/CircleUpdateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/circle/CircleUpdateRequestDto.java
@@ -10,7 +10,11 @@ import lombok.Setter;
 public class CircleUpdateRequestDto {
 
     @Schema(description = "동아리 이름", example = "소프트웨어학부 특별기구 ICT위원회 동문 네트워크")
+<<<<<<< HEAD
     @NotBlank(message = "동아리 이름은 필수 입력값입니다.")
+=======
+    @NotBlank(message = "동아리 이름을 입력해 주세요.")
+>>>>>>> 8b8cf77 (refactor: @NotBlank로 변경)
     private String name;
 
     @Schema(description = "동아리 메인 이미지(nullable)", example = "String")

--- a/src/main/java/net/causw/application/dto/circle/CircleUpdateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/circle/CircleUpdateRequestDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.circle;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,6 +10,7 @@ import lombok.Setter;
 public class CircleUpdateRequestDto {
 
     @Schema(description = "동아리 이름", example = "소프트웨어학부 특별기구 ICT위원회 동문 네트워크")
+    @NotBlank(message = "동아리 이름은 필수 입력값입니다.")
     private String name;
 
     @Schema(description = "동아리 메인 이미지(nullable)", example = "String")

--- a/src/main/java/net/causw/application/dto/circle/CircleUpdateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/circle/CircleUpdateRequestDto.java
@@ -10,11 +10,7 @@ import lombok.Setter;
 public class CircleUpdateRequestDto {
 
     @Schema(description = "동아리 이름", example = "소프트웨어학부 특별기구 ICT위원회 동문 네트워크")
-<<<<<<< HEAD
-    @NotBlank(message = "동아리 이름은 필수 입력값입니다.")
-=======
     @NotBlank(message = "동아리 이름을 입력해 주세요.")
->>>>>>> 8b8cf77 (refactor: @NotBlank로 변경)
     private String name;
 
     @Schema(description = "동아리 메인 이미지(nullable)", example = "String")

--- a/src/main/java/net/causw/application/dto/comment/ChildCommentCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/comment/ChildCommentCreateRequestDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.comment;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,9 +13,15 @@ import java.util.Optional;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ChildCommentCreateRequestDto {
+
+    @NotBlank(message = "대댓글 내용을 입력해 주세요.")
     private String content;
-    private String parentCommentId;
+
+    @NotBlank(message = "참고 대댓글을 선택해 주세요.")
     private String refChildComment;
+
+    @NotBlank(message = "부모 댓글을 선택해 주세요.")
+    private String parentCommentId;
 
     public Optional<String> getRefChildComment() {
         return Optional.ofNullable(this.refChildComment);

--- a/src/main/java/net/causw/application/dto/comment/ChildCommentUpdateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/comment/ChildCommentUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.comment;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,5 +11,6 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ChildCommentUpdateRequestDto {
+    @NotBlank(message = "대댓글 내용을 입력해 주세요.")
     private String content;
 }

--- a/src/main/java/net/causw/application/dto/comment/CommentCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/comment/CommentCreateRequestDto.java
@@ -15,6 +15,6 @@ public class CommentCreateRequestDto {
     @NotBlank(message = "댓글 내용을 입력해 주세요.")
     private String content;
 
-    @NotBlank
+    @NotBlank(message = "게시물 id를 입력해 주세요.")
     private String postId;
 }

--- a/src/main/java/net/causw/application/dto/comment/CommentCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/comment/CommentCreateRequestDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.comment;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,10 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class CommentCreateRequestDto {
+
+    @NotBlank(message = "댓글 내용을 입력해 주세요.")
     private String content;
+
+    @NotBlank
     private String postId;
 }

--- a/src/main/java/net/causw/application/dto/comment/CommentUpdateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/comment/CommentUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.comment;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,5 +11,6 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class CommentUpdateRequestDto {
+    @NotBlank(message = "댓글 내용을 입력해 주세요.")
     private String content;
 }

--- a/src/main/java/net/causw/application/dto/inquiry/InquiryCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/inquiry/InquiryCreateRequestDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.inquiry;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,8 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class InquiryCreateRequestDto {
+    @NotBlank(message = "설문 제목을 입력해 주세요.")
     private String title;
+    @NotBlank(message = "설문 내용을 입력해 주세요.")
     private String content;
 }

--- a/src/main/java/net/causw/application/dto/inquiry/InquiryResponseDto.java
+++ b/src/main/java/net/causw/application/dto/inquiry/InquiryResponseDto.java
@@ -3,9 +3,9 @@ package net.causw.application.dto.inquiry;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import net.causw.domain.model.inquiry.InquiryDomainModel;
+import net.causw.adapter.persistence.inquiry.Inquiry;
+import net.causw.adapter.persistence.user.User;
 import net.causw.domain.model.enums.Role;
-import net.causw.domain.model.user.UserDomainModel;
 
 import java.time.LocalDateTime;
 
@@ -24,8 +24,8 @@ public class InquiryResponseDto {
     private LocalDateTime updatedAt;
 
     public static InquiryResponseDto of(
-            InquiryDomainModel inquiry,
-            UserDomainModel user
+            Inquiry inquiry,
+            User user
     ){
         boolean updatable = false;
         boolean deletable = false;

--- a/src/main/java/net/causw/application/dto/locker/LockerCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/locker/LockerCreateRequestDto.java
@@ -13,6 +13,6 @@ import lombok.Setter;
 public class LockerCreateRequestDto {
     @NotBlank(message = "사물함 번호를 입력해 주세요.")
     private Long lockerNumber;
-    @NotBlank // 사물한 위치 id TODO
+    @NotBlank(message = "사물함 위치 id를 입력해 주세요.")
     private String lockerLocationId;
 }

--- a/src/main/java/net/causw/application/dto/locker/LockerCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/locker/LockerCreateRequestDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.locker;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +12,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class LockerCreateRequestDto {
-    @NotBlank(message = "사물함 번호를 입력해 주세요.")
+    @NotNull(message = "사물함 번호를 입력해 주세요.")
     private Long lockerNumber;
     @NotBlank(message = "사물함 위치 id를 입력해 주세요.")
     private String lockerLocationId;

--- a/src/main/java/net/causw/application/dto/locker/LockerCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/locker/LockerCreateRequestDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.locker;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,8 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class LockerCreateRequestDto {
+    @NotBlank(message = "사물함 번호를 입력해 주세요.")
     private Long lockerNumber;
+    @NotBlank // 사물한 위치 id TODO
     private String lockerLocationId;
 }

--- a/src/main/java/net/causw/application/dto/locker/LockerExpiredAtRequestDto.java
+++ b/src/main/java/net/causw/application/dto/locker/LockerExpiredAtRequestDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.locker;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +14,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 public class LockerExpiredAtRequestDto {
-    @Schema(description = "Expiration date and time", example = "2024-09-01T11:41", required = true)
+    @Schema(description = "Expiration date and time", example = "2024-09-01T11:41")
+    @NotBlank(message = "사용 만료일을 입력해 주세요.")
     private LocalDateTime expiredAt;
 }

--- a/src/main/java/net/causw/application/dto/locker/LockerLocationCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/locker/LockerLocationCreateRequestDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.locker;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,5 +11,6 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class LockerLocationCreateRequestDto {
+    @NotBlank(message = "사물함 위치 이름을 입력해 주세요.")
     private String name;
 }

--- a/src/main/java/net/causw/application/dto/locker/LockerLocationUpdateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/locker/LockerLocationUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.locker;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,5 +11,6 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class LockerLocationUpdateRequestDto {
+    @NotBlank(message = "사물함 위치 이름을 입력해 주세요.")
     private String name;
 }

--- a/src/main/java/net/causw/application/dto/locker/LockerMoveRequestDto.java
+++ b/src/main/java/net/causw/application/dto/locker/LockerMoveRequestDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.locker;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,5 +11,6 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class LockerMoveRequestDto {
+    @NotBlank // 사물함 위치 id
     private String locationId;
 }

--- a/src/main/java/net/causw/application/dto/locker/LockerMoveRequestDto.java
+++ b/src/main/java/net/causw/application/dto/locker/LockerMoveRequestDto.java
@@ -11,6 +11,6 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class LockerMoveRequestDto {
-    @NotBlank // 사물함 위치 id
+    @NotBlank(message = "사물함 위치 id를 입력해 주세요.")
     private String locationId;
 }

--- a/src/main/java/net/causw/application/dto/locker/LockerUpdateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/locker/LockerUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.locker;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,6 +16,7 @@ import java.util.Optional;
 public class LockerUpdateRequestDto {
 
     @Schema(description = "Action to perform on the locker", allowableValues = {"ENABLE", "DISABLE", "REGISTER", "RETURN", "EXTEND"}, example = "REGISTER")
+    @NotBlank(message = "활성화 여부를 선택해 주세요.")
     private String action;
 
     @Schema(description = "Message to be logged", example = "hi(자율)")

--- a/src/main/java/net/causw/application/dto/post/PostCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/post/PostCreateRequestDto.java
@@ -25,7 +25,7 @@ public class PostCreateRequestDto {
     private String content;
 
     @Schema(description = "게시판 id", example = "uuid 형식의 String 값입니다.")
-    @NotBlank // 게시판 id
+    @NotBlank(message = "게시판 id를 입력해 주세요.")
     private String boardId;
 
     @Schema(description = "첨부파일", example = "첨부파일 url 작성")

--- a/src/main/java/net/causw/application/dto/post/PostCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/post/PostCreateRequestDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.post;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,12 +17,15 @@ import java.util.Optional;
 public class PostCreateRequestDto {
 
     @Schema(description = "게시글 제목", example = "공지사항입니다.")
+    @NotBlank(message = "게시글 제목을 입력해 주세요.")
     private String title;
 
     @Schema(description = "게시글 내용", example = "안녕하세요. 학생회입니다. 공지사항입니다.")
+    @NotBlank(message = "게시글 내용을 입력해 주세요.")
     private String content;
 
     @Schema(description = "게시판 id", example = "uuid 형식의 String 값입니다.")
+    @NotBlank // 게시판 id
     private String boardId;
 
     @Schema(description = "첨부파일", example = "첨부파일 url 작성")

--- a/src/main/java/net/causw/application/dto/post/PostUpdateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/post/PostUpdateRequestDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.post;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,9 +17,11 @@ import java.util.Optional;
 public class PostUpdateRequestDto {
 
     @Schema(description = "게시글 제목", example = "게시글의 제목입니다.")
+    @NotBlank(message = "게시글 제목을 입력해 주세요.")
     private String title;
 
     @Schema(description = "게시글 내용", example = "게시글의 내용입니다.")
+    @NotBlank(message = "게시글 내용을 입력해 주세요.")
     private String content;
 
     @Schema(description = "첨부파일", example = "첨부파일 url 작성")

--- a/src/main/java/net/causw/application/dto/user/UserAdmissionCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserAdmissionCreateRequestDto.java
@@ -1,6 +1,8 @@
 package net.causw.application.dto.user;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,6 +18,8 @@ import java.util.Optional;
 public class UserAdmissionCreateRequestDto {
 
     @Schema(description = "이메일", example = "yebin@cau.ac.kr")
+    @Email(message = "이메일 형식에 맞지 않습니다.")
+    @NotBlank(message = "이메일을 입력해 주세요.")
     private String email;
 
     @Schema(description = "자기소개 글 (255자 이내)", example = "안녕하세요! 코딩을 좋아하는 신입생 이예빈입니다.")

--- a/src/main/java/net/causw/application/dto/user/UserCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserCreateRequestDto.java
@@ -41,12 +41,7 @@ public class UserCreateRequestDto {
 
     @Schema(description = "프로필 이미지 URL", example = "")
     private String profileImage;
-<<<<<<< HEAD
     public User toEntity(String encodedPassword, Set<Role> roles, UserState state) {
-=======
-
-    public User toEntity(String encodedPassword, Role role, UserState state) {
->>>>>>> fd3bc17 (refactor: User 관련 dto에 Valid 적용)
         return User.builder()
                 .email(email)
                 .name(name)

--- a/src/main/java/net/causw/application/dto/user/UserCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserCreateRequestDto.java
@@ -1,5 +1,8 @@
 package net.causw.application.dto.user;
+
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,24 +19,34 @@ import java.util.Set;
 @NoArgsConstructor
 public class UserCreateRequestDto {
 
-    @Schema(description = "이메일", example = "yebin@cau.ac.kr", required = true)
+    @Schema(description = "이메일", example = "yebin@cau.ac.kr")
+    @Email(message = "이메일 형식에 맞지 않습니다.")
+    @NotBlank(message = "이메일을 입력해 주세요.")
     private String email;
 
-    @Schema(description = "이름", example = "이예빈", required = true)
+    @Schema(description = "이름", example = "이예빈")
+    @NotBlank(message = "이름을 입력해 주세요.")
     private String name;
 
-    @Schema(description = "비밀번호", example = "password00!!", required = true)
+    @Schema(description = "비밀번호", example = "password00!!")
+    @NotBlank(message = "비밀번호를 입력해 주세요.")
     private String password;
 
-    @Schema(description = "학번", example = "20209999", required = true)
+    @Schema(description = "학번", example = "20209999")
     private String studentId;
 
-    @Schema(description = "입학년도", example = "2020", required = true)
+    @Schema(description = "입학년도", example = "2020")
+    @NotBlank(message = "입학 년도를 입력해 주세요.")
     private Integer admissionYear;
 
-    @Schema(description = "프로필 이미지 URL", example = "", required = true)
+    @Schema(description = "프로필 이미지 URL", example = "")
     private String profileImage;
+<<<<<<< HEAD
     public User toEntity(String encodedPassword, Set<Role> roles, UserState state) {
+=======
+
+    public User toEntity(String encodedPassword, Role role, UserState state) {
+>>>>>>> fd3bc17 (refactor: User 관련 dto에 Valid 적용)
         return User.builder()
                 .email(email)
                 .name(name)

--- a/src/main/java/net/causw/application/dto/user/UserCreateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserCreateRequestDto.java
@@ -3,6 +3,7 @@ package net.causw.application.dto.user;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,7 +37,7 @@ public class UserCreateRequestDto {
     private String studentId;
 
     @Schema(description = "입학년도", example = "2020")
-    @NotBlank(message = "입학 년도를 입력해 주세요.")
+    @NotNull(message = "입학 년도를 입력해 주세요.")
     private Integer admissionYear;
 
     @Schema(description = "프로필 이미지 URL", example = "")

--- a/src/main/java/net/causw/application/dto/user/UserFindPasswordRequestDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserFindPasswordRequestDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.user;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,6 +12,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserFindPasswordRequestDto {
+    @Email(message = "이메일 형식에 맞지 않습니다.")
     @NotBlank(message = "이메일을 입력해 주세요.")
     private String email;
     @NotBlank(message = "이름을 입력해 주세요.")

--- a/src/main/java/net/causw/application/dto/user/UserFindPasswordRequestDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserFindPasswordRequestDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.user;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +11,10 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserFindPasswordRequestDto {
+    @NotBlank(message = "이메일을 입력해 주세요.")
     private String email;
+    @NotBlank(message = "이름을 입력해 주세요.")
     private String name;
+    @NotBlank(message = "학번을 입력해 주세요.")
     private String studentId;
 }

--- a/src/main/java/net/causw/application/dto/user/UserSignInRequestDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserSignInRequestDto.java
@@ -1,6 +1,8 @@
 package net.causw.application.dto.user;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,8 +15,11 @@ import lombok.Setter;
 public class UserSignInRequestDto {
 
     @Schema(description = "이메일", example = "yebin@cau.ac.kr")
+    @Email(message = "이메일 형식에 맞지 않습니다.")
+    @NotBlank(message = "이메일을 입력해 주세요.")
     private String email;
 
     @Schema(description = "비밀번호", example = "password00!!")
+    @NotBlank(message = "비밀번호를 입력해 주세요.")
     private String password;
 }

--- a/src/main/java/net/causw/application/dto/user/UserUpdatePasswordRequestDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserUpdatePasswordRequestDto.java
@@ -1,5 +1,6 @@
 package net.causw.application.dto.user;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,8 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserUpdatePasswordRequestDto {
+    @NotBlank(message = "기존 비밀번호를 입력해 주세요.")
     private String originPassword;
+    @NotBlank(message = "새로운 비밀번호를 입력해 주세요.")
     private String updatedPassword;
 }

--- a/src/main/java/net/causw/application/dto/user/UserUpdateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserUpdateRequestDto.java
@@ -1,6 +1,9 @@
 package net.causw.application.dto.user;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,15 +16,20 @@ import lombok.Setter;
 public class UserUpdateRequestDto {
 
     @Schema(description = "이메일", example = "yebin@cau.ac.kr")
+    @Email(message = "이메일 형식에 맞지 않습니다.")
+    @NotBlank(message = "이메일을 입력해 주세요.")
     private String email;
 
     @Schema(description = "이름", example = "이에빈")
+    @NotBlank(message = "이름을 입력해 주세요.")
     private String name;
 
     @Schema(description = "학번", example = "20209999")
+    @NotBlank(message = "학번을 입력해 주세요.")
     private String studentId;
 
     @Schema(description = "입학년도", example = "2020")
+    @NotBlank(message = "입학 년도를 입력해 주세요.")
     private Integer admissionYear;
 
     @Schema(description = "프로필 이미지 URL", example = "")

--- a/src/main/java/net/causw/application/dto/user/UserUpdateRequestDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserUpdateRequestDto.java
@@ -29,7 +29,7 @@ public class UserUpdateRequestDto {
     private String studentId;
 
     @Schema(description = "입학년도", example = "2020")
-    @NotBlank(message = "입학 년도를 입력해 주세요.")
+    @NotNull(message = "입학 년도를 입력해 주세요.")
     private Integer admissionYear;
 
     @Schema(description = "프로필 이미지 URL", example = "")

--- a/src/main/java/net/causw/application/dto/user/UserUpdateRoleRequestDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserUpdateRoleRequestDto.java
@@ -21,7 +21,7 @@ public class UserUpdateRoleRequestDto {
     private String role;
 
     @Schema(description = "동아리 고유 id값", example = "uuid 형식의 String 값입니다.")
-    @NotBlank // 동아리 id
+    @NotBlank(message = "동아리 id를 입력해 주세요.")
     private String circleId;
 
     public Role getRole() {

--- a/src/main/java/net/causw/application/dto/user/UserUpdateRoleRequestDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserUpdateRoleRequestDto.java
@@ -1,6 +1,7 @@
 package net.causw.application.dto.user;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,9 +17,11 @@ import java.util.Optional;
 public class UserUpdateRoleRequestDto {
 
     @Schema(description = "역할", example = "COMMON")
+    @NotBlank(message = "역할을 선택해 주세요.")
     private String role;
 
     @Schema(description = "동아리 고유 id값", example = "uuid 형식의 String 값입니다.")
+    @NotBlank // 동아리 id
     private String circleId;
 
     public Role getRole() {

--- a/src/main/java/net/causw/application/homepage/HomePageService.java
+++ b/src/main/java/net/causw/application/homepage/HomePageService.java
@@ -6,7 +6,6 @@ import net.causw.adapter.persistence.circle.Circle;
 import net.causw.adapter.persistence.page.PageableFactory;
 import net.causw.adapter.persistence.repository.BoardRepository;
 import net.causw.adapter.persistence.repository.PostRepository;
-import net.causw.adapter.persistence.repository.UserRepository;
 import net.causw.adapter.persistence.user.User;
 import net.causw.application.dto.homepage.HomePageResponseDto;
 import net.causw.application.dto.board.BoardResponseDto;
@@ -16,9 +15,7 @@ import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.model.enums.Role;
 import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
-import net.causw.domain.validation.UserRoleIsNoneValidator;
-import net.causw.domain.validation.UserStateValidator;
-import net.causw.domain.validation.ValidatorBucket;
+import net.causw.domain.validation.valid.UserValid;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -28,18 +25,12 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class HomePageService {
 
-    private final UserRepository userRepository;
     private final PostRepository postRepository;
     private final BoardRepository boardRepository;
     private final PageableFactory pageableFactory;
 
-    public List<HomePageResponseDto> getHomePage(User user) {
+    public List<HomePageResponseDto> getHomePage(@UserValid User user) {
         Set<Role> roles = user.getRoles();
-
-        ValidatorBucket.of()
-                .consistOf(UserStateValidator.of(user.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(roles))
-                .validate();
 
         List<Board> boards = boardRepository.findByCircle_IdIsNullAndIsDeletedOrderByCreatedAtAsc(false);
         if (boards.isEmpty()) {

--- a/src/main/java/net/causw/application/inquiry/InquiryService.java
+++ b/src/main/java/net/causw/application/inquiry/InquiryService.java
@@ -50,10 +50,10 @@ public class InquiryService {
                 )
         );
 
-        validatorBucket
-                .consistOf(UserStateValidator.of(userDomainModel.getState()))
-                .consistOf(UserRoleIsNoneValidator.of(userDomainModel.getRoles()))
-                .consistOf(TargetIsDeletedValidator.of(inquiryDomainModel.getIsDeleted(), StaticValue.DOMAIN_INQUIRY));
+//        validatorBucket
+//                .consistOf(UserStateValidator.of(userDomainModel.getState()))
+//                .consistOf(UserRoleIsNoneValidator.of(userDomainModel.getRoles()))
+//                .consistOf(TargetIsDeletedValidator.of(inquiryDomainModel.getIsDeleted(), StaticValue.DOMAIN_INQUIRY));
 
         validatorBucket
                 .validate();
@@ -88,6 +88,7 @@ public class InquiryService {
         validatorBucket
                 .consistOf(ConstraintValidator.of(inquiryDomainModel, this.validator))
                 .validate();
+
 
         return InquiryResponseDto.of(
                 this.inquiryPort.create(inquiryDomainModel),

--- a/src/main/java/net/causw/application/locker/LockerAction.java
+++ b/src/main/java/net/causw/application/locker/LockerAction.java
@@ -7,7 +7,7 @@ import net.causw.application.common.CommonService;
 import java.util.Optional;
 
 public interface LockerAction {
-    Optional<Locker> updateLockerDomainModel(
+    Optional<Locker> updateLocker(
             Locker locker,
             User user,
             LockerService lockerService,

--- a/src/main/java/net/causw/application/locker/LockerActionDisable.java
+++ b/src/main/java/net/causw/application/locker/LockerActionDisable.java
@@ -16,16 +16,13 @@ import java.util.Set;
 @NoArgsConstructor
 public class LockerActionDisable implements LockerAction {
     @Override
-    public Optional<Locker> updateLockerDomainModel(
+    public Optional<Locker> updateLocker(
             Locker locker,
             User user,
             LockerService lockerService,
             CommonService commonService
     ) {
-        ValidatorBucket.of()
-                .consistOf(UserRoleValidator.of(user.getRoles(), Set.of()))
-                .consistOf(LockerIsDeactivatedValidator.of(locker.getIsActive()))
-                .validate();
+        new LockerIsDeactivatedValidator().validate(locker.getIsActive());
 
         locker.deactivate();
         return Optional.of(locker);

--- a/src/main/java/net/causw/application/locker/LockerActionEnable.java
+++ b/src/main/java/net/causw/application/locker/LockerActionEnable.java
@@ -4,31 +4,21 @@ import lombok.NoArgsConstructor;
 import net.causw.adapter.persistence.locker.Locker;
 import net.causw.adapter.persistence.user.User;
 import net.causw.application.common.CommonService;
-import net.causw.domain.model.enums.Role;
 import net.causw.domain.validation.LockerIsActiveValidator;
-import net.causw.domain.validation.UserRoleValidator;
-import net.causw.domain.validation.ValidatorBucket;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 @NoArgsConstructor
 public class LockerActionEnable implements LockerAction {
     @Override
-    public Optional<Locker> updateLockerDomainModel(
+    public Optional<Locker> updateLocker(
             Locker locker,
             User user,
             LockerService lockerService,
             CommonService commonService
     ) {
-        ValidatorBucket.of()
-                .consistOf(UserRoleValidator.of(user.getRoles(), Set.of()))
-                .consistOf(LockerIsActiveValidator.of(locker.getIsActive()))
-                .validate();
-
+        new LockerIsActiveValidator().validate(locker.getIsActive());
         locker.activate();
-
         return Optional.of(locker);
     }
 }

--- a/src/main/java/net/causw/application/locker/LockerActionExtend.java
+++ b/src/main/java/net/causw/application/locker/LockerActionExtend.java
@@ -23,7 +23,7 @@ import java.util.Set;
 @NoArgsConstructor
 public class LockerActionExtend implements LockerAction {
     @Override
-    public Optional<Locker> updateLockerDomainModel(
+    public Optional<Locker> updateLocker(
             Locker locker,
             User user,
             LockerService lockerService,
@@ -37,9 +37,7 @@ public class LockerActionExtend implements LockerAction {
         }
 
         if (!user.getId().equals(locker.getUser().get().getId()))
-            ValidatorBucket.of()
-                    .consistOf(UserRoleValidator.of(user.getRoles(), Set.of()))
-                    .validate();
+            new UserRoleValidator().validate(user.getRoles(), Set.of());
 
         LocalDateTime expiredAtToExtend = LocalDateTime.parse(commonService.findByKeyInTextField(StaticValue.EXPIRED_AT).orElseThrow(
                 () -> new InternalServerException(
@@ -49,12 +47,7 @@ public class LockerActionExtend implements LockerAction {
         ), DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"));
 
         Optional.ofNullable(locker.getExpireDate()).ifPresent(expiredAt ->
-                ValidatorBucket.of()
-                        .consistOf(ExtendLockerExpiredAtValidator.of(
-                                expiredAt,
-                                expiredAtToExtend))
-                        .validate());
-
+                new ExtendLockerExpiredAtValidator().validate(expiredAt, expiredAtToExtend));
 
         locker.extendExpireDate(expiredAtToExtend);
 

--- a/src/main/java/net/causw/application/locker/LockerActionReturn.java
+++ b/src/main/java/net/causw/application/locker/LockerActionReturn.java
@@ -18,7 +18,7 @@ import java.util.Set;
 @NoArgsConstructor
 public class LockerActionReturn implements LockerAction {
     @Override
-    public Optional<Locker> updateLockerDomainModel(
+    public Optional<Locker> updateLocker(
             Locker locker,
             User user,
             LockerService lockerService,
@@ -32,9 +32,7 @@ public class LockerActionReturn implements LockerAction {
         }
 
         if (!user.getId().equals(locker.getUser().get().getId()))
-            ValidatorBucket.of()
-                    .consistOf(UserRoleValidator.of(user.getRoles(), Set.of()))
-                    .validate();
+            new UserRoleValidator().validate(user.getRoles(), Set.of());
 
         locker.returnLocker();
 

--- a/src/main/java/net/causw/application/locker/LockerService.java
+++ b/src/main/java/net/causw/application/locker/LockerService.java
@@ -72,8 +72,6 @@ public class LockerService {
             @UserValid(UserRoleValidator = true) User user,
             LockerCreateRequestDto lockerCreateRequestDto
     ) {
-        ValidatorBucket validatorBucket = ValidatorBucket.of();
-
         LockerLocation lockerLocation = lockerLocationRepository.findById(lockerCreateRequestDto.getLockerLocationId())
                 .orElseThrow(
                         () -> new BadRequestException(
@@ -89,9 +87,7 @@ public class LockerService {
             );
         }
         Locker locker = Locker.of(lockerCreateRequestDto.getLockerNumber(), true, user, lockerLocation, null);
-        validatorBucket
-                .consistOf(ConstraintValidator.of(locker, this.validator))
-                .validate();
+        new ConstraintValidator<Locker>().validate(locker, validator);
 
         lockerRepository.save(locker);
         lockerLogRepository.save(LockerLog.of(locker.getLockerNumber(), lockerLocation.getName(), user.getEmail(), user.getName(), LockerLogAction.ENABLE,
@@ -151,10 +147,7 @@ public class LockerService {
                 );
 
         locker.move(lockerLocation);
-
-        ValidatorBucket.of()
-                .consistOf(ConstraintValidator.of(locker, this.validator))
-                .validate();
+        new ConstraintValidator<Locker>().validate(locker, validator);
 
         lockerRepository.save(locker);
 
@@ -246,10 +239,7 @@ public class LockerService {
         LockerLocation lockerLocation = LockerLocation.of(
                 lockerLocationCreateRequestDto.getName()
         );
-
-        ValidatorBucket.of()
-                .consistOf(ConstraintValidator.of(lockerLocation, this.validator))
-                .validate();
+        new ConstraintValidator<LockerLocation>().validate(lockerLocation, validator);
         LockerLocation location = LockerLocation.of(lockerLocationCreateRequestDto.getName());
 
         return LockerLocationResponseDto.of(
@@ -265,7 +255,6 @@ public class LockerService {
             String locationId,
             LockerLocationUpdateRequestDto lockerLocationRequestDto
     ) {
-        Set<Role> roles = user.getRoles();
         LockerLocation lockerLocation = lockerLocationRepository.findById(locationId).orElseThrow(
                 () -> new BadRequestException(
                         ErrorCode.ROW_DOES_NOT_EXIST,
@@ -285,10 +274,7 @@ public class LockerService {
         lockerLocation.update(
                 lockerLocationRequestDto.getName()
         );
-
-        ValidatorBucket.of()
-                .consistOf(ConstraintValidator.of(lockerLocation, this.validator))
-                .validate();
+        new ConstraintValidator<LockerLocation>().validate(lockerLocation, validator);
 
         return LockerLocationResponseDto.of(
                 lockerLocation,
@@ -359,9 +345,6 @@ public class LockerService {
 
     @Transactional
     public void createAllLockers(User user) {
-        ValidatorBucket validatorBucket = ValidatorBucket.of();
-
-
         LockerLocation lockerLocationSecondFloor = LockerLocation.of("Second Floor");
         lockerLocationRepository.save(lockerLocationSecondFloor);
 
@@ -371,14 +354,13 @@ public class LockerService {
         LockerLocation lockerLocationFourthFloor = LockerLocation.of("Fourth Floor");
         lockerLocationRepository.save(lockerLocationFourthFloor);
 
-        createLockerByLockerLocationAndEndLockerNumber(lockerLocationSecondFloor, validatorBucket, user, 136L);
-        createLockerByLockerLocationAndEndLockerNumber(lockerLocationThirdFloor, validatorBucket, user, 168L);
-        createLockerByLockerLocationAndEndLockerNumber(lockerLocationFourthFloor, validatorBucket, user, 32L);
+        createLockerByLockerLocationAndEndLockerNumber(lockerLocationSecondFloor, user, 136L);
+        createLockerByLockerLocationAndEndLockerNumber(lockerLocationThirdFloor, user, 168L);
+        createLockerByLockerLocationAndEndLockerNumber(lockerLocationFourthFloor, user, 32L);
     }
 
     private void createLockerByLockerLocationAndEndLockerNumber(
             LockerLocation lockerLocationSecondFloor,
-            ValidatorBucket validatorBucket,
             @UserValid(UserRoleValidator = true) User user,
             Long endNum
     ) {
@@ -392,11 +374,8 @@ public class LockerService {
                     null
             );
             Set<Role> roles = user.getRoles();
-
-            validatorBucket
-                    .consistOf(ConstraintValidator.of(locker, this.validator))
-                    .validate();
             new UserRoleValidator().validate(roles, Set.of());
+            new ConstraintValidator<Locker>().validate(locker, validator);
 
             lockerRepository.save(locker);
 

--- a/src/main/java/net/causw/application/post/PostService.java
+++ b/src/main/java/net/causw/application/post/PostService.java
@@ -31,6 +31,7 @@ import net.causw.domain.validation.UserRoleValidator;
 import net.causw.domain.validation.ValidatorBucket;
 import net.causw.domain.validation.TargetIsNotDeletedValidator;
 import net.causw.domain.validation.valid.CircleMemberValid;
+import net.causw.domain.validation.valid.PostValid;
 import net.causw.domain.validation.valid.UserValid;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -158,7 +159,7 @@ public class PostService {
     }
 
     @Transactional
-    public PostResponseDto createPost(@UserValid User creator, PostCreateRequestDto postCreateRequestDto) {
+    public PostResponseDto createPost(@UserValid User creator, @PostValid(PostNumberOfAttachmentsValidator = true) PostCreateRequestDto postCreateRequestDto) {
         ValidatorBucket validatorBucket = ValidatorBucket.of();
         Set<Role> roles = creator.getRoles();
 
@@ -178,7 +179,6 @@ public class PostService {
         );
 
         validatorBucket
-                .consistOf(PostNumberOfAttachmentsValidator.of(postCreateRequestDto.getAttachmentList()))
                 .consistOf(TargetIsDeletedValidator.of(board.getIsDeleted(), StaticValue.DOMAIN_BOARD));
         new UserRoleValidator().validate(
                 roles,
@@ -262,7 +262,7 @@ public class PostService {
     public PostResponseDto updatePost(
             User updater,
             String postId,
-            PostUpdateRequestDto postUpdateRequestDto
+            @PostValid(PostNumberOfAttachmentsValidator = true) PostUpdateRequestDto postUpdateRequestDto
     ) {
         Set<Role> roles = updater.getRoles();
         Post post = getPost(postId);
@@ -272,7 +272,6 @@ public class PostService {
             new UserRoleValidator().validate(roles, Set.of());
         }
         validatorBucket
-                .consistOf(PostNumberOfAttachmentsValidator.of(postUpdateRequestDto.getAttachmentList()))
                 .consistOf(TargetIsDeletedValidator.of(post.getBoard().getIsDeleted(), StaticValue.DOMAIN_BOARD))
                 .consistOf(TargetIsDeletedValidator.of(post.getIsDeleted(), StaticValue.DOMAIN_POST))
                 .consistOf(ContentsAdminValidator.of(

--- a/src/main/java/net/causw/application/storage/StorageService.java
+++ b/src/main/java/net/causw/application/storage/StorageService.java
@@ -7,9 +7,7 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
 import net.causw.domain.model.enums.ImageLocation;
 import net.causw.domain.model.util.S3Util;
-import net.causw.domain.validation.ImageLocationTypeValidator;
-import net.causw.domain.validation.UserStateValidator;
-import net.causw.domain.validation.ValidatorBucket;
+import net.causw.domain.validation.valid.UtilValid;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -27,10 +25,7 @@ public class StorageService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucketName;
 
-    public String uploadFile(MultipartFile multipartFile, String type) {
-
-        ValidatorBucket.of()
-                .consistOf(ImageLocationTypeValidator.of(type)).validate();
+    public String uploadFile(MultipartFile multipartFile, @UtilValid(ImageLocationTypeValidator = true) String type) {
 
         ImageLocation imageLocation = ImageLocation.of(type);
 

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -79,8 +79,6 @@ public class UserService {
     private final LockerLogRepository lockerLogRepository;
     private final UserAdmissionLogRepository userAdmissionLogRepository;
     private final BoardRepository boardRepository;
-    private final FavoriteBoardRepository favoriteBoardRepository;
-    private final UserRoleIsNoneValidator userRoleIsNoneValidator;
 
     @Transactional
     public UserResponseDto findPassword(

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -410,7 +410,7 @@ public class UserService {
      * @return UserResponseDto
      */
     @Transactional
-    public UserResponseDto signUp(UserCreateRequestDto userCreateRequestDto) {
+    public UserResponseDto signUp(@UserValid(AdmissionYearValidator = true) UserCreateRequestDto userCreateRequestDto) {
         // Make domain model for generalized data model and validate the format of request parameter
 
         this.userRepository.findByEmail(userCreateRequestDto.getEmail()).ifPresent(
@@ -434,7 +434,6 @@ public class UserService {
         ValidatorBucket.of()
                 .consistOf(ConstraintValidator.of(user, this.validator))
                 .consistOf(PasswordFormatValidator.of(userCreateRequestDto.getPassword()))
-                .consistOf(AdmissionYearValidator.of(userCreateRequestDto.getAdmissionYear()))
                 .validate();
 
         return UserResponseDto.from(user);
@@ -495,7 +494,10 @@ public class UserService {
     }
 
     @Transactional
-    public UserResponseDto update(@UserValid User user, UserUpdateRequestDto userUpdateRequestDto) {
+    public UserResponseDto update(
+            @UserValid User user,
+            @UserValid(AdmissionYearValidator = true) UserUpdateRequestDto userUpdateRequestDto
+    ) {
         if (!user.getEmail().equals(userUpdateRequestDto.getEmail())) {
             userRepository.findByEmail(userUpdateRequestDto.getEmail()).ifPresent(
                     email -> {
@@ -517,7 +519,6 @@ public class UserService {
         // Validate the admission year range
         ValidatorBucket.of()
                 .consistOf(ConstraintValidator.of(user, this.validator))
-                .consistOf(AdmissionYearValidator.of(userUpdateRequestDto.getAdmissionYear()))
                 .validate();
 
         User updatedUser = userRepository.save(user);

--- a/src/main/java/net/causw/application/util/ServiceProxy.java
+++ b/src/main/java/net/causw/application/util/ServiceProxy.java
@@ -29,13 +29,11 @@ public class ServiceProxy {
         return userService.getUserByEmailSignIn(email);
     }
 
-    //
     public CircleMember getCircleMemberUser(String userId, String circleId, List<CircleMemberStatus> list) {
         UserService userService = applicationContext.getBean(UserService.class);
         return userService.getCircleMember(userId, circleId, list);
     }
 
-    //
     public User getGrantee(String granteeId, Set<Role> granterRoles, Role targetRole) {
         UserService userService = applicationContext.getBean(UserService.class);
         return userService.getGrantee(granteeId, granterRoles, targetRole);
@@ -67,25 +65,21 @@ public class ServiceProxy {
         return circleService.getCircleWithRoleCheckAll(user, circleId);
     }
 
-    //
     public CircleMember getCircleMemberById(String applicationId, List<CircleMemberStatus> list) {
         CircleService circleService = applicationContext.getBean(CircleService.class);
         return circleService.getCircleMember(applicationId, list);
     }
 
-    //
     public CircleMember getCircleMemberCircleService(String userId, String circleId, List<CircleMemberStatus> list) {
         CircleService circleService = applicationContext.getBean(CircleService.class);
         return circleService.getCircleMember(userId, circleId, list);
     }
 
-    //
     public CircleMember getCircleMemberOrCreate(User user, Circle circle, List<CircleMemberStatus> list) {
         CircleService circleService = applicationContext.getBean(CircleService.class);
         return circleService.getCircleMemberOrCreate(user, circle, list);
     }
 
-    //
     public User getLeader(String granteeId, Set<Role> granterRoles, Role targetRole) {
         CircleService circleService = applicationContext.getBean(CircleService.class);
         return circleService.getLeader(granteeId, granterRoles, targetRole);
@@ -93,7 +87,6 @@ public class ServiceProxy {
 
     /* ChildCommentService */
 
-    //
     public CircleMember getCircleMemberChildComment(String userId, String circleId, List<CircleMemberStatus> list) {
         ChildCommentService childCommentService = applicationContext.getBean(ChildCommentService.class);
         return childCommentService.getCircleMember(userId, circleId, list);
@@ -101,7 +94,6 @@ public class ServiceProxy {
 
     /* CommentService */
 
-    //
     public CircleMember getCircleMemberComment(String userId, String circleId, List<CircleMemberStatus> list) {
         CommentService commentService = applicationContext.getBean(CommentService.class);
         return commentService.getCircleMember(userId, circleId, list);
@@ -109,7 +101,6 @@ public class ServiceProxy {
 
     /* PostService */
 
-    //
     public CircleMember getCircleMemberPost(String userId, String circleId, List<CircleMemberStatus> list) {
         PostService postService = applicationContext.getBean(PostService.class);
         return postService.getCircleMember(userId, circleId, list);

--- a/src/main/java/net/causw/application/util/ServiceProxy.java
+++ b/src/main/java/net/causw/application/util/ServiceProxy.java
@@ -10,10 +10,12 @@ import net.causw.application.comment.CommentService;
 import net.causw.application.post.PostService;
 import net.causw.application.user.UserService;
 import net.causw.domain.model.enums.CircleMemberStatus;
+import net.causw.domain.model.enums.Role;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +33,12 @@ public class ServiceProxy {
     public CircleMember getCircleMemberUser(String userId, String circleId, List<CircleMemberStatus> list) {
         UserService userService = applicationContext.getBean(UserService.class);
         return userService.getCircleMember(userId, circleId, list);
+    }
+
+    //
+    public User getGrantee(String granteeId, Set<Role> granterRoles, Role targetRole) {
+        UserService userService = applicationContext.getBean(UserService.class);
+        return userService.getGrantee(granteeId, granterRoles, targetRole);
     }
 
     /* CircleService */
@@ -75,6 +83,12 @@ public class ServiceProxy {
     public CircleMember getCircleMemberOrCreate(User user, Circle circle, List<CircleMemberStatus> list) {
         CircleService circleService = applicationContext.getBean(CircleService.class);
         return circleService.getCircleMemberOrCreate(user, circle, list);
+    }
+
+    //
+    public User getLeader(String granteeId, Set<Role> granterRoles, Role targetRole) {
+        CircleService circleService = applicationContext.getBean(CircleService.class);
+        return circleService.getLeader(granteeId, granterRoles, targetRole);
     }
 
     /* ChildCommentService */

--- a/src/main/java/net/causw/application/util/ServiceProxy.java
+++ b/src/main/java/net/causw/application/util/ServiceProxy.java
@@ -20,10 +20,20 @@ import java.util.List;
 public class ServiceProxy {
     private final ApplicationContext applicationContext;
 
+    /* UserService */
+
     public User getUserByEmailSignIn(String email) {
         UserService userService = applicationContext.getBean(UserService.class);
         return userService.getUserByEmailSignIn(email);
     }
+
+    //
+    public CircleMember getCircleMemberUser(String userId, String circleId, List<CircleMemberStatus> list) {
+        UserService userService = applicationContext.getBean(UserService.class);
+        return userService.getCircleMember(userId, circleId, list);
+    }
+
+    /* CircleService */
 
     // User의 Role에 상관 없이 UserEqualValidator을 실행하는 메서드 (userId == circleLeaderId)
     public Circle getCircleWithUserEqualValidator(User user, String circleId) {
@@ -67,11 +77,15 @@ public class ServiceProxy {
         return circleService.getCircleMemberOrCreate(user, circle, list);
     }
 
+    /* ChildCommentService */
+
     //
     public CircleMember getCircleMemberChildComment(String userId, String circleId, List<CircleMemberStatus> list) {
         ChildCommentService childCommentService = applicationContext.getBean(ChildCommentService.class);
         return childCommentService.getCircleMember(userId, circleId, list);
     }
+
+    /* CommentService */
 
     //
     public CircleMember getCircleMemberComment(String userId, String circleId, List<CircleMemberStatus> list) {
@@ -79,16 +93,12 @@ public class ServiceProxy {
         return commentService.getCircleMember(userId, circleId, list);
     }
 
+    /* PostService */
+
     //
     public CircleMember getCircleMemberPost(String userId, String circleId, List<CircleMemberStatus> list) {
         PostService postService = applicationContext.getBean(PostService.class);
         return postService.getCircleMember(userId, circleId, list);
-    }
-
-    //
-    public CircleMember getCircleMemberUser(String userId, String circleId, List<CircleMemberStatus> list) {
-        UserService userService = applicationContext.getBean(UserService.class);
-        return userService.getCircleMember(userId, circleId, list);
     }
 
 }

--- a/src/main/java/net/causw/application/util/ServiceProxy.java
+++ b/src/main/java/net/causw/application/util/ServiceProxy.java
@@ -1,0 +1,94 @@
+package net.causw.application.util;
+
+import lombok.RequiredArgsConstructor;
+import net.causw.adapter.persistence.circle.Circle;
+import net.causw.adapter.persistence.circle.CircleMember;
+import net.causw.adapter.persistence.user.User;
+import net.causw.application.circle.CircleService;
+import net.causw.application.comment.ChildCommentService;
+import net.causw.application.comment.CommentService;
+import net.causw.application.post.PostService;
+import net.causw.application.user.UserService;
+import net.causw.domain.model.enums.CircleMemberStatus;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ServiceProxy {
+    private final ApplicationContext applicationContext;
+
+    public User getUserByEmailSignIn(String email) {
+        UserService userService = applicationContext.getBean(UserService.class);
+        return userService.getUserByEmailSignIn(email);
+    }
+
+    // User의 Role에 상관 없이 UserEqualValidator을 실행하는 메서드 (userId == circleLeaderId)
+    public Circle getCircleWithUserEqualValidator(User user, String circleId) {
+        CircleService circleService = applicationContext.getBean(CircleService.class);
+        return circleService.getCircleUserEqualValidator(user, circleId);
+    }
+
+    // User의 Role에 상관 없이 UserNotEqualValidator을 실행하는 메서드 (userId == circleLeaderId)
+    public Circle getCircleWithUserNotEqualValidator(User user, String circleId) {
+        CircleService circleService = applicationContext.getBean(CircleService.class);
+        return circleService.getCircleUserNotEqualValidator(user, circleId);
+    }
+
+    // User의 Role에 LEADER_CIRCLE이 포함되는지 조건을 확인하여 있으면 UserEqualValidator을 실행하는 메서드 (userId == circleLeaderId)
+    public Circle getCircleWithValidatorWithRoleCheck(User user, String circleId) {
+        CircleService circleService = applicationContext.getBean(CircleService.class);
+        return circleService.getCircleWithRoleCheck(user, circleId);
+    }
+
+    // User의 Role에 LEADER_CIRCLE이 포함되는지 조건을 확인하여 있으면 UserEqualValidator + UserNotEqualValidator을 실행하는 메서드 (userId == circleLeaderId)
+    public Circle getCircleWithValidatorWithRoleCheckAll(User user, String circleId) {
+        CircleService circleService = applicationContext.getBean(CircleService.class);
+        return circleService.getCircleWithRoleCheckAll(user, circleId);
+    }
+
+    //
+    public CircleMember getCircleMemberById(String applicationId, List<CircleMemberStatus> list) {
+        CircleService circleService = applicationContext.getBean(CircleService.class);
+        return circleService.getCircleMember(applicationId, list);
+    }
+
+    //
+    public CircleMember getCircleMemberCircleService(String userId, String circleId, List<CircleMemberStatus> list) {
+        CircleService circleService = applicationContext.getBean(CircleService.class);
+        return circleService.getCircleMember(userId, circleId, list);
+    }
+
+    //
+    public CircleMember getCircleMemberOrCreate(User user, Circle circle, List<CircleMemberStatus> list) {
+        CircleService circleService = applicationContext.getBean(CircleService.class);
+        return circleService.getCircleMemberOrCreate(user, circle, list);
+    }
+
+    //
+    public CircleMember getCircleMemberChildComment(String userId, String circleId, List<CircleMemberStatus> list) {
+        ChildCommentService childCommentService = applicationContext.getBean(ChildCommentService.class);
+        return childCommentService.getCircleMember(userId, circleId, list);
+    }
+
+    //
+    public CircleMember getCircleMemberComment(String userId, String circleId, List<CircleMemberStatus> list) {
+        CommentService commentService = applicationContext.getBean(CommentService.class);
+        return commentService.getCircleMember(userId, circleId, list);
+    }
+
+    //
+    public CircleMember getCircleMemberPost(String userId, String circleId, List<CircleMemberStatus> list) {
+        PostService postService = applicationContext.getBean(PostService.class);
+        return postService.getCircleMember(userId, circleId, list);
+    }
+
+    //
+    public CircleMember getCircleMemberUser(String userId, String circleId, List<CircleMemberStatus> list) {
+        UserService userService = applicationContext.getBean(UserService.class);
+        return userService.getCircleMember(userId, circleId, list);
+    }
+
+}

--- a/src/main/java/net/causw/config/valid/ValidConfig.java
+++ b/src/main/java/net/causw/config/valid/ValidConfig.java
@@ -1,0 +1,9 @@
+package net.causw.config.valid;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+@Configuration
+@EnableAspectJAutoProxy
+public class ValidConfig {
+}

--- a/src/main/java/net/causw/domain/exceptions/ErrorCode.java
+++ b/src/main/java/net/causw/domain/exceptions/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     INVALID_EXPIRE_DATE(4016),
     FLAG_NOT_AVAILABLE(4017),
     LOCKER_ACTION_ERROR(4018),
+    VALIDATE_FAILURE(4019),
 
     /**
      * 401 Unauthorized

--- a/src/main/java/net/causw/domain/exceptions/ErrorCode.java
+++ b/src/main/java/net/causw/domain/exceptions/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     FLAG_NOT_AVAILABLE(4017),
     LOCKER_ACTION_ERROR(4018),
     VALIDATE_FAILURE(4019),
+    VALUE_NOT_EXIST(4020),
 
     /**
      * 401 Unauthorized

--- a/src/main/java/net/causw/domain/validation/AdmissionYearValidator.java
+++ b/src/main/java/net/causw/domain/validation/AdmissionYearValidator.java
@@ -9,9 +9,6 @@ import java.util.Calendar;
 public class AdmissionYearValidator {
 
     public void isValid(Integer admissionYear) {
-        System.out.println("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
-        System.out.println(admissionYear);
-
         if (!validateAdmissionYear(admissionYear)) {
             throw new BadRequestException(
                     ErrorCode.INVALID_USER_DATA_REQUEST,

--- a/src/main/java/net/causw/domain/validation/AdmissionYearValidator.java
+++ b/src/main/java/net/causw/domain/validation/AdmissionYearValidator.java
@@ -6,21 +6,13 @@ import net.causw.domain.model.util.StaticValue;
 
 import java.util.Calendar;
 
-public class AdmissionYearValidator extends AbstractValidator {
+public class AdmissionYearValidator {
 
-    private final Integer admissionYear;
+    public void isValid(Integer admissionYear) {
+        System.out.println("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
+        System.out.println(admissionYear);
 
-    private AdmissionYearValidator(Integer admissionYear) {
-        this.admissionYear = admissionYear;
-    }
-
-    public static AdmissionYearValidator of(Integer admissionYear) {
-        return new AdmissionYearValidator(admissionYear);
-    }
-
-    @Override
-    public void validate() {
-        if (!this.validateAdmissionYear()) {
+        if (!validateAdmissionYear(admissionYear)) {
             throw new BadRequestException(
                     ErrorCode.INVALID_USER_DATA_REQUEST,
                     "입학년도를 다시 확인해주세요."
@@ -28,13 +20,13 @@ public class AdmissionYearValidator extends AbstractValidator {
         }
     }
 
-    public boolean validateAdmissionYear() {
-        if (this.admissionYear < StaticValue.CAUSW_CREATED) {
+    public boolean validateAdmissionYear(Integer admissionYear) {
+        if (admissionYear < StaticValue.CAUSW_CREATED) {
             return false;
         }
 
         Calendar cal = Calendar.getInstance();
         int presentYear = cal.get(Calendar.YEAR);
-        return this.admissionYear <= presentYear;
+        return admissionYear <= presentYear;
     }
 }

--- a/src/main/java/net/causw/domain/validation/CircleMemberStatusValidator.java
+++ b/src/main/java/net/causw/domain/validation/CircleMemberStatusValidator.java
@@ -1,36 +1,33 @@
 package net.causw.domain.validation;
 
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.Setter;
+import net.causw.adapter.persistence.circle.CircleMember;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.UnauthorizedException;
 import net.causw.domain.model.enums.CircleMemberStatus;
+import net.causw.domain.validation.valid.CircleMemberValid;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-public class CircleMemberStatusValidator extends AbstractValidator {
-
-    private final CircleMemberStatus status;
-
-    private final List<CircleMemberStatus> statusList;
-
-    private CircleMemberStatusValidator(CircleMemberStatus status, List<CircleMemberStatus> statusList) {
-        this.status = status;
-        this.statusList = statusList;
-    }
-
-    public static CircleMemberStatusValidator of(CircleMemberStatus status, List<CircleMemberStatus> statusList) {
-        return new CircleMemberStatusValidator(status, statusList);
-    }
+@Setter
+@Component
+public class CircleMemberStatusValidator implements ConstraintValidator<CircleMemberValid, CircleMember> {
+    private List<CircleMemberStatus> statusList;
 
     @Override
-    public void validate() {
-        for (CircleMemberStatus allowedStatus : this.statusList) {
-            if (this.status.equals(allowedStatus)) {
-                return;
+    public boolean isValid(CircleMember circleMember, ConstraintValidatorContext constraintValidatorContext) {
+        CircleMemberStatus status = circleMember.getStatus();
+        for (CircleMemberStatus allowedStatus : statusList) {
+            if (status.equals(allowedStatus)) {
+                return true;
             }
         }
 
-        switch (this.status) {
+        switch (status) {
             case MEMBER:
                 throw new BadRequestException(
                         ErrorCode.ROW_ALREADY_EXIST,
@@ -59,5 +56,6 @@ public class CircleMemberStatusValidator extends AbstractValidator {
             default:
                 break;
         }
+        return false;
     }
 }

--- a/src/main/java/net/causw/domain/validation/ConstraintValidator.java
+++ b/src/main/java/net/causw/domain/validation/ConstraintValidator.java
@@ -5,24 +5,9 @@ import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validator;
 import java.util.Set;
 
-public class ConstraintValidator <T> extends AbstractValidator {
-
-    private final T domainModel;
-
-    private final Validator validator;
-
-    private ConstraintValidator(T domainModel, Validator validator) {
-        this.domainModel = domainModel;
-        this.validator = validator;
-    }
-
-    public static <T> ConstraintValidator<T> of(T domainModel, Validator validator) {
-        return new ConstraintValidator<T>(domainModel, validator);
-    }
-
-    @Override
-    public void validate() {
-        Set<ConstraintViolation<T>> violations = this.validator.validate(this.domainModel);
+public class ConstraintValidator <T>{
+    public void validate(T object, Validator validator) {
+        Set<ConstraintViolation<T>> violations = validator.validate(object);
 
         if (!violations.isEmpty()) {
             StringBuilder sb = new StringBuilder();

--- a/src/main/java/net/causw/domain/validation/ContentsAdminValidator.java
+++ b/src/main/java/net/causw/domain/validation/ContentsAdminValidator.java
@@ -13,54 +13,18 @@ import java.util.Set;
  * Post & Comment Update => The user must be the writer of the contents
  * Post & Comment Delete => The user may be the writer of the contents or administrator of the board
  */
-public class ContentsAdminValidator extends AbstractValidator {
-
-    private final Set<Role> requestUserRoles;
-
-    private final String requestUserId;
-
-    private final String writerUserId;
-
-    private final List<Role> adminRoleList;
-
-    private ContentsAdminValidator(
-            Set<Role> requestUserRoles,
-            String requestUserId,
-            String writerUserId,
-            List<Role> adminRoleList
-    ) {
-        this.requestUserRoles = requestUserRoles;
-        this.requestUserId = requestUserId;
-        this.writerUserId = writerUserId;
-        this.adminRoleList = adminRoleList;
-    }
-
-    public static ContentsAdminValidator of(
-            Set<Role> requestUserRoles,
-            String requestUserId,
-            String writerUserId,
-            List<Role> adminRoleList
-    ) {
-        return new ContentsAdminValidator(
-                requestUserRoles,
-                requestUserId,
-                writerUserId,
-                adminRoleList
-        );
-    }
-
-    @Override
-    public void validate() {
-        if (this.requestUserId.equals(this.writerUserId)) {
+public class ContentsAdminValidator {
+    public void validate(Set<Role> requestUserRoles, String requestUserId, String writerUserId, List<Role> adminRoleList) {
+        if (requestUserId.equals(writerUserId)) {
             return;
         }
 
-        if (this.requestUserRoles.stream().anyMatch(role -> EnumSet.of(Role.ADMIN, Role.PRESIDENT, Role.VICE_PRESIDENT).contains(role))) {
+        if (requestUserRoles.stream().anyMatch(role -> EnumSet.of(Role.ADMIN, Role.PRESIDENT, Role.VICE_PRESIDENT).contains(role))) {
             return;
         }
 
-        for (Role adminRole : this.adminRoleList) {
-            if (this.requestUserRoles.contains(adminRole)) {
+        for (Role adminRole : adminRoleList) {
+            if (requestUserRoles.contains(adminRole)) {
                 return;
             }
         }

--- a/src/main/java/net/causw/domain/validation/ExtendLockerExpiredAtValidator.java
+++ b/src/main/java/net/causw/domain/validation/ExtendLockerExpiredAtValidator.java
@@ -5,27 +5,8 @@ import net.causw.domain.exceptions.ErrorCode;
 
 import java.time.LocalDateTime;
 
-public class ExtendLockerExpiredAtValidator extends AbstractValidator {
-    private final LocalDateTime src;
-    private final LocalDateTime dst;
-
-    private ExtendLockerExpiredAtValidator(
-            LocalDateTime src,
-            LocalDateTime dst
-    ) {
-        this.src = src;
-        this.dst = dst;
-    }
-
-    public static ExtendLockerExpiredAtValidator of(
-            LocalDateTime src,
-            LocalDateTime dst
-    ) {
-        return new ExtendLockerExpiredAtValidator(src, dst);
-    }
-
-    @Override
-    public void validate() {
+public class ExtendLockerExpiredAtValidator {
+    public void validate(LocalDateTime src, LocalDateTime dst) {
         if (src.isEqual(dst)) {
             throw new BadRequestException(
                     ErrorCode.INVALID_EXPIRE_DATE,

--- a/src/main/java/net/causw/domain/validation/ImageLocationTypeValidator.java
+++ b/src/main/java/net/causw/domain/validation/ImageLocationTypeValidator.java
@@ -1,29 +1,24 @@
 package net.causw.domain.validation;
 
-import lombok.RequiredArgsConstructor;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.model.enums.ImageLocation;
-import org.springframework.web.multipart.MultipartFile;
+import net.causw.domain.validation.valid.UtilValid;
+import org.springframework.stereotype.Component;
 
-public class ImageLocationTypeValidator extends AbstractValidator{
+@Component
+public class ImageLocationTypeValidator implements ConstraintValidator<UtilValid, String> {
 
-    String type;
-    private ImageLocationTypeValidator(String type) {
-        this.type = type;
-    }
-
-
-    public static ImageLocationTypeValidator of(String type){
-        return new ImageLocationTypeValidator(type);
-    }
     @Override
-    public void validate() {
+    public boolean isValid(String type, ConstraintValidatorContext constraintValidatorContext) {
         if (ImageLocation.of(type) == null){
             throw new BadRequestException(
                     ErrorCode.INVALID_PARAMETER,
                     "ImageLocation type이 일치하지 않습니다."
             );
         }
+        return true;
     }
 }

--- a/src/main/java/net/causw/domain/validation/LockerAccessValidator.java
+++ b/src/main/java/net/causw/domain/validation/LockerAccessValidator.java
@@ -3,19 +3,8 @@ package net.causw.domain.validation;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 
-public class LockerAccessValidator extends AbstractValidator {
-    private final Boolean flag;
-
-    private LockerAccessValidator(Boolean flag) {
-        this.flag = flag;
-    }
-
-    public static LockerAccessValidator of(Boolean flag) {
-        return new LockerAccessValidator(flag);
-    }
-
-    @Override
-    public void validate() {
+public class LockerAccessValidator {
+    public void validate(Boolean flag) {
         if (!flag) {
             throw new BadRequestException(
                     ErrorCode.FLAG_NOT_AVAILABLE,

--- a/src/main/java/net/causw/domain/validation/LockerExpiredAtValidator.java
+++ b/src/main/java/net/causw/domain/validation/LockerExpiredAtValidator.java
@@ -5,27 +5,8 @@ import net.causw.domain.exceptions.ErrorCode;
 
 import java.time.LocalDateTime;
 
-public class LockerExpiredAtValidator extends AbstractValidator {
-    private final LocalDateTime src;
-    private final LocalDateTime dst;
-
-    private LockerExpiredAtValidator(
-            LocalDateTime src,
-            LocalDateTime dst
-    ) {
-        this.src = src;
-        this.dst = dst;
-    }
-
-    public static LockerExpiredAtValidator of(
-            LocalDateTime src,
-            LocalDateTime dst
-    ) {
-        return new LockerExpiredAtValidator(src, dst);
-    }
-
-    @Override
-    public void validate() {
+public class LockerExpiredAtValidator {
+    public void validate(LocalDateTime src, LocalDateTime dst) {
         if (src.isAfter(dst)) {
             throw new BadRequestException(
                     ErrorCode.INVALID_EXPIRE_DATE,

--- a/src/main/java/net/causw/domain/validation/LockerInUseValidator.java
+++ b/src/main/java/net/causw/domain/validation/LockerInUseValidator.java
@@ -3,19 +3,8 @@ package net.causw.domain.validation;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 
-public class LockerInUseValidator extends AbstractValidator {
-    private final Boolean isInUse;
-
-    private LockerInUseValidator(Boolean isInUse) {
-        this.isInUse = isInUse;
-    }
-
-    public static LockerInUseValidator of(Boolean isInUse) {
-        return new LockerInUseValidator(isInUse);
-    }
-
-    @Override
-    public void validate() {
+public class LockerInUseValidator {
+    public void validate(boolean isInUse) {
         if (isInUse) {
             throw new BadRequestException(
                     ErrorCode.CANNOT_PERFORMED,

--- a/src/main/java/net/causw/domain/validation/LockerIsActiveValidator.java
+++ b/src/main/java/net/causw/domain/validation/LockerIsActiveValidator.java
@@ -3,20 +3,9 @@ package net.causw.domain.validation;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 
-public class LockerIsActiveValidator extends AbstractValidator {
-    private final Boolean isActive;
-
-    private LockerIsActiveValidator(Boolean isActive) {
-        this.isActive = isActive;
-    }
-
-    public static LockerIsActiveValidator of(Boolean isActive) {
-        return new LockerIsActiveValidator(isActive);
-    }
-
-    @Override
-    public void validate() {
-        if (this.isActive) {
+public class LockerIsActiveValidator {
+    public void validate(boolean isActive) {
+        if (isActive) {
             throw new BadRequestException(
                     ErrorCode.CANNOT_PERFORMED,
                     "이미 사용 가능한 사물함입니다."

--- a/src/main/java/net/causw/domain/validation/LockerIsDeactivatedValidator.java
+++ b/src/main/java/net/causw/domain/validation/LockerIsDeactivatedValidator.java
@@ -3,20 +3,9 @@ package net.causw.domain.validation;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 
-public class LockerIsDeactivatedValidator extends AbstractValidator {
-    private final Boolean isActive;
-
-    private LockerIsDeactivatedValidator(Boolean isActive) {
-        this.isActive = isActive;
-    }
-
-    public static LockerIsDeactivatedValidator of(Boolean isActive) {
-        return new LockerIsDeactivatedValidator(isActive);
-    }
-
-    @Override
-    public void validate() {
-        if (!this.isActive) {
+public class LockerIsDeactivatedValidator  {
+    public void validate(boolean isActive) {
+        if (!isActive) {
             throw new BadRequestException(
                     ErrorCode.CANNOT_PERFORMED,
                     "사물함이 사용 불가능한 상태입니다."

--- a/src/main/java/net/causw/domain/validation/PasswordCorrectValidator.java
+++ b/src/main/java/net/causw/domain/validation/PasswordCorrectValidator.java
@@ -1,28 +1,24 @@
 package net.causw.domain.validation;
 
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import net.causw.adapter.persistence.user.User;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.UnauthorizedException;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
 
-public class PasswordCorrectValidator extends AbstractValidator {
+@Component
+@RequiredArgsConstructor
+public class PasswordCorrectValidator {
 
     private final PasswordEncoder passwordEncoder;
 
-    private final String srcPassword;
-    private final String dstPassword;
+    @Setter
+    private String srcPassword;
 
-    private PasswordCorrectValidator(PasswordEncoder passwordEncoder, String srcPassword, String dstPassword) {
-        this.passwordEncoder = passwordEncoder;
-        this.srcPassword = srcPassword;
-        this.dstPassword = dstPassword;
-    }
-
-    public static PasswordCorrectValidator of(PasswordEncoder passwordEncoder, String srcPassword, String dstPassword) {
-        return new PasswordCorrectValidator(passwordEncoder, srcPassword, dstPassword);
-    }
-
-    @Override
-    public void validate() {
+    public void validate(String srcPassword, String dstPassword) {
         if (!passwordEncoder.matches(dstPassword, srcPassword)) {
             throw new UnauthorizedException(
                     ErrorCode.INVALID_SIGNIN,

--- a/src/main/java/net/causw/domain/validation/PasswordFormatValidator.java
+++ b/src/main/java/net/causw/domain/validation/PasswordFormatValidator.java
@@ -2,25 +2,16 @@ package net.causw.domain.validation;
 
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
+import org.springframework.stereotype.Component;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class PasswordFormatValidator extends AbstractValidator {
+@Component
+public class PasswordFormatValidator {
 
-    private final String password;
-
-    private PasswordFormatValidator(String password) {
-        this.password = password;
-    }
-
-    public static PasswordFormatValidator of(String password) {
-        return new PasswordFormatValidator(password);
-    }
-
-    @Override
-    public void validate() {
-        if (!this.validatePassword()) {
+    public void validate(String password) {
+        if (!this.validatePassword(password)) {
             throw new BadRequestException(
                     ErrorCode.INVALID_USER_DATA_REQUEST,
                     "비밀번호 형식이 잘못되었습니다."
@@ -28,11 +19,11 @@ public class PasswordFormatValidator extends AbstractValidator {
         }
     }
 
-    public boolean validatePassword() {
+    public boolean validatePassword(String password) {
         String passwordPolicy = "((?=.*[a-zA-Z])(?=.*[0-9])(?=.*[^a-zA-Z0-9]).{8,})";
 
         Pattern pattern_password = Pattern.compile(passwordPolicy);
-        Matcher matcher_password = pattern_password.matcher(this.password);
+        Matcher matcher_password = pattern_password.matcher(password);
 
         return matcher_password.matches();
     }

--- a/src/main/java/net/causw/domain/validation/PostNumberOfAttachmentsValidator.java
+++ b/src/main/java/net/causw/domain/validation/PostNumberOfAttachmentsValidator.java
@@ -7,19 +7,9 @@ import java.util.List;
 
 import static net.causw.domain.model.util.StaticValue.MAX_NUM_FILE_ATTACHMENTS;
 
-public class PostNumberOfAttachmentsValidator extends AbstractValidator {
-    private final List<String> attachmentList;
+public class PostNumberOfAttachmentsValidator {
 
-    private PostNumberOfAttachmentsValidator(List<String> attachmentList) {
-        this.attachmentList = attachmentList;
-    }
-
-    public static PostNumberOfAttachmentsValidator of(List<String> attachmentList) {
-        return new PostNumberOfAttachmentsValidator(attachmentList);
-    }
-
-    @Override
-    public void validate() {
+    public void isValid(List<String> attachmentList) {
         if (attachmentList.size() > MAX_NUM_FILE_ATTACHMENTS) {
             throw new BadRequestException(
                     ErrorCode.INVALID_PARAMETER,

--- a/src/main/java/net/causw/domain/validation/StudentIdIsNullValidator.java
+++ b/src/main/java/net/causw/domain/validation/StudentIdIsNullValidator.java
@@ -1,27 +1,24 @@
 package net.causw.domain.validation;
 
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import net.causw.adapter.persistence.user.User;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
+import net.causw.domain.validation.valid.UserValid;
+import org.springframework.stereotype.Component;
 
-public class StudentIdIsNullValidator extends AbstractValidator {
-
-    private final String studentId;
-
-    private StudentIdIsNullValidator(String studentId) {
-        this.studentId = studentId;
-    }
-
-    public static StudentIdIsNullValidator of(String studentId) {
-        return new StudentIdIsNullValidator(studentId);
-    }
+@Component
+public class StudentIdIsNullValidator implements ConstraintValidator<UserValid, User> {
 
     @Override
-    public void validate() {
-        if (this.studentId == null) {
+    public boolean isValid(User user, ConstraintValidatorContext constraintValidatorContext) {
+        if (user.getStudentId() == null) {
             throw new BadRequestException(
                     ErrorCode.INVALID_STUDENT_ID,
                     "학번이 입력되지 않았습니다."
             );
         }
+        return true;
     }
 }

--- a/src/main/java/net/causw/domain/validation/TargetIsDeletedValidator.java
+++ b/src/main/java/net/causw/domain/validation/TargetIsDeletedValidator.java
@@ -3,27 +3,12 @@ package net.causw.domain.validation;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 
-public class TargetIsDeletedValidator extends AbstractValidator {
-
-    private final boolean isDeleted;
-
-    private final String domain;
-
-    private TargetIsDeletedValidator(boolean isDeleted, String domain) {
-        this.isDeleted = isDeleted;
-        this.domain = domain;
-    }
-
-    public static TargetIsDeletedValidator of(boolean isDeleted, String domain) {
-        return new TargetIsDeletedValidator(isDeleted, domain);
-    }
-
-    @Override
-    public void validate() {
-        if (this.isDeleted) {
+public class TargetIsDeletedValidator {
+    public void validate(boolean isDeleted, String domain) {
+        if (isDeleted) {
             throw new BadRequestException(
                     ErrorCode.TARGET_DELETED,
-                    String.format("삭제된 %s 입니다.", this.domain)
+                    String.format("삭제된 %s 입니다.", domain)
             );
         }
     }

--- a/src/main/java/net/causw/domain/validation/TargetIsNotDeletedValidator.java
+++ b/src/main/java/net/causw/domain/validation/TargetIsNotDeletedValidator.java
@@ -3,27 +3,12 @@ package net.causw.domain.validation;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 
-public class TargetIsNotDeletedValidator extends AbstractValidator {
-
-    private final boolean isDeleted;
-
-    private final String domain;
-
-    private TargetIsNotDeletedValidator(boolean isDeleted, String domain) {
-        this.isDeleted = isDeleted;
-        this.domain = domain;
-    }
-
-    public static TargetIsNotDeletedValidator of(boolean isDeleted, String domain) {
-        return new TargetIsNotDeletedValidator(isDeleted, domain);
-    }
-
-    @Override
-    public void validate() {
-        if (!this.isDeleted) {
+public class TargetIsNotDeletedValidator {
+    public void validate(boolean isDeleted, String domain) {
+        if (!isDeleted) {
             throw new BadRequestException(
                     ErrorCode.TARGET_DELETED,
-                    String.format("삭제되지 않은 %s 입니다.", this.domain)
+                    String.format("삭제되지 않은 %s 입니다.", domain)
             );
         }
     }

--- a/src/main/java/net/causw/domain/validation/UserEqualValidator.java
+++ b/src/main/java/net/causw/domain/validation/UserEqualValidator.java
@@ -1,30 +1,38 @@
 package net.causw.domain.validation;
 
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.Setter;
+import net.causw.adapter.persistence.user.User;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.UnauthorizedException;
+import net.causw.domain.validation.valid.UserValid;
+import org.springframework.stereotype.Component;
 
-public class UserEqualValidator extends AbstractValidator {
+@Setter
+@Component
+public class UserEqualValidator implements ConstraintValidator<UserValid, User> {
 
-    private final String srcUserId;
+    //TODO AOP proxy 사용할 것
+    private String targetUserId;
 
-    private final String targetUserId;
-
-    private UserEqualValidator(String srcUserId, String targetUserId) {
-        this.srcUserId = srcUserId;
-        this.targetUserId = targetUserId;
-    }
-
-    public static UserEqualValidator of(String srcUserId, String targetUserId) {
-        return new UserEqualValidator(srcUserId, targetUserId);
-    }
-
-    @Override
-    public void validate() {
-        if (!this.srcUserId.equals(this.targetUserId)) {
+    public void validate(String srcUserId, String targetUserId) {
+        if (srcUserId.equals(targetUserId)) {
             throw new UnauthorizedException(
                     ErrorCode.API_NOT_ALLOWED,
                     "접근 권한이 없습니다."
             );
         }
+    }
+
+    @Override
+    public boolean isValid(User user, ConstraintValidatorContext constraintValidatorContext) {
+        if (user.getId().equals(targetUserId)) {
+            throw new UnauthorizedException(
+                    ErrorCode.API_NOT_ALLOWED,
+                    "접근 권한이 없습니다."
+            );
+        }
+        return true;
     }
 }

--- a/src/main/java/net/causw/domain/validation/UserNotEqualValidator.java
+++ b/src/main/java/net/causw/domain/validation/UserNotEqualValidator.java
@@ -1,30 +1,39 @@
 package net.causw.domain.validation;
 
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.Setter;
+import net.causw.adapter.persistence.user.User;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
+import net.causw.domain.validation.valid.UserValid;
+import org.springframework.stereotype.Component;
 
-public class UserNotEqualValidator extends AbstractValidator {
+@Setter
+@Component
+public class UserNotEqualValidator implements ConstraintValidator<UserValid, User> {
 
-    private final String srcUserId;
+    //TODO AOP proxy 사용할 것
+    private String targetUserId;
 
-    private final String targetUserId;
-
-    private UserNotEqualValidator(String srcUserId, String targetUserId) {
-        this.srcUserId = srcUserId;
-        this.targetUserId = targetUserId;
-    }
-
-    public static UserNotEqualValidator of(String srcUserId, String targetUserId) {
-        return new UserNotEqualValidator(srcUserId, targetUserId);
-    }
-
-    @Override
-    public void validate() {
-        if (this.srcUserId.equals(this.targetUserId)) {
+    public void validate(String srcUserId, String targetUserId) {
+        System.out.println("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
+        if (srcUserId.equals(targetUserId)) {
             throw new BadRequestException(
                     ErrorCode.CANNOT_PERFORMED,
                     "해당 사용자는 명령을 수행할 수 없습니다."
             );
         }
+    }
+
+    @Override
+    public boolean isValid(User user, ConstraintValidatorContext constraintValidatorContext) {
+        if (user.getId().equals(targetUserId)) {
+            throw new BadRequestException(
+                    ErrorCode.CANNOT_PERFORMED,
+                    "해당 사용자는 명령을 수행할 수 없습니다."
+            );
+        }
+        return true;
     }
 }

--- a/src/main/java/net/causw/domain/validation/UserNotEqualValidator.java
+++ b/src/main/java/net/causw/domain/validation/UserNotEqualValidator.java
@@ -13,11 +13,9 @@ import org.springframework.stereotype.Component;
 @Component
 public class UserNotEqualValidator implements ConstraintValidator<UserValid, User> {
 
-    //TODO AOP proxy 사용할 것
     private String targetUserId;
 
     public void validate(String srcUserId, String targetUserId) {
-        System.out.println("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
         if (srcUserId.equals(targetUserId)) {
             throw new BadRequestException(
                     ErrorCode.CANNOT_PERFORMED,
@@ -28,12 +26,7 @@ public class UserNotEqualValidator implements ConstraintValidator<UserValid, Use
 
     @Override
     public boolean isValid(User user, ConstraintValidatorContext constraintValidatorContext) {
-        if (user.getId().equals(targetUserId)) {
-            throw new BadRequestException(
-                    ErrorCode.CANNOT_PERFORMED,
-                    "해당 사용자는 명령을 수행할 수 없습니다."
-            );
-        }
+        validate(user.getId(), targetUserId);
         return true;
     }
 }

--- a/src/main/java/net/causw/domain/validation/UserRoleIsNoneValidator.java
+++ b/src/main/java/net/causw/domain/validation/UserRoleIsNoneValidator.java
@@ -1,29 +1,27 @@
 package net.causw.domain.validation;
 
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import net.causw.adapter.persistence.user.User;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.UnauthorizedException;
 import net.causw.domain.model.enums.Role;
+import net.causw.domain.validation.valid.UserValid;
+import org.springframework.stereotype.Component;
 
 import java.util.Set;
 
-public class UserRoleIsNoneValidator extends AbstractValidator {
-    private final Set<Role> requestUserRoles;
-
-    private UserRoleIsNoneValidator(Set<Role> requestUserRoles) {
-        this.requestUserRoles = requestUserRoles;
-    }
-
-    public static UserRoleIsNoneValidator of(Set<Role> requestUserRoles) {
-        return new UserRoleIsNoneValidator(requestUserRoles);
-    }
+@Component
+public class UserRoleIsNoneValidator implements ConstraintValidator<UserValid, User> {
 
     @Override
-    public void validate() {
-        if (this.requestUserRoles.contains(Role.NONE)) {
+    public boolean isValid(User user, ConstraintValidatorContext constraintValidatorContext) {
+        if (user.getRoles().contains(Role.NONE)) {
             throw new UnauthorizedException(
                     ErrorCode.NEED_SIGN_IN,
                     "접근 권한이 없습니다. 다시 로그인 해주세요. 문제 반복시 관리자에게 문의해주세요."
             );
         }
+        return true;
     }
 }

--- a/src/main/java/net/causw/domain/validation/UserRoleValidator.java
+++ b/src/main/java/net/causw/domain/validation/UserRoleValidator.java
@@ -1,37 +1,46 @@
 package net.causw.domain.validation;
 
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.Setter;
+import net.causw.adapter.persistence.user.User;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.UnauthorizedException;
 import net.causw.domain.model.enums.Role;
+import net.causw.domain.validation.valid.UserValid;
+import org.springframework.stereotype.Component;
 
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Set;
 
-public class UserRoleValidator extends AbstractValidator {
+@Setter
+@Component
+public class UserRoleValidator implements ConstraintValidator<UserValid, User> {
 
-    private final Set<Role> requestUserRoles;
+    private Set<Role> targetRoleSet;
 
-    private final Set<Role> targetRoleSet;
-
-    private UserRoleValidator(Set<Role> requestUserRoles, Set<Role> targetRoleSet) {
-        this.requestUserRoles = requestUserRoles;
-        this.targetRoleSet = targetRoleSet;
-    }
-
-    public static UserRoleValidator of(Set<Role> requestUserRoles, Set<Role> targetRoleSet) {
-        return new UserRoleValidator(requestUserRoles, targetRoleSet);
-    }
-
-    @Override
-    public void validate() {
-
-        if (this.requestUserRoles.stream().anyMatch(role -> EnumSet.of(Role.ADMIN, Role.PRESIDENT, Role.VICE_PRESIDENT).contains(role))) {
+    public void validate(Set<Role> requestUserRoles, Set<Role> targetRoleSet) {
+        if (requestUserRoles.stream().anyMatch(role -> EnumSet.of(Role.ADMIN, Role.PRESIDENT, Role.VICE_PRESIDENT).contains(role))) {
+            return;
+        }
+        if (requestUserRoles.stream().anyMatch(targetRoleSet::contains)) {
             return;
         }
 
-        if (this.requestUserRoles.stream().anyMatch(this.targetRoleSet::contains)) {
-            return;
+        throw new UnauthorizedException(
+                ErrorCode.API_NOT_ALLOWED,
+                "접근 권한이 없습니다."
+        );
+    }
+
+    @Override
+    public boolean isValid(User user, ConstraintValidatorContext constraintValidatorContext) {
+        Set<Role> requestUserRoles = user.getRoles();
+        if (requestUserRoles.stream().anyMatch(role -> EnumSet.of(Role.ADMIN, Role.PRESIDENT, Role.VICE_PRESIDENT).contains(role))) {
+            return true;
+        }
+        if (requestUserRoles.stream().anyMatch(this.targetRoleSet::contains)) {
+            return true;
         }
 
         throw new UnauthorizedException(

--- a/src/main/java/net/causw/domain/validation/UserRoleWithoutAdminValidator.java
+++ b/src/main/java/net/causw/domain/validation/UserRoleWithoutAdminValidator.java
@@ -1,31 +1,26 @@
 package net.causw.domain.validation;
 
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import net.causw.adapter.persistence.user.User;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.UnauthorizedException;
 import net.causw.domain.model.enums.Role;
+import net.causw.domain.validation.valid.UserValid;
+import org.springframework.stereotype.Component;
 
 import java.util.Set;
 
-public class UserRoleWithoutAdminValidator extends AbstractValidator {
+@Component
+public class UserRoleWithoutAdminValidator implements ConstraintValidator<UserValid, User> {
 
-    private final Set<Role> requestUserRoles;
-
-    private final Set<Role> targetRoleSet;
-
-    private UserRoleWithoutAdminValidator(Set<Role> requestUserRoles, Set<Role> targetRoleSet) {
-        this.requestUserRoles = requestUserRoles;
-        this.targetRoleSet = targetRoleSet;
-    }
-
-    public static UserRoleWithoutAdminValidator of(Set<Role> requestUserRoles, Set<Role> targetRoleSet) {
-        return new UserRoleWithoutAdminValidator(requestUserRoles, targetRoleSet);
-    }
+    private final Set<Role> targetRoleSet = Set.of(Role.COMMON, Role.PROFESSOR);
 
     @Override
-    public void validate() {
+    public boolean isValid(User user, ConstraintValidatorContext constraintValidatorContext) {
         for (Role targetRole : this.targetRoleSet) {
-            if (this.requestUserRoles.contains(targetRole)) {
-                return;
+            if (user.getRoles().contains(targetRole)) {
+                return true;
             }
         }
 

--- a/src/main/java/net/causw/domain/validation/UserStateIsDropOrIsInActiveValidator.java
+++ b/src/main/java/net/causw/domain/validation/UserStateIsDropOrIsInActiveValidator.java
@@ -1,27 +1,26 @@
 package net.causw.domain.validation;
 
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import net.causw.adapter.persistence.user.User;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.UnauthorizedException;
 import net.causw.domain.model.enums.UserState;
+import net.causw.domain.validation.valid.UserValid;
+import org.springframework.stereotype.Component;
 
-public class UserStateIsDropOrIsInActiveValidator extends AbstractValidator {
-    private final UserState userState;
-
-    private UserStateIsDropOrIsInActiveValidator(UserState userState) {
-        this.userState = userState;
-    }
-
-    public static UserStateIsDropOrIsInActiveValidator of(UserState userState) {
-        return new UserStateIsDropOrIsInActiveValidator(userState);
-    }
+@Component
+public class UserStateIsDropOrIsInActiveValidator implements ConstraintValidator<UserValid, User> {
 
     @Override
-    public void validate() {
-        if (!(this.userState.equals(UserState.DROP) || this.userState.equals(UserState.INACTIVE))) {
+    public boolean isValid(User user, ConstraintValidatorContext constraintValidatorContext) {
+        UserState userState = user.getState();
+        if (!(userState.equals(UserState.DROP) || userState.equals(UserState.INACTIVE))) {
             throw new UnauthorizedException(
                     ErrorCode.BLOCKED_USER,
                     "등록된 사용자가 아닙니다."
             );
         }
+        return true;
     }
 }

--- a/src/main/java/net/causw/domain/validation/UserStateIsNotDropAndActiveValidator.java
+++ b/src/main/java/net/causw/domain/validation/UserStateIsNotDropAndActiveValidator.java
@@ -1,33 +1,31 @@
 package net.causw.domain.validation;
 
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import net.causw.adapter.persistence.user.User;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.UnauthorizedException;
 import net.causw.domain.model.enums.UserState;
+import net.causw.domain.validation.valid.UserValid;
+import org.springframework.stereotype.Component;
 
-public class UserStateIsNotDropAndActiveValidator extends AbstractValidator {
-
-    private final UserState userState;
-
-    private UserStateIsNotDropAndActiveValidator(UserState userState) {
-        this.userState = userState;
-    }
-
-    public static UserStateIsNotDropAndActiveValidator of(UserState userState) {
-        return new UserStateIsNotDropAndActiveValidator(userState);
-    }
+@Component
+public class UserStateIsNotDropAndActiveValidator implements ConstraintValidator<UserValid, User> {
 
     @Override
-    public void validate() {
-        if (this.userState == UserState.DROP) {
+    public boolean isValid(User user, ConstraintValidatorContext constraintValidatorContext) {
+        UserState userState = user.getState();
+        if (userState == UserState.DROP) {
             throw new UnauthorizedException(
                     ErrorCode.BLOCKED_USER,
                     "추방된 사용자 입니다."
             );
-        } else if (this.userState == UserState.ACTIVE) {
+        } else if (userState == UserState.ACTIVE) {
             throw new UnauthorizedException(
                     ErrorCode.API_NOT_ALLOWED,
                     "이미 등록된 사용자 입니다."
             );
         }
+        return true;
     }
 }

--- a/src/main/java/net/causw/domain/validation/UserStateValidator.java
+++ b/src/main/java/net/causw/domain/validation/UserStateValidator.java
@@ -1,49 +1,49 @@
 package net.causw.domain.validation;
 
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import net.causw.adapter.persistence.user.User;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.UnauthorizedException;
 import net.causw.domain.model.enums.UserState;
+import net.causw.domain.validation.valid.UserValid;
+import org.springframework.stereotype.Component;
 
-public class UserStateValidator extends AbstractValidator {
-
-    private final UserState userState;
-
-    private UserStateValidator(UserState userState) {
-        this.userState = userState;
-    }
-
-    public static UserStateValidator of(UserState userState) {
-        return new UserStateValidator(userState);
-    }
+@Component
+public class UserStateValidator implements ConstraintValidator<UserValid, User> {
 
     @Override
-    public void validate() {
-        if (this.userState == UserState.DROP) {
+    public boolean isValid(User user, ConstraintValidatorContext constraintValidatorContext) {
+        UserState state = user.getState();
+
+        if (state == UserState.DROP) {
             throw new UnauthorizedException(
                     ErrorCode.BLOCKED_USER,
                     "추방된 사용자 입니다."
             );
         }
 
-        if (this.userState == UserState.INACTIVE) {
+        if (state == UserState.INACTIVE) {
             throw new UnauthorizedException(
                     ErrorCode.INACTIVE_USER,
                     "비활성화된 사용자 입니다."
             );
         }
 
-        if (this.userState == UserState.AWAIT) {
+        if (state == UserState.AWAIT) {
             throw new UnauthorizedException(
                     ErrorCode.AWAITING_USER,
                     "대기 중인 사용자 입니다."
             );
         }
 
-        if (this.userState == UserState.REJECT) {
+        if (state == UserState.REJECT) {
             throw new UnauthorizedException(
                     ErrorCode.REJECT_USER,
                     "가입이 거절된 사용자 입니다."
             );
         }
+
+        return true;
     }
 }

--- a/src/main/java/net/causw/domain/validation/valid/AdminValid.java
+++ b/src/main/java/net/causw/domain/validation/valid/AdminValid.java
@@ -1,0 +1,11 @@
+package net.causw.domain.validation.valid;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AdminValid {
+}

--- a/src/main/java/net/causw/domain/validation/valid/AdminValidAspect.java
+++ b/src/main/java/net/causw/domain/validation/valid/AdminValidAspect.java
@@ -1,0 +1,47 @@
+package net.causw.domain.validation.valid;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.causw.adapter.persistence.user.User;
+import net.causw.domain.model.enums.Role;
+import net.causw.domain.validation.GrantableRoleValidator;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Slf4j
+@Component
+@Aspect
+@RequiredArgsConstructor
+public class AdminValidAspect {
+
+    private final GrantableRoleValidator grantableRoleValidator;
+
+    @Pointcut("@annotation(net.causw.domain.validation.valid.AdminValid)")
+    public void pointCut() {}
+
+    @AfterReturning(value = "pointCut()", returning = "user")
+    public void validUserMethod(JoinPoint joinPoint, User user) {
+        Object[] parameters = joinPoint.getArgs(); // 메서드의 파라미터
+
+        Set<Role> granterRoles = null;
+        Role targetRole = null;
+
+        for (Object parameter : parameters) {
+            if (parameter instanceof Set) {
+                if (!((Set<?>) parameter).isEmpty() && ((Set<?>) parameter).iterator().next() instanceof Role) {
+                    granterRoles = (Set<Role>) parameter;
+                }
+            } else if (parameter instanceof Role) {
+                targetRole = (Role) parameter;
+            }
+        }
+
+        grantableRoleValidator.setRoles(granterRoles, targetRole);
+        grantableRoleValidator.isValid(user, null);
+    }
+}

--- a/src/main/java/net/causw/domain/validation/valid/CircleMemberValid.java
+++ b/src/main/java/net/causw/domain/validation/valid/CircleMemberValid.java
@@ -1,0 +1,12 @@
+package net.causw.domain.validation.valid;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CircleMemberValid {
+    boolean CircleMemberStatusValidator() default false;
+}

--- a/src/main/java/net/causw/domain/validation/valid/CircleMemberValidAspect.java
+++ b/src/main/java/net/causw/domain/validation/valid/CircleMemberValidAspect.java
@@ -1,0 +1,49 @@
+package net.causw.domain.validation.valid;
+
+import lombok.RequiredArgsConstructor;
+import net.causw.adapter.persistence.circle.Circle;
+import net.causw.adapter.persistence.circle.CircleMember;
+import net.causw.domain.model.enums.CircleMemberStatus;
+import net.causw.domain.validation.CircleMemberStatusValidator;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+@Aspect
+@RequiredArgsConstructor
+public class CircleMemberValidAspect {
+    private final CircleMemberStatusValidator circleMemberStatusValidator;
+
+    @Pointcut("@annotation(net.causw.domain.validation.valid.CircleMemberValid)")
+    public void pointCut() {}
+
+    @AfterReturning(value = "pointCut()", returning = "circleMember")
+    public void validUserMethod(JoinPoint joinPoint, CircleMember circleMember) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        Object[] parameters = joinPoint.getArgs(); // 메서드의 파라미터
+
+        CircleMemberValid circleMemberValid = method.getAnnotation(CircleMemberValid.class);
+
+        if (circleMemberValid.CircleMemberStatusValidator()) {
+            for (Object parameter : parameters) {
+                if (parameter instanceof List<?> paramList) {
+                    if (!paramList.isEmpty() && paramList.get(0) instanceof CircleMemberStatus) {
+                        List<CircleMemberStatus> list = (List<CircleMemberStatus>) paramList;
+                        System.out.println(Arrays.toString(list.toArray()));
+                        circleMemberStatusValidator.setStatusList(list);
+                        circleMemberStatusValidator.isValid(circleMember, null);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/net/causw/domain/validation/valid/CircleValid.java
+++ b/src/main/java/net/causw/domain/validation/valid/CircleValid.java
@@ -1,0 +1,13 @@
+package net.causw.domain.validation.valid;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CircleValid {
+    boolean UserEqualValidator() default false;
+    boolean UserNotEqualValidator() default false;
+}

--- a/src/main/java/net/causw/domain/validation/valid/CircleValidAspect.java
+++ b/src/main/java/net/causw/domain/validation/valid/CircleValidAspect.java
@@ -1,0 +1,67 @@
+package net.causw.domain.validation.valid;
+
+import lombok.RequiredArgsConstructor;
+import net.causw.adapter.persistence.circle.Circle;
+import net.causw.adapter.persistence.user.User;
+import net.causw.domain.exceptions.ErrorCode;
+import net.causw.domain.exceptions.InternalServerException;
+import net.causw.domain.model.util.MessageUtil;
+import net.causw.domain.validation.UserEqualValidator;
+import net.causw.domain.validation.UserNotEqualValidator;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Component
+@Aspect
+@RequiredArgsConstructor
+public class CircleValidAspect {
+    private final UserEqualValidator userEqualValidator;
+    private final UserNotEqualValidator userNotEqualValidator;
+
+    @Pointcut("@annotation(net.causw.domain.validation.valid.CircleValid)")
+    public void pointCut() {}
+
+    @AfterReturning(value = "pointCut()", returning = "circle")
+    public void validUserMethod(JoinPoint joinPoint, Circle circle) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        Object[] parameters = joinPoint.getArgs(); // 메서드의 파라미터
+
+        CircleValid circleValid = method.getAnnotation(CircleValid.class);
+
+        if (circleValid.UserEqualValidator()) {
+            for (Object parameter : parameters) {
+                if (parameter instanceof User paramUser) {
+                    String userId = paramUser.getId();
+                    String leaderId = circle.getLeader().orElseThrow(
+                            () -> new InternalServerException(
+                                    ErrorCode.INTERNAL_SERVER,
+                                    MessageUtil.CIRCLE_WITHOUT_LEADER
+                            )
+                    ).getId();
+                    userEqualValidator.validate(userId, leaderId);
+                }
+            }
+        }
+        if (circleValid.UserNotEqualValidator()) {
+            for (Object parameter : parameters) {
+                if (parameter instanceof User paramUser) {
+                    String userId = paramUser.getId();
+                    String leaderId = circle.getLeader().orElseThrow(
+                            () -> new InternalServerException(
+                                    ErrorCode.INTERNAL_SERVER,
+                                    MessageUtil.CIRCLE_WITHOUT_LEADER
+                            )
+                    ).getId();
+                    userNotEqualValidator.validate(userId, leaderId);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/net/causw/domain/validation/valid/PostValid.java
+++ b/src/main/java/net/causw/domain/validation/valid/PostValid.java
@@ -1,0 +1,12 @@
+package net.causw.domain.validation.valid;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PostValid {
+    boolean PostNumberOfAttachmentsValidator() default false;
+}

--- a/src/main/java/net/causw/domain/validation/valid/PostValidAspect.java
+++ b/src/main/java/net/causw/domain/validation/valid/PostValidAspect.java
@@ -1,0 +1,54 @@
+package net.causw.domain.validation.valid;
+
+import lombok.RequiredArgsConstructor;
+import net.causw.domain.exceptions.BadRequestException;
+import net.causw.domain.exceptions.ErrorCode;
+import net.causw.domain.validation.PostNumberOfAttachmentsValidator;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.List;
+
+@Component
+@Aspect
+@RequiredArgsConstructor
+public class PostValidAspect {
+
+    @Pointcut("execution(* *(.., @net.causw.domain.validation.valid.PostValid (*), ..))")
+    public void enableValid() {}
+
+    @Before("enableValid()")
+    public void validPostParameter(JoinPoint joinPoint) {
+        Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
+        Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+        Object[] args = joinPoint.getArgs();
+
+        for (int i = 0; i < parameterAnnotations.length; i++) {
+            for (Annotation annotation : parameterAnnotations[i]) {
+                if (annotation instanceof PostValid postValid) {
+                    Object object = args[i];
+
+                    if (postValid.PostNumberOfAttachmentsValidator()) {
+                        Method getAttachmentsListMethod = null;
+                        try {
+                            getAttachmentsListMethod = object.getClass().getMethod("getAttachmentList");
+                            List<String> attachmentsList = (List<String>) getAttachmentsListMethod.invoke(object);
+                            new PostNumberOfAttachmentsValidator().isValid(attachmentsList); // validate !!
+                        } catch (Exception e) {
+                            throw new BadRequestException(
+                                    ErrorCode.VALUE_NOT_EXIST,
+                                    "첨부 파일 목록을 찾을 수 없습니다."
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/net/causw/domain/validation/valid/UserValid.java
+++ b/src/main/java/net/causw/domain/validation/valid/UserValid.java
@@ -21,7 +21,5 @@ public @interface UserValid {
 
     boolean UserStateIsNotDropAndActiveValidator() default false;
 
-    boolean UserEqualValidator() default false;
-    boolean UserNotEqualValidator() default false;
-    String targetUserId() default "";
+    boolean AdmissionYearValidator() default false;
 }

--- a/src/main/java/net/causw/domain/validation/valid/UserValid.java
+++ b/src/main/java/net/causw/domain/validation/valid/UserValid.java
@@ -21,5 +21,7 @@ public @interface UserValid {
 
     boolean UserStateIsNotDropAndActiveValidator() default false;
 
+    boolean StudentIsNullValidator() default false;
+
     boolean AdmissionYearValidator() default false;
 }

--- a/src/main/java/net/causw/domain/validation/valid/UserValid.java
+++ b/src/main/java/net/causw/domain/validation/valid/UserValid.java
@@ -1,5 +1,7 @@
 package net.causw.domain.validation.valid;
 
+import net.causw.domain.model.enums.Role;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -13,7 +15,7 @@ public @interface UserValid {
     boolean UserStateValidator() default true;
 
     boolean UserRoleValidator() default false;
-    String[] targetRoleSet() default {};
+    Role[] targetRoleSet() default {};
 
     boolean UserRoleWithoutAdminValidator() default false;
 

--- a/src/main/java/net/causw/domain/validation/valid/UserValid.java
+++ b/src/main/java/net/causw/domain/validation/valid/UserValid.java
@@ -1,0 +1,27 @@
+package net.causw.domain.validation.valid;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserValid {
+    boolean UserRolesIsNoneValidator() default true;
+
+    boolean UserStateValidator() default true;
+
+    boolean UserRoleValidator() default false;
+    String[] targetRoleSet() default {};
+
+    boolean UserRoleWithoutAdminValidator() default false;
+
+    boolean UserStateIsDropOrIsInActiveValidator() default false;
+
+    boolean UserStateIsNotDropAndActiveValidator() default false;
+
+    boolean UserEqualValidator() default false;
+    boolean UserNotEqualValidator() default false;
+    String targetUserId() default "";
+}

--- a/src/main/java/net/causw/domain/validation/valid/UserValidAspect.java
+++ b/src/main/java/net/causw/domain/validation/valid/UserValidAspect.java
@@ -27,8 +27,7 @@ public class UserValidAspect {
     private final UserRoleWithoutAdminValidator userRoleWithoutAdminValidator;
     private final UserStateIsDropOrIsInActiveValidator userStateIsDropOrIsInActiveValidator;
     private final UserStateIsNotDropAndActiveValidator userStateIsNotDropAndActiveValidator;
-    private final UserEqualValidator userEqualValidator;
-    private final UserNotEqualValidator userNotEqualValidator;
+    private final AdmissionYearValidator admissionYearValidator;
 
     @Pointcut("@annotation(net.causw.domain.validation.valid.UserValid)")
     public void pointCut() {}
@@ -86,14 +85,6 @@ public class UserValidAspect {
                         }
                         if (userValid.UserStateIsNotDropAndActiveValidator()) {
                             userStateIsNotDropAndActiveValidator.isValid(user, null);
-                        }
-                        if (userValid.UserEqualValidator()) {
-                            userEqualValidator.setTargetUserId(userValid.targetUserId());
-                            userEqualValidator.isValid(user, null);
-                        }
-                        if (userValid.UserNotEqualValidator()) {
-                            userNotEqualValidator.setTargetUserId(userValid.targetUserId());
-                            userNotEqualValidator.isValid(user, null);
                         }
                     }
                 }

--- a/src/main/java/net/causw/domain/validation/valid/UserValidAspect.java
+++ b/src/main/java/net/causw/domain/validation/valid/UserValidAspect.java
@@ -73,8 +73,6 @@ public class UserValidAspect {
                         }
                         if (userValid.UserRoleValidator()) {
                             Set<Role> targetRoleSet = Stream.of(userValid.targetRoleSet())
-                                    .map(String::trim)
-                                    .map(Role::valueOf)
                                     .collect(Collectors.toSet());
                             userRoleValidator.setTargetRoleSet(targetRoleSet);
                             userRoleValidator.isValid(user, null);

--- a/src/main/java/net/causw/domain/validation/valid/UserValidAspect.java
+++ b/src/main/java/net/causw/domain/validation/valid/UserValidAspect.java
@@ -1,0 +1,104 @@
+package net.causw.domain.validation.valid;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.causw.adapter.persistence.user.User;
+import net.causw.domain.model.enums.Role;
+import net.causw.domain.validation.*;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.*;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Slf4j
+@Component
+@Aspect
+@RequiredArgsConstructor
+public class UserValidAspect {
+    private final UserRoleIsNoneValidator userRoleIsNoneValidator;
+    private final UserStateValidator userStateValidator;
+    private final UserRoleValidator userRoleValidator;
+    private final UserRoleWithoutAdminValidator userRoleWithoutAdminValidator;
+    private final UserStateIsDropOrIsInActiveValidator userStateIsDropOrIsInActiveValidator;
+    private final UserStateIsNotDropAndActiveValidator userStateIsNotDropAndActiveValidator;
+    private final UserEqualValidator userEqualValidator;
+    private final UserNotEqualValidator userNotEqualValidator;
+
+    @Pointcut("@annotation(net.causw.domain.validation.valid.UserValid)")
+    public void pointCut() {}
+
+    @Pointcut("execution(* *(.., @net.causw.domain.validation.valid.UserValid (*), ..))")
+    public void enableValid() {}
+
+    // Method
+    @AfterReturning(value = "pointCut()", returning = "user")
+    public void validUserMethod(JoinPoint joinPoint, User user) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        Object[] parameters = joinPoint.getArgs(); // 메서드의 파라미터
+
+        UserValid userValid = method.getAnnotation(UserValid.class);
+
+        if (userValid.UserRolesIsNoneValidator()) {
+            userRoleIsNoneValidator.isValid(user, null);
+        }
+        if (userValid.UserStateValidator()) {
+            userStateValidator.isValid(user, null);
+        }
+    }
+
+    // Parameter
+    @Before("enableValid()")
+    public void validUserParameter(JoinPoint joinPoint) {
+        Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
+        Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+        Object[] args = joinPoint.getArgs();
+
+        for (int i = 0; i < parameterAnnotations.length; i++) {
+            for (Annotation annotation : parameterAnnotations[i]) {
+                if (annotation instanceof UserValid userValid) {
+                    if (args[i] instanceof User user) {
+                        if (userValid.UserRolesIsNoneValidator()) {
+                            userRoleIsNoneValidator.isValid(user, null);
+                        }
+                        if (userValid.UserStateValidator()) {
+                            userStateValidator.isValid(user, null);
+                        }
+                        if (userValid.UserRoleValidator()) {
+                            Set<Role> targetRoleSet = Stream.of(userValid.targetRoleSet())
+                                    .map(String::trim)
+                                    .map(Role::valueOf)
+                                    .collect(Collectors.toSet());
+                            userRoleValidator.setTargetRoleSet(targetRoleSet);
+                            userRoleValidator.isValid(user, null);
+                        }
+                        if (userValid.UserRoleWithoutAdminValidator()) {
+                            userRoleWithoutAdminValidator.isValid(user, null);
+                        }
+                        if (userValid.UserStateIsDropOrIsInActiveValidator()) {
+                            userStateIsDropOrIsInActiveValidator.isValid(user, null);
+                        }
+                        if (userValid.UserStateIsNotDropAndActiveValidator()) {
+                            userStateIsNotDropAndActiveValidator.isValid(user, null);
+                        }
+                        if (userValid.UserEqualValidator()) {
+                            userEqualValidator.setTargetUserId(userValid.targetUserId());
+                            userEqualValidator.isValid(user, null);
+                        }
+                        if (userValid.UserNotEqualValidator()) {
+                            userNotEqualValidator.setTargetUserId(userValid.targetUserId());
+                            userNotEqualValidator.isValid(user, null);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/net/causw/domain/validation/valid/UserValidAspect.java
+++ b/src/main/java/net/causw/domain/validation/valid/UserValidAspect.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Component;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -30,6 +29,7 @@ public class UserValidAspect {
     private final UserRoleWithoutAdminValidator userRoleWithoutAdminValidator;
     private final UserStateIsDropOrIsInActiveValidator userStateIsDropOrIsInActiveValidator;
     private final UserStateIsNotDropAndActiveValidator userStateIsNotDropAndActiveValidator;
+    private final StudentIdIsNullValidator studentIdIsNullValidator;
 
     @Pointcut("@annotation(net.causw.domain.validation.valid.UserValid)")
     public void pointCut() {}
@@ -87,6 +87,9 @@ public class UserValidAspect {
                         }
                         if (userValid.UserStateIsNotDropAndActiveValidator()) {
                             userStateIsNotDropAndActiveValidator.isValid(user, null);
+                        }
+                        if (userValid.StudentIsNullValidator()) {
+                            studentIdIsNullValidator.isValid(user, null);
                         }
                     } else { // User 객체에 대한 Valid가 아닐 때 (Ex. UserCreateRequestDto, UserUpdateRequestDto)
                         if (userValid.AdmissionYearValidator()) {

--- a/src/main/java/net/causw/domain/validation/valid/UtilValid.java
+++ b/src/main/java/net/causw/domain/validation/valid/UtilValid.java
@@ -1,0 +1,12 @@
+package net.causw.domain.validation.valid;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UtilValid {
+    boolean ImageLocationTypeValidator() default false;
+}

--- a/src/main/java/net/causw/domain/validation/valid/UtilValidAspect.java
+++ b/src/main/java/net/causw/domain/validation/valid/UtilValidAspect.java
@@ -1,0 +1,44 @@
+package net.causw.domain.validation.valid;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.causw.domain.validation.ImageLocationTypeValidator;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+@Slf4j
+@Component
+@Aspect
+@RequiredArgsConstructor
+public class UtilValidAspect {
+    private final ImageLocationTypeValidator imageLocationTypeValidator;
+
+    @Pointcut("execution(* *(.., @net.causw.domain.validation.valid.UtilValid (*), ..))")
+    public void enableValid() {}
+
+    @Before("enableValid()")
+    public void validUserParameter(JoinPoint joinPoint) {
+        Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
+        Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+        Object[] args = joinPoint.getArgs();
+
+        for (int i = 0; i < parameterAnnotations.length; i++) {
+            for (Annotation annotation : parameterAnnotations[i]) {
+                if (annotation instanceof UtilValid utilValid) {
+                    if (args[i] instanceof String type) {
+                        if (utilValid.ImageLocationTypeValidator()) {
+                            imageLocationTypeValidator.isValid(type, null);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 🚩 관련사항

#562 


### 📢 전달사항

- @Valid를 사용하여 RequestDto에 null이 불가능한 요소들에 대해 검증 및 에러 핸들링을 구현하였습니다.
- Service 단에 있는 ValidatorBucket을 모두 제거하였습니다. 다음은 적용 규칙입니다.
    - @interface와 aspect로 Validator가 적용되도록 어노테이션 생성 및 내부 구현
    - UserRoleIsNoneValidator와 UserStateValidator는 거의 모든 메서드에 공통적으로 적용되어 default를 true로 설정
    - 나머지 Validator들에 대해선 default를 false로 하여 필요한 메서드 (또는 파라미터) 에만 적용
    - 하나의 메서드 내에서 if-else문에 의해 여러 가지 경우의 수로 나뉘는 경우 Validator 클래스를 메서드 내에서 'new'로 익명 클래스를 생성하여 호출 (Ex. UserRoleValidator, ConstraintValidator 등)

- 그 외에는
    - Id 생성 전략 @UuidGenerator 사용
    - Inquiry 내의 DomainModel, Port 제거
    - InquiryController에 UCustomUserDetails 적용

#### 일관성을 최대한 맞추기 위해 노력했지만 그럼에도 불구하고 어색한 부분이 있습니다. 상세한 리뷰 부탁드립니다.

### 📸 스크린샷
#### Aop 파라미터 적용 예시 
<img width="739" alt="image" src="https://github.com/user-attachments/assets/4b0b2d9e-cfaf-4759-b7e4-767fac3762e6">

#### Aop 메서드 적용 예시
<img width="983" alt="image" src="https://github.com/user-attachments/assets/d4b672f7-017f-423a-8e74-a5e5a4a847ef">

- Proxy 객체 우회를 위해 ServiceProxy 클래스를 만들어 사용하였습니다.

#### 익명 클래스로의 적용 예시
<img width="851" alt="image" src="https://github.com/user-attachments/assets/bbed702a-d998-437e-8c29-5cca768c5118">

### 📃 진행사항
- [x] dto valid
- [x] ValidatorBucket 제거

개발기간: 3주