### PR TITLE
refactor: 임시 비밀번호 발급 및 메일 전송

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/port/user/UserPortImpl.java
+++ b/src/main/java/net/causw/adapter/persistence/port/user/UserPortImpl.java
@@ -40,8 +40,8 @@ public class UserPortImpl extends DomainModelMapper implements UserPort {
     }
 
     @Override
-    public Optional<UserDomainModel> findForPassword(String email, String name, String studentId) {
-        return this.userRepository.findByEmailAndNameAndStudentId(email, name, studentId).map(this::entityToDomainModel);
+    public Optional<UserDomainModel> findForPassword(String email, String name, String studentId, String phoneNumber) {
+        return this.userRepository.findByEmailAndNameAndStudentIdAndPhoneNumber(email, name, studentId, phoneNumber).map(this::entityToDomainModel);
     }
 
     @Override

--- a/src/main/java/net/causw/adapter/persistence/repository/UserRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/UserRepository.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, String> {
     List<User> findAll();
 
-    Optional<User> findByEmailAndNameAndStudentId(String email, String name, String studentId);
+    Optional<User> findByEmailAndNameAndStudentIdAndPhoneNumber(String email, String name, String studentId, String phoneNumber);
 
     Optional<User> findByEmail(String email);
 

--- a/src/main/java/net/causw/application/dto/user/UserFindPasswordRequestDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserFindPasswordRequestDto.java
@@ -13,4 +13,5 @@ public class UserFindPasswordRequestDto {
     private String email;
     private String name;
     private String studentId;
+    private String phoneNumber;
 }

--- a/src/main/java/net/causw/application/spi/UserPort.java
+++ b/src/main/java/net/causw/application/spi/UserPort.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 public interface UserPort {
 
-    Optional<UserDomainModel> findForPassword(String email, String name, String studentId);
+    Optional<UserDomainModel> findForPassword(String email, String name, String studentId, String phoneNumber);
 
     Optional<UserDomainModel> findById(String id);
 

--- a/src/main/java/net/causw/config/mail/MailConfig.java
+++ b/src/main/java/net/causw/config/mail/MailConfig.java
@@ -1,0 +1,49 @@
+package net.causw.config.mail;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private Integer port;
+
+    @Value("${spring.mail.username}")
+    private String adminMail;
+
+    @Value("${spring.mail.password}")
+    private String adminPassword;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        final JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+        javaMailSender.setHost(host);
+        javaMailSender.setPort(port);
+        javaMailSender.setUsername(adminMail);
+        javaMailSender.setPassword(adminPassword);
+        javaMailSender.setJavaMailProperties(getMailProperties());
+
+        return javaMailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("mail.smtp.auth", "true");
+        properties.setProperty("mail.smtp.starttls.enable", "true");
+        properties.setProperty("mail.smtp.timeout", "10000");
+//        properties.setProperty("mail.smtp.ssl.enable","true");
+        properties.setProperty("mail.smtp.ssl.trust", "smtp.gmail.com");
+        properties.setProperty("mail.debug", "true");
+
+        return properties;
+    }
+
+}

--- a/src/main/java/net/causw/infrastructure/GoogleMailSender.java
+++ b/src/main/java/net/causw/infrastructure/GoogleMailSender.java
@@ -3,6 +3,7 @@ package net.causw.infrastructure;
 import lombok.RequiredArgsConstructor;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.ServiceUnavailableException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -23,14 +24,17 @@ public class GoogleMailSender {
             String to,
             String password
     ) {
-        String title = "중앙대학교 소프트웨어학부 동문네트워크 커뮤니티에서 임시 비밀번호를 알려 드립니다.";
-        String content = "<div style=\"font-size: 16px;color: #4d4d4d;padding: 35px 0px 5px 0px;text-align: left;\">    " +
-                "<div style=\"padding:10px 10px 10px 20px;\">        " +
-                "<p>귀하의 계정 비밀번호가 [" + password + "]으로 초기화 되었습니다.</p>        " +
-                "<p>임시 비밀번호로 동문네트워크에 로그인 후 새 비밀번호로 변경해 사용하시기 바랍니다.</p>    " +
-                "</div>" +
-                "<br><span style=\"font-weight: bold;\">중앙대학교 소프트웨어학부 동문네트워크</span> 드림<br>" +
-                "</div>";
+        String title = "[중앙대학교 소프트웨어학부 동문네트워크] 계정 임시 비밀번호 안내";
+        String content = "<div style=\"font-family: Arial, sans-serif; font-size: 16px; color: #333333; background-color: #f9f9f9; padding: 20px; border: 1px solid #dddddd; border-radius: 5px; max-width: 600px; margin: 0 auto;\">"
+                + "<div style=\"padding: 15px; background-color: #ffffff; border-radius: 5px; box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1);\">"
+                + "<p style=\"font-size: 18px; font-weight: bold; color: #2c3e50;\">계정 임시 비밀번호 발급</p>"
+                + "<p style=\"line-height: 1.6;\">안녕하세요,</p>"
+                + "<p style=\"line-height: 1.6;\">귀하의 계정에 대한 임시 비밀번호가 <strong style=\"color: #e74c3c;\">[" + password + "]</strong>로 설정되었습니다.</p>"
+                + "<p style=\"line-height: 1.6;\">임시 비밀번호를 사용하여 동문네트워크에 로그인하신 후, 보안을 위해 새 비밀번호로 변경해 주시기 바랍니다.</p>"
+                + "</div>"
+                + "<p style=\"font-weight: bold; text-align: center; margin-top: 20px; color: #2c3e50;\">중앙대학교 소프트웨어학부 동문네트워크</p>"
+                + "</div>";
+
         this.sendMail(to, title, content);
     }
 


### PR DESCRIPTION
🚩 관련사항
#601

📢 전달사항
임시 비밀번호 발급 기능을 리팩토링했습니다.
1. 피그마에 따라 기존 코드에 더해 전화번호를 받을 수 있도록 수정했습니다.
2. GoogleMailSender  클래스 속성 내부 JavaMailSender를 Bean으로 인식하지 못하는 이슈가 발견되어 별도의 MailConfig 클래스를 정의하고 JavaMailSender를 수동으로 Bean으로 등록해 줬습니다. 이때 필요한 민감한 정보는 @Value를 통해 application.yml에서 주입 받았습니다. (참고: https://developer-nyong.tistory.com/56)
3. 이메일 HTML 디자인을 수정했습니다.
4. 현재 MailConfig의 Debug가 true로 설정되어 있는데 아래 이슈 해결 후 최종 프로덕션에서는 false로 설정되는게 좋을 것 같습니다.
![image](https://github.com/user-attachments/assets/cfc0060f-069e-45d6-8351-626b7c47dc03)
![image](https://github.com/user-attachments/assets/d2ab4a68-a297-4498-a876-683df414297b)
-> 이전과 달리 Gmail 내부 처리에 의해 중요 메일로 마킹됩니다. (노란색 북마크 표시)


API 테스트는 Gmail, 네이버메일, outlook 세 가지 계정에서 진행했습니다. (네이버 메일 사진과 outlook 추가 첨부)
![image](https://github.com/user-attachments/assets/7d812c14-1de1-4f8b-9982-ddf84eec5a91)
![image](https://github.com/user-attachments/assets/34ab19ae-b2b1-42c1-8acb-58dd3ecba4cc)


Gmail과 네이버메일에서는 전혀 문제가 없으나 Outlook에서는 스팸 필터 처리가 되는 이슈가 존재합니다.
트러블 슈팅으로 시도한 방법은 다음과 같습니다.
- JavaMailSender의 property 수정(SSL enable, 587 port 대신 SSL 전송에 사용되는 465 port로 변경, 신뢰할 서버 smtp.gmail.com으로 설정 등등 (모든 설정 다 통하지 않았음)
- HTML, CSS 수정 및 제목과 내용 스팸필터에 걸리지 않도록 최적화
- 이메일 내 자사 도메인 삽입해서 신뢰성 높이기
=> 해결 되지 않음

일단 피그마 요구사항은 만족하고 메일 발송은 성공적으로 이루어지니, pull request를 만들겠습니다. 다만 아웃룩 cau.ac.kr 메일 주소는 우리 학교 학생들이 다수 이용하는 주소이므로 이슈를 반드시 해결해야 할 것으로 보입니다. 
검색 결과 causedongne 메일 발신 계정 자체 설정을 만져서 신뢰도를 올려야 할 것 같은데, 현재 동문네트워크 계정에 2차 인증이 안되어 접근할 수 없는 상태입니다. outlook 이슈는 다음 대면 회의 때 동네 구글 계정에 로그인하고 이어서 해결하도록 하겠습니다.



📃 진행사항
- [x] 임시 비밀번호 발송 기능 수정
- [x] 이메일 콘텐츠 및 스타일링 개선
- [x] 스팸 메일로 분류되지 않도록 최적화
- [ ] 아웃룩 스팸 분류 이슈 해결


