### PR TITLE
refactor : controller에 preauthorize 적용으로 api 별 접근 가능 권한 설정

### DIFF
--- a/src/main/java/net/causw/adapter/web/BoardController.java
+++ b/src/main/java/net/causw/adapter/web/BoardController.java
@@ -15,6 +15,7 @@ import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.InternalServerException;
 import net.causw.domain.exceptions.UnauthorizedException;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -38,6 +39,7 @@ public class BoardController {
 
     @GetMapping
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "게시판 검색 API(완료)", description = "전체 게시판을 불러오는 api로 관리자 권한을 가진 경우 삭제된 게시판도 확인할 수 있습니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json")),
@@ -56,6 +58,7 @@ public class BoardController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "게시판 생성 API(완료)", description = "circleId는 현재 존재하는 circleId를 적용해야 합니다(nullable)\n" +
             "createRoleList에는 ADMIN과 PRESIDENT가 디폴트로 입력됩니다. 그 외의 권한을 별도로 입력해주세요.\n" +
             "createRoleList에 'ALL'을 입력할 경우 모든 권한을 가진 사용자가 게시글을 생성할 수 있습니다.(NONE 제외)\n" +
@@ -83,6 +86,7 @@ public class BoardController {
 
     @PutMapping(value = "/{id}")
     @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "게시판 업데이트 API(완료)", description = "id에는 board id 값을 넣어주세요")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json")),
@@ -108,6 +112,7 @@ public class BoardController {
 
     @DeleteMapping(value = "/{id}")
     @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "게시판 삭제 API(완료)", description = "id에는 board id 값을 넣어주세요")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json")),
@@ -132,6 +137,7 @@ public class BoardController {
 
     @PutMapping(value = "/{id}/restore")
     @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "게시판 복구 API(완료)", description = "id에는 board id 값을 넣어주세요")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json")),

--- a/src/main/java/net/causw/adapter/web/ChildCommentController.java
+++ b/src/main/java/net/causw/adapter/web/ChildCommentController.java
@@ -15,6 +15,7 @@ import net.causw.config.security.userdetails.CustomUserDetails;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.UnauthorizedException;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -35,6 +36,7 @@ public class ChildCommentController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "대댓글 생성 API(완료)", description = "대댓글을 생성하는 api입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Created", content = @Content(mediaType = "application/json")),
@@ -68,6 +70,7 @@ public class ChildCommentController {
 
     @PutMapping(value = "/{id}")
     @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "대댓글 수정 API", description = "특정 대댓글을 수정하는 API입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json")),
@@ -102,6 +105,7 @@ public class ChildCommentController {
 
     @DeleteMapping(value = "/{id}")
     @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "대댓글 삭제 API", description = "특정 대댓글을 삭제하는 API입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json")),

--- a/src/main/java/net/causw/adapter/web/CircleController.java
+++ b/src/main/java/net/causw/adapter/web/CircleController.java
@@ -21,6 +21,7 @@ import net.causw.domain.exceptions.UnauthorizedException;
 import net.causw.domain.model.enums.CircleMemberStatus;
 import net.causw.domain.validation.ConstraintValidator;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.parameters.P;
@@ -75,6 +76,7 @@ public class CircleController {
      */
     @GetMapping
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "전체 동아리 정보 조회 API / findAll (완료)")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CircleResponseDto.class, type = "array"))),
@@ -97,6 +99,7 @@ public class CircleController {
      */
     @GetMapping("/{circleId}/boards")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "동아리 소속 게시판 조회 API / findBoards (완료)", description = "circleId에는 동아리 고유 id 값(PK)을 입력해주세요.")
 //    @ApiImplicitParam(name = "circleId",
 //            value = "동아리 ID",
@@ -130,6 +133,7 @@ public class CircleController {
      */
     @GetMapping(value = "/{circleId}/num-member")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT','LEADER_CIRCLE')")
     @Operation(summary = "동아리원 숫자 조회 API / getNumMember (완료)", description = "circleId에는 동아리 고유 id 값(PK)을 입력해주세요.")
 //    @ApiImplicitParam(name = "circleId",
 //            value = "동아리 ID",
@@ -154,6 +158,7 @@ public class CircleController {
      */
     @GetMapping(value = "/{circleId}/users")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT','LEADER_CIRCLE')")
     @Operation(summary = "동아리원 상태별 조회 API / getUserList (완료)", description = "circleId에는 동아리 고유 id 값(PK), circleMemberStatus 엔 조회하고자 하는 동아리원의 상태를 입력해주세요.")
 //    @ApiImplicitParams(
 //            {
@@ -205,6 +210,7 @@ public class CircleController {
      */
     @PostMapping
     @ResponseStatus(value = HttpStatus.CREATED)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
     @Operation(
             summary = "동아리 생성 API / create (완료)",
             description = "생성하고자 하는 동아리의 정보를 입력해주세요. 동아리장의 권한은 일반 유저만 가능하며, 생성 요청은 관리자(admin), 학생회장(president)만 가능합니다."
@@ -241,6 +247,7 @@ public class CircleController {
      */
     @PutMapping(value = "/{circleId}")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT','LEADER_CIRCLE')")
     @Operation(
             summary = "동아리 수정 API / update (완료)",
             description = "circleId 에는 수정하고자 하는 동아리의 UUID 형식의 ID String 값을 입력해주세요.\n" +
@@ -289,6 +296,7 @@ public class CircleController {
      */
     @DeleteMapping(value = "/{circleId}")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT','LEADER_CIRCLE')")
     @Operation(
             summary = "동아리 삭제 API",
             description = "동아리 삭제 API 입니다.\n" +
@@ -336,6 +344,7 @@ public class CircleController {
      */
     @GetMapping(value = "/{circleId}/applications")
     @ResponseStatus(value = HttpStatus.CREATED)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(
             summary = "사용자 동아리 지원 API",
             description = "사용자가 동아리에 지원하는 API 입니다.\n" +
@@ -413,6 +422,7 @@ public class CircleController {
      */
     @PutMapping(value = "/{circleId}/users/leave")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(
             summary = "동아리 탈퇴 API",
             description = "현재 로그인 된 유저 기준으로 동아리에서 탈퇴합니다.\n" +
@@ -451,6 +461,7 @@ public class CircleController {
      */
     @PutMapping(value = "/{circleId}/users/{userId}/drop")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT','LEADER_CIRCLE')")
 //    @ApiImplicitParams(
 //            {
 //                    @ApiImplicitParam(name = "userId",
@@ -505,6 +516,7 @@ public class CircleController {
      */
     @PutMapping(value = "/applications/{applicationId}/accept")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT','LEADER_CIRCLE')")
 //    @ApiImplicitParams(
 //            {
 //                    @ApiImplicitParam(name = "applicationId",
@@ -546,6 +558,7 @@ public class CircleController {
      */
     @PutMapping(value = "/applications/{applicationId}/reject")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT','LEADER_CIRCLE')")
 //    @ApiImplicitParams(
 //            {
 //                    @ApiImplicitParam(name = "applicationId",
@@ -588,6 +601,7 @@ public class CircleController {
      */
     @PutMapping(value = "/{circleId}/users/{userId}/restore")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT','LEADER_CIRCLE')")
 //    @ApiImplicitParams(
 //            {
 //                    @ApiImplicitParam(name = "circleId",

--- a/src/main/java/net/causw/adapter/web/CommentController.java
+++ b/src/main/java/net/causw/adapter/web/CommentController.java
@@ -15,6 +15,7 @@ import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.UnauthorizedException;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -36,6 +37,7 @@ public class CommentController {
 
     @GetMapping(params = "postId")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "댓글 조회 API(완료)", description = "해당 게시글의 전체 댓글을 불러오는 api입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json")),
@@ -67,6 +69,7 @@ public class CommentController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "댓글 생성 API(완료)", description = "댓글을 생성하는 api입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Created", content = @Content(mediaType = "application/json")),
@@ -96,6 +99,7 @@ public class CommentController {
 
     @PutMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "댓글 수정 API(완료)", description = "댓글을 수정하는 api입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json")),
@@ -133,6 +137,7 @@ public class CommentController {
 
     @DeleteMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "댓글 삭제 API(완료)", description = "댓글을 삭제하는 api입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json")),

--- a/src/main/java/net/causw/adapter/web/CommonController.java
+++ b/src/main/java/net/causw/adapter/web/CommonController.java
@@ -7,6 +7,7 @@ import net.causw.application.homepage.HomePageService;
 import net.causw.application.dto.homepage.HomePageResponseDto;
 import net.causw.config.security.userdetails.CustomUserDetails;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,6 +30,7 @@ public class CommonController {
 
     @GetMapping("/api/v1/home")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "홈페이지 불러오기 API(완료)", description = "동아리에 속하지 않고 삭제되지 않은 게시판과 해당 게시판의 최신 글 3개의 정보를 반환합니다. \n 개발 db상에는 동아리에 속하지 않은 많은 더미 데이터가 있지만 실제 운영될 때는 동아리에 속하지 않는 게시판은 학생회 공지게시판 뿐입니다.")
     public List<HomePageResponseDto> getHomePage(@AuthenticationPrincipal CustomUserDetails userDetails) {
 

--- a/src/main/java/net/causw/adapter/web/LockerController.java
+++ b/src/main/java/net/causw/adapter/web/LockerController.java
@@ -16,8 +16,8 @@ import net.causw.application.dto.locker.LockerResponseDto;
 import net.causw.application.dto.locker.LockerUpdateRequestDto;
 import net.causw.config.security.userdetails.CustomUserDetails;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -39,6 +39,7 @@ public class LockerController {
     @GetMapping(value = "/{id}")
     @Operation(summary = "사물함 조회 Api(완료)", description = "사물함 id를 바탕으로 사물함 정보를 가져오는 Api 입니다.")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     public LockerResponseDto findById(
             @PathVariable("id") String id,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -49,6 +50,7 @@ public class LockerController {
     @PostMapping(value = "")
     @Operation(summary = "사물함 생성 Api(완료)", description = "사물함을 생성하는 Api입니다.")
     @ResponseStatus(value = HttpStatus.CREATED)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
     public LockerResponseDto create(
             @RequestBody LockerCreateRequestDto lockerCreateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -58,6 +60,7 @@ public class LockerController {
 
     @PutMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "사물함 상태 update Api", description = "사물함 상태를 변경하는 Api입니다.")
     public LockerResponseDto update(
             @PathVariable("id") String id,
@@ -73,6 +76,7 @@ public class LockerController {
 
     @PutMapping(value = "/{id}/move")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
     @Operation(summary = "사물함 위치 이동 Api(완료)", description = "사물함의 위치를 이동시키는 Api입니다.")
     public LockerResponseDto move(
             @PathVariable("id") String id,
@@ -88,6 +92,7 @@ public class LockerController {
 
     @DeleteMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
     @Operation(summary = "사물함 삭제 Api(완료)", description = "사물함을 삭제하는 Api입니다.")
     public LockerResponseDto delete(
             @PathVariable("id") String id,
@@ -98,6 +103,7 @@ public class LockerController {
 
     @GetMapping(value = "/locations")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "사물함 층별 사용가능 여부 조회 Api(완료)", description = "사물함 층별 개수 정보와 사용 가능 개수를 제공하는 API입니다.")
     public LockerLocationsResponseDto findAllLocation(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return this.lockerService.findAllLocation(userDetails.getUser());
@@ -106,6 +112,7 @@ public class LockerController {
     @GetMapping(value = "/locations/{locationId}")
     @Operation(summary = "사물함 특정 층별 사용가능 여부 조회 Api(완료)", description = "사물함 특정 층별 개수 정보와 사용 가능 개수를 제공하는 API입니다.")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     public LockersResponseDto findByLocation(
             @PathVariable("locationId") String locationId,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -116,6 +123,7 @@ public class LockerController {
     @PostMapping(value = "/locations")
     @Operation(summary = "사물함 위치 생성 API(완료)", description = "사물함 특정 층 생성 API 입니다.")
     @ResponseStatus(value = HttpStatus.CREATED)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
     public LockerLocationResponseDto createLocation(
             @RequestBody LockerLocationCreateRequestDto lockerLocationCreateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -126,6 +134,7 @@ public class LockerController {
     @PutMapping(value = "/locations/{locationId}")
     @Operation(summary = "사물함 위치 업데이트 API(완료)", description = "사물함 특정 층 업데이트 API 입니다.")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
     public LockerLocationResponseDto updateLocation(
             @PathVariable("locationId") String locationId,
             @RequestBody LockerLocationUpdateRequestDto lockerLocationUpdateRequestDto,
@@ -141,6 +150,7 @@ public class LockerController {
     @DeleteMapping(value = "/locations/{locationId}")
     @Operation(summary = "사물함 위치 삭제 API(완료)", description = "사물함 특정 층 삭제 API 입니다.")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
     public LockerLocationResponseDto deleteLocation(
             @PathVariable("locationId") String locationId,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -157,6 +167,7 @@ public class LockerController {
     @PostMapping(value = "/expire")
     @Operation(summary = "사물함 만료 기한 설정 Api(완료)", description = "사물함 만료 기한을 설정하는 API입니다.(학생회장만 가능)")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
     public void setExpireDate(
             @RequestBody LockerExpiredAtRequestDto lockerExpiredAtRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -167,6 +178,7 @@ public class LockerController {
     @PostMapping(value = "/createAll")
     @Operation(summary = "사물함 전체 생성 API(관리자)" , description = "현재 존재하는 모든 사물함을 생성하는 API입니다.")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
     public void createAllLockers(@AuthenticationPrincipal CustomUserDetails userDetails){
         this.lockerService.createAllLockers(userDetails.getUser());
     }

--- a/src/main/java/net/causw/adapter/web/PostController.java
+++ b/src/main/java/net/causw/adapter/web/PostController.java
@@ -16,6 +16,7 @@ import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.InternalServerException;
 import net.causw.domain.exceptions.UnauthorizedException;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -35,6 +36,7 @@ public class PostController {
     private final PostService postService;
     @GetMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "게시글 열람 API(완료)", description = "게시판에서 게시글을 선택했을 때 게시글을 열람할 수 있습니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
@@ -62,6 +64,7 @@ public class PostController {
 
     @GetMapping
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "게시글 전체 조회 API(완료)",
             description = "전체 게시글을 불러오는 API로 페이지 별로 불러올 수 있습니다. 현재 한 페이지당 20개의 게시글이 조회 가능합니다. 1페이지는 value값이 0입니다.")
     @ApiResponses({
@@ -91,6 +94,7 @@ public class PostController {
 
     @GetMapping("/search")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "게시글 검색 API(완료)",
             description = "게시글을 검색하는 API로 제목의 연관검색어로 검색 가능합니다.")
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class)))
@@ -136,6 +140,7 @@ public class PostController {
 
     @PostMapping
     @ResponseStatus(value = HttpStatus.CREATED)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "게시글 생성 API(완료)",
             description = "게시글을 생성하는 API로 각 게시판의 createrolelist에 따라서 작성할 수 있는 권한이 달라집니다.")
     @ApiResponses({
@@ -165,6 +170,7 @@ public class PostController {
 
     @DeleteMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "게시글 삭제 API(완료)",
             description = "게시글을 삭제하는 API로 작성자 본인이나 해당 게시판이 속한 동아리의 동아리장, 관리자, 학생회장의 경우 삭제 가능합니다.")
     @ApiResponses({
@@ -196,6 +202,7 @@ public class PostController {
 
     @PutMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "게시글 업데이트 API(완료)",
             description = "게시글을 업데이트하는 API로 작성자 본인이나 해당 게시판이 속한 동아리의 동아리장, 관리자, 학생회장의 경우 업데이트 가능합니다.")
     @ApiResponses({
@@ -236,6 +243,7 @@ public class PostController {
 
     @PutMapping(value = "/{id}/restore")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "게시글 복구 API(완료)",
             description = "게시글을 복구하는 API로 작성자 본인이나 해당 게시판이 속한 동아리의 동아리장, 관리자, 학생회장의 경우 복구 가능합니다.")
     @ApiResponses({

--- a/src/main/java/net/causw/adapter/web/UserController.java
+++ b/src/main/java/net/causw/adapter/web/UserController.java
@@ -10,10 +10,12 @@ import net.causw.application.dto.user.*;
 import net.causw.application.user.UserService;
 import net.causw.application.dto.duplicate.DuplicatedCheckResponseDto;
 import net.causw.application.dto.circle.CircleResponseDto;
+import net.causw.config.security.SecurityService;
 import net.causw.config.security.userdetails.CustomUserDetails;
 import net.causw.domain.exceptions.BadRequestException;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -38,6 +40,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
+    private final SecurityService securityService;
 
     /**
      * 사용자 고유 id 값으로 사용자 정보를 조회하는 API
@@ -46,6 +49,7 @@ public class UserController {
      */
     @GetMapping(value = "/{userId}")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT', 'LEADER_CIRCLE')")
     @Operation(summary = "사용자 정보 조회 API (완료)",
             description = "userId에는 사용자 고유 id 값을 입력해주세요.")
     @ApiResponses({
@@ -71,6 +75,7 @@ public class UserController {
      */
     @GetMapping(value = "/me")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "로그인한 사용자 정보 조회 API (완료)",
             description = "현재 로그인한 사용자의 정보를 조회합니다.")
     @ApiResponses({
@@ -88,6 +93,7 @@ public class UserController {
 
     @GetMapping(value = "/posts")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "로그인한 사용자의 게시글 조회 API(완료)")
     public UserPostsResponseDto findPosts(
             @RequestParam(name = "pageNum", defaultValue = "0") Integer pageNum,
@@ -98,6 +104,7 @@ public class UserController {
 
     @GetMapping(value = "/comments")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "로그인한 사용자의 댓글 조회 API(완료)")
     public UserCommentsResponseDto findComments(
             @RequestParam(name = "pageNum",defaultValue = "0") Integer pageNum,
@@ -109,6 +116,7 @@ public class UserController {
 
     @GetMapping(value = "/name/{name}")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT', 'LEADER_CIRCLE')")
     @Operation(summary = "유저 관리 시 사용자 이름으로 검색 API(완료)")
     public List<UserResponseDto> findByName(
             @PathVariable("name") String name,
@@ -119,6 +127,7 @@ public class UserController {
 
     @GetMapping(value = "/privileged")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
     @Operation(summary = "특별한 권한을 가진 사용자 목록 확인 API(완료)", description = "학생회장, 부학생회장, 학생회, 학년대표, 동문회장 역할을 가지는 사용자를 반환합니다. \n 권한 역임을 할 수 있기 때문에 중복되는 사용자가 존재합니다.(ex. PRESIDENT_N_LEADER_CIRCLE)")
     public UserPrivilegedResponseDto findPrivilegedUsers(
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -128,6 +137,7 @@ public class UserController {
 
     @GetMapping(value = "/state/{state}")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
     @Operation(summary = "유저 관리 시 사용자의 상태(ACTIVE, INACTIVE 등) 에 따라 검색하는 API(완료)", description = "유저를 관리할 때 사용자가 활성, 비활성 상태인지에 따라서 분류하여 검색할 수 있습니다. \n state 는 ACTIVE, INACTIVE, AWAIT, REJECT, DROP 으로 검색가능합니다.")
     public Page<UserResponseDto> findByState(
             @PathVariable("state") String state,
@@ -204,6 +214,7 @@ public class UserController {
      */
     @PutMapping
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "사용자 정보 업데이트 API (완료)")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
@@ -233,6 +244,7 @@ public class UserController {
      */
     @PutMapping(value = "/{granteeId}/role")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','LEADER_CIRCLE')")
     @Operation(summary = "역할 업데이트 API(완료)", description = "grantorId 에는 관리자의 고유 id값, granteeId 에는 권한이 업데이트될 사용자의 고유 id 값을 넣어주세요")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
@@ -270,6 +282,7 @@ public class UserController {
 
     @PutMapping(value = "/password")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "비밀번호 업데이트 API (완료)")
     public UserResponseDto updatePassword(
             @RequestBody UserUpdatePasswordRequestDto userUpdatePasswordRequestDto,
@@ -285,6 +298,7 @@ public class UserController {
      */
     @DeleteMapping
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('COMMON','PROFESSOR')")
     @Operation(summary = "사용자 탈퇴 API (완료)")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
@@ -304,6 +318,7 @@ public class UserController {
 
     @PutMapping(value = "{id}/drop")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
     @Operation(summary = "사용자 추방 및 사물함 반환 API (완료)")
     public UserResponseDto drop(
             @PathVariable("id") String id,
@@ -313,6 +328,7 @@ public class UserController {
     }
     @GetMapping(value = "/circles")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
     @Operation(summary = "사용자가 속한 동아리 목록 불러오기 API(완료)" , description = "관리자, 학생회장인 경우 모든 동아리 불러오기")
     public List<CircleResponseDto> getCircleList(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return this.userService.getCircleList(userDetails.getUser());
@@ -320,6 +336,7 @@ public class UserController {
 
     @GetMapping(value = "/admissions/{id}")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
     @Operation(summary = "가입 대기 사용자 정보 확인 API (완료)")
     public UserAdmissionResponseDto findAdmissionById(
             @PathVariable("id") String id,
@@ -331,6 +348,7 @@ public class UserController {
 
     @GetMapping(value = "/admissions")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
     @Operation(summary = "모든 가입 대기 사용자 목록 확인 API (완료)")
     public Page<UserAdmissionsResponseDto> findAllAdmissions(
             @RequestParam(name = "pageNum",defaultValue = "0") Integer pageNum,
@@ -357,6 +375,7 @@ public class UserController {
     }
 
     @PutMapping(value = "/admissions/{id}/accept")
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
     @Operation(summary = "신청 승인 API (완료)", description = "id 에는 승인 고유 id 값(admission id)을 넣어주세요.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = String.class))),
@@ -382,6 +401,7 @@ public class UserController {
      * @return
      */
     @PutMapping(value = "/admissions/{id}/reject")
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
     @Operation(summary = "신청 거절 API (완료)", description = "id 에는 승인 고유 id 값(admission id)을 넣어주세요.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = String.class))),
@@ -414,6 +434,7 @@ public class UserController {
 
     @PutMapping(value = "/restore/{id}")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
     @Operation(summary = "사용자 복구 API(완료)", description = "복구할 사용자의 id를 넣어주세요")
     public UserResponseDto restore(
             @PathVariable("id") String id,

--- a/src/main/java/net/causw/config/security/SecurityService.java
+++ b/src/main/java/net/causw/config/security/SecurityService.java
@@ -1,0 +1,21 @@
+package net.causw.config.security;
+
+import net.causw.config.security.userdetails.CustomUserDetails;
+import net.causw.domain.model.enums.UserState;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SecurityService {
+    public boolean isActiveAndNotNoneUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return false;
+        }
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        return userDetails.getUserState() == UserState.ACTIVE &&
+                userDetails.getAuthorities().stream()
+                        .noneMatch(authority -> authority.getAuthority().equals("ROLE_NONE"));
+    }
+}


### PR DESCRIPTION
### 🚩 관련사항
#567 
#540 

### 📢 전달사항
controller 별로 preauthorize를 적용해서 토큰을 통해 api 의 사용 접근을 제한하였습니다.
현재는 NONE역할을 제외하고는 모두 접근이 가능한 api 가 다수 존재합니다. 이 경우 내부에 조건문 로직으로 관리자일 경우와 아닐 경우에 기능이 달라지게 되는데 논의를 통해 별도 api를 생성할 지 현상 유지를 할지 정해야 할 것 같습니다.

securityservice를 별도 생성하여서 기본적으로 ACTIVE 상태와 NONE이 무조건 아니어야 하는 경우를 캡슐화하였습니다. 그 외에는 역할 별로 달라지는 경우이기 때문에 hasAnyRole을 사용하였습니다. 

현재 삭제되지 않은 불필요 validator는 동현님 작업 이후에 상의 후 삭제할 예정입니다

### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [x] preauthorize 적용으로 역할별 권한 접근 리팩토링

### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 