### PR TITLE
refactor:  유저기록을 위한 API 추가

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/repository/ChildCommentRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/ChildCommentRepository.java
@@ -1,6 +1,7 @@
 package net.causw.adapter.persistence.repository;
 
 import net.causw.adapter.persistence.comment.ChildComment;
+import net.causw.adapter.persistence.post.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -19,4 +20,11 @@ public interface ChildCommentRepository extends JpaRepository<ChildComment, Stri
     @Query("select c from ChildComment c where c.parentComment.id = :parentCommentId")
     List<ChildComment> findByParentComment_Id(@Param("parentCommentId") String parentCommentId);
 
+    @Query("SELECT DISTINCT p " +
+            "FROM ChildComment cc " +
+            "JOIN cc.parentComment c " +
+            "JOIN c.post p " +
+            "WHERE cc.writer.id = :userId AND cc.isDeleted = false " +
+            "ORDER BY p.createdAt DESC")
+    Page<Post> findPostsByUserId(@Param("userId") String userId, Pageable pageable);
 }

--- a/src/main/java/net/causw/adapter/persistence/repository/CommentRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package net.causw.adapter.persistence.repository;
 
 import net.causw.adapter.persistence.comment.Comment;
+import net.causw.adapter.persistence.post.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -25,5 +26,11 @@ public interface CommentRepository extends JpaRepository<Comment, String> {
             "and (c.id is null or (c.is_deleted = false and cm.status = 'MEMBER')) ORDER BY p.created_at DESC", nativeQuery = true)
     Page<Comment> findByUserId(@Param("user_id") String userId, Pageable pageable);
 
+    @Query("SELECT DISTINCT p " +
+            "FROM Comment c " +
+            "JOIN c.post p " +
+            "WHERE c.writer.id = :userId AND c.isDeleted = false " +
+            "ORDER BY p.createdAt DESC")
+    Page<Post> findPostsByUserId(@Param("userId") String userId, Pageable pageable);
 
 }

--- a/src/main/java/net/causw/adapter/persistence/repository/FavoritePostRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/FavoritePostRepository.java
@@ -4,6 +4,8 @@ import net.causw.adapter.persistence.post.FavoritePost;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -12,7 +14,12 @@ public interface FavoritePostRepository extends JpaRepository<FavoritePost, Stri
 
     Optional<FavoritePost> findByPostIdAndUserId(String postId, String userId);
 
-    Page<FavoritePost> findByUserIdAndIsDeletedFalse(String userId, Pageable pageable);
-
     Long countByPostIdAndIsDeletedFalse(String postId);
+
+    @Query("SELECT fp " +
+            "FROM FavoritePost fp " +
+            "JOIN fp.post p " +
+            "WHERE fp.user.id = :userId AND fp.isDeleted = false " +
+            "ORDER BY p.createdAt DESC")
+    Page<FavoritePost> findByUserId(@Param("userId") String userId, Pageable pageable);
 }

--- a/src/main/java/net/causw/adapter/persistence/repository/FavoritePostRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/FavoritePostRepository.java
@@ -1,6 +1,8 @@
 package net.causw.adapter.persistence.repository;
 
 import net.causw.adapter.persistence.post.FavoritePost;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -9,6 +11,8 @@ public interface FavoritePostRepository extends JpaRepository<FavoritePost, Stri
     Boolean existsByPostIdAndUserId(String postId, String userId);
 
     Optional<FavoritePost> findByPostIdAndUserId(String postId, String userId);
+
+    Page<FavoritePost> findByUserIdAndIsDeletedFalse(String userId, Pageable pageable);
 
     Long countByPostIdAndIsDeletedFalse(String postId);
 }

--- a/src/main/java/net/causw/adapter/persistence/repository/PostRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/PostRepository.java
@@ -33,14 +33,16 @@ public interface PostRepository extends JpaRepository<Post, String> {
 
     Page<Post> searchByTitle(@Param("title") String title, @Param("boardId") String boardId, Pageable pageable, @Param("isDeleted") boolean isDeleted);
 
-
-    @Query(value = "SELECT * FROM tb_post AS p " +
-            "JOIN tb_board AS b ON p.board_id = b.id " +
-            "LEFT JOIN tb_circle AS c ON c.id = b.circle_id " +
-            "LEFT JOIN tb_circle_member AS cm ON p.user_id = cm.user_id AND c.id = cm.circle_id " +
-            "WHERE p.user_id = :user_id AND p.is_deleted = false AND b.is_deleted = false " +
-            "AND (c.id is NULL " +
-            "OR (cm.status = 'MEMBER' AND c.is_deleted = false)) ORDER BY p.created_at DESC", nativeQuery = true)
+    // 특정 사용자가 작성한 게시글 검색
+    @Query("SELECT p " +
+            "FROM Post p " +
+            "JOIN p.board b " +
+            "LEFT JOIN b.circle c " +
+            "LEFT JOIN CircleMember cm ON p.writer.id = cm.user.id AND c.id = cm.circle.id " +
+            "WHERE p.writer.id = :user_id AND p.isDeleted = false AND b.isDeleted = false " +
+            "AND (c.id IS NULL " +
+            "OR (cm.status = 'MEMBER' AND c.isDeleted = false)) " +
+            "ORDER BY p.createdAt DESC")
     Page<Post> findByUserId(@Param("user_id") String userId, Pageable pageable);
 
     // 게시물에 작성된 모든 댓글(댓글+대댓글)의 수 세기

--- a/src/main/java/net/causw/adapter/web/ChildCommentController.java
+++ b/src/main/java/net/causw/adapter/web/ChildCommentController.java
@@ -140,7 +140,7 @@ public class ChildCommentController {
     @PostMapping(value = "/{id}/like")
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
-    @Operation(summary = "대댓글 좋아요 저장 API(작업중)", description = "특정 유저가 특정 대댓글에 좋아요를 누른 걸 저장하는 Api 입니다.")
+    @Operation(summary = "대댓글 좋아요 저장 API(완료)", description = "특정 유저가 특정 대댓글에 좋아요를 누른 걸 저장하는 Api 입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Created", content = @Content(mediaType = "application/json")),
             @ApiResponse(responseCode = "4000", description = "로그인된 사용자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),

--- a/src/main/java/net/causw/adapter/web/CommentController.java
+++ b/src/main/java/net/causw/adapter/web/CommentController.java
@@ -172,7 +172,7 @@ public class CommentController {
     @PostMapping(value = "/{id}/like")
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
-    @Operation(summary = "댓글 좋아요 저장 API(작업중)", description = "특정 유저가 특정 댓글에 좋아요를 누른 걸 저장하는 Api 입니다.")
+    @Operation(summary = "댓글 좋아요 저장 API(완료)", description = "특정 유저가 특정 댓글에 좋아요를 누른 걸 저장하는 Api 입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Created", content = @Content(mediaType = "application/json")),
             @ApiResponse(responseCode = "4000", description = "로그인된 사용자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),

--- a/src/main/java/net/causw/adapter/web/UserController.java
+++ b/src/main/java/net/causw/adapter/web/UserController.java
@@ -147,6 +147,27 @@ public class UserController {
         return this.userService.findFavoritePosts(userDetails.getUser(), pageNum);
     }
 
+    @GetMapping(value = "/comments/written")
+    @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
+    @Operation(summary = "로그인한 사용자가 작성한 댓글들의 게시물 기록 조회 API(완료)",
+            description = "로그인한 사용자가 작성한 댓글들의 게시물 기록 조회하는 Api 입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "4000", description = "로그인된 사용자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+            @ApiResponse(responseCode = "4102", description = "추방된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+            @ApiResponse(responseCode = "4103", description = "비활성화된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+            @ApiResponse(responseCode = "4104", description = "대기 중인 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+            @ApiResponse(responseCode = "4109", description = "가입이 거절된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+            @ApiResponse(responseCode = "4012", description = "접근 권한이 없습니다. 다시 로그인 해주세요. 문제 반복시 관리자에게 문의해주세요.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+    })
+    public UserPostsResponseDto findMyCommentedPosts(
+            @RequestParam(name = "pageNum", defaultValue = "0") Integer pageNum,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return this.userService.findCommentedPosts(userDetails.getUser(), pageNum);
+    }
+
     @GetMapping(value = "/comments")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUser()")

--- a/src/main/java/net/causw/adapter/web/UserController.java
+++ b/src/main/java/net/causw/adapter/web/UserController.java
@@ -92,16 +92,29 @@ public class UserController {
         return this.userService.findCurrentUser(userDetails.getUser());
     }
 
+    //FIXME: findMyWrittenPost로 대체(동일 기능), 리팩토링 통합 완료 후 삭제 예정
     @GetMapping(value = "/posts")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
-    @Operation(summary = "로그인한 사용자의 게시글 조회 API(완료)")
+    @Operation(summary = "(구)로그인한 사용자의 게시글 조회 API(삭제 예정 -> posts/written으로 변경)")
     public UserPostsResponseDto findPosts(
             @RequestParam(name = "pageNum", defaultValue = "0") Integer pageNum,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         return this.userService.findPosts(userDetails.getUser(), pageNum);
     }
+
+    @GetMapping(value = "/posts/written")
+    @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
+    @Operation(summary = "로그인한 사용자가 작성한 게시글 기록 조회 API(완료)")
+    public UserPostsResponseDto findMyWrittenPosts(
+            @RequestParam(name = "pageNum", defaultValue = "0") Integer pageNum,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return this.userService.findPosts(userDetails.getUser(), pageNum);
+    }
+
 
     @GetMapping(value = "/comments")
     @ResponseStatus(value = HttpStatus.OK)
@@ -111,7 +124,6 @@ public class UserController {
             @RequestParam(name = "pageNum",defaultValue = "0") Integer pageNum,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-
         return this.userService.findComments(userDetails.getUser(), pageNum);
     }
 

--- a/src/main/java/net/causw/adapter/web/UserController.java
+++ b/src/main/java/net/causw/adapter/web/UserController.java
@@ -14,6 +14,7 @@ import net.causw.application.dto.circle.CircleResponseDto;
 import net.causw.config.security.SecurityService;
 import net.causw.config.security.userdetails.CustomUserDetails;
 import net.causw.domain.exceptions.BadRequestException;
+import net.causw.domain.exceptions.UnauthorizedException;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -107,7 +108,17 @@ public class UserController {
     @GetMapping(value = "/posts/written")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
-    @Operation(summary = "로그인한 사용자가 작성한 게시글 기록 조회 API(완료)")
+    @Operation(summary = "로그인한 사용자가 작성한 게시글 기록 조회 API(완료)",
+            description = "로그인한 사용자가 작성한 게시글의 목록을 조회하는 Api 입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "4000", description = "로그인된 사용자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+            @ApiResponse(responseCode = "4102", description = "추방된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+            @ApiResponse(responseCode = "4103", description = "비활성화된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+            @ApiResponse(responseCode = "4104", description = "대기 중인 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+            @ApiResponse(responseCode = "4109", description = "가입이 거절된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+            @ApiResponse(responseCode = "4012", description = "접근 권한이 없습니다. 다시 로그인 해주세요. 문제 반복시 관리자에게 문의해주세요.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+    })
     public UserPostsResponseDto findMyWrittenPosts(
             @RequestParam(name = "pageNum", defaultValue = "0") Integer pageNum,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -115,6 +126,26 @@ public class UserController {
         return this.userService.findPosts(userDetails.getUser(), pageNum);
     }
 
+    @GetMapping(value = "/posts/favorite")
+    @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
+    @Operation(summary = "로그인한 사용자가 누른 즐겨찾기 게시글 기록 조회 API(완료)",
+            description = "로그인한 사용자가 즐겨찾기한 게시글의 목록을 조회하는 Api 입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "4000", description = "로그인된 사용자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+            @ApiResponse(responseCode = "4102", description = "추방된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+            @ApiResponse(responseCode = "4103", description = "비활성화된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+            @ApiResponse(responseCode = "4104", description = "대기 중인 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+            @ApiResponse(responseCode = "4109", description = "가입이 거절된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+            @ApiResponse(responseCode = "4012", description = "접근 권한이 없습니다. 다시 로그인 해주세요. 문제 반복시 관리자에게 문의해주세요.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+    })
+    public UserPostsResponseDto findMyFavoritePosts(
+            @RequestParam(name = "pageNum", defaultValue = "0") Integer pageNum,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return this.userService.findFavoritePosts(userDetails.getUser(), pageNum);
+    }
 
     @GetMapping(value = "/comments")
     @ResponseStatus(value = HttpStatus.OK)

--- a/src/main/java/net/causw/application/dto/post/PostsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/post/PostsResponseDto.java
@@ -21,6 +21,9 @@ public class PostsResponseDto {
     @Schema(description = "게시글 제목", example = "게시글의 제목입니다.")
     private String title;
 
+    @Schema(description = "게시글 내용", example = "게시글의 내용입니다.")
+    private String content;
+
     @Schema(description = "게시글 작성자 이름", example = "관리자")
     private String writerName;
 

--- a/src/main/java/net/causw/application/dto/user/UserPostsResponseDto.java
+++ b/src/main/java/net/causw/application/dto/user/UserPostsResponseDto.java
@@ -1,9 +1,11 @@
 package net.causw.application.dto.user;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.causw.adapter.persistence.user.User;
+import net.causw.application.dto.post.PostsResponseDto;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
@@ -18,11 +20,14 @@ public class UserPostsResponseDto {
     private String studentId;
     private Integer admissionYear;
     private List<String> profileImages;
-    private Page<UserPostResponseDto> post;
+
+    @Schema(description = "간락화된 게시글 정보들입니다")
+    private Page<PostsResponseDto> posts;
+
 
     public static UserPostsResponseDto of(
             User user,
-            Page<UserPostResponseDto> post
+            Page<PostsResponseDto> post
     ) {
         return UserPostsResponseDto.builder()
                 .id(user.getId())
@@ -31,7 +36,7 @@ public class UserPostsResponseDto {
                 .studentId(user.getStudentId())
                 .admissionYear(user.getAdmissionYear())
                 .profileImages(user.getProfileImages())
-                .post(post)
+                .posts(post)
                 .build();
     }
 }

--- a/src/main/java/net/causw/application/dto/util/DtoMapper.java
+++ b/src/main/java/net/causw/application/dto/util/DtoMapper.java
@@ -45,10 +45,10 @@ import java.util.stream.Collectors;
 // Custom Annotation을 사용하여 중복되는 @Mapping을 줄일 수 있습니다.
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.METHOD})
-@Mapping(target = "writerName", source = "entity.writer.name")
-@Mapping(target = "writerAdmissionYear", source = "entity.writer.admissionYear")
-@Mapping(target = "writerProfileImages", source = "entity.writer.profileImages")
-@interface CommonWriterMappings {}
+@Mapping(target = "writerName", source = "post.writer.name")
+@Mapping(target = "writerAdmissionYear", source = "post.writer.admissionYear")
+@Mapping(target = "writerProfileImages", source = "post.writer.profileImages")
+@interface CommonPostWriterMappings {}
 
 @Mapper(componentModel = "spring")
 public interface DtoMapper{
@@ -67,48 +67,52 @@ public interface DtoMapper{
     }
 
     // Dto writerName 필드에 post.writer.name을 삽입한다는 의미입니다.
-    @Mapping(target = "writerName", source = "entity.writer.name")
-    @Mapping(target = "writerAdmissionYear", source = "entity.writer.admissionYear")
-    @Mapping(target = "content", source = "entity.content")
-    @Mapping(target = "isAnonymous", source = "entity.isAnonymous")
-    @Mapping(target = "isQuestion", source = "entity.isQuestion")
+    @Mapping(target = "writerName", source = "post.writer.name")
+    @Mapping(target = "writerAdmissionYear", source = "post.writer.admissionYear")
+    @Mapping(target = "content", source = "post.content")
+    @Mapping(target = "isAnonymous", source = "post.isAnonymous")
+    @Mapping(target = "isQuestion", source = "post.isQuestion")
     @Mapping(target = "numLike", source = "numPostLike")
     @Mapping(target = "numFavorite", source = "numPostFavorite")
-    PostsResponseDto toPostsResponseDto(Post entity, Long numComment, Long numPostLike, Long numPostFavorite);
+    PostsResponseDto toPostsResponseDto(Post post, Long numComment, Long numPostLike, Long numPostFavorite);
 
-    @CommonWriterMappings
-    @Mapping(target = "boardName", source = "entity.board.name")
-    @Mapping(target = "attachmentList", source = "entity.attachments", qualifiedByName = "attachmentsToStringList")
-    @Mapping(target = "isAnonymous", source = "entity.isAnonymous")
-    @Mapping(target = "isQuestion", source = "entity.isQuestion")
+    @CommonPostWriterMappings
+    @Mapping(target = "boardName", source = "post.board.name")
+    @Mapping(target = "attachmentList", source = "post.attachments", qualifiedByName = "attachmentsToStringList")
+    @Mapping(target = "isAnonymous", source = "post.isAnonymous")
+    @Mapping(target = "isQuestion", source = "post.isQuestion")
     @Mapping(target = "numLike", source = "numPostLike")
     @Mapping(target = "numFavorite", source = "numPostFavorite")
-    PostResponseDto toPostResponseDto(Post entity, Long numPostLike, Long numPostFavorite,  Boolean updatable, Boolean deletable);
+    PostResponseDto toPostResponseDto(Post post, Long numPostLike, Long numPostFavorite,  Boolean updatable, Boolean deletable);
 
-    @CommonWriterMappings
-    @Mapping(target = "boardName", source = "entity.board.name")
-    @Mapping(target = "attachmentList", source = "entity.attachments", qualifiedByName = "attachmentsToStringList")
-    @Mapping(target = "content", source = "entity.content")
-    @Mapping(target = "isAnonymous", source = "entity.isAnonymous")
-    @Mapping(target = "isQuestion", source = "entity.isQuestion")
+    @CommonPostWriterMappings
+    @Mapping(target = "boardName", source = "post.board.name")
+    @Mapping(target = "attachmentList", source = "post.attachments", qualifiedByName = "attachmentsToStringList")
+    @Mapping(target = "content", source = "post.content")
+    @Mapping(target = "isAnonymous", source = "post.isAnonymous")
+    @Mapping(target = "isQuestion", source = "post.isQuestion")
     @Mapping(target = "numLike", source = "numPostLike")
     @Mapping(target = "numFavorite", source = "numPostFavorite")
-    PostResponseDto toPostResponseDtoExtended(Post entity, Page<CommentResponseDto> commentList, Long numComment, Long numPostLike, Long numPostFavorite, Boolean updatable, Boolean deletable);
+    PostResponseDto toPostResponseDtoExtended(Post post, Page<CommentResponseDto> commentList, Long numComment, Long numPostLike, Long numPostFavorite, Boolean updatable, Boolean deletable);
 
     @Mapping(target = "title", source = "post.title")
     @Mapping(target = "contentId", source = "post.id")
     PostContentDto toPostContentDto(Post post);
 
-    @CommonWriterMappings
-    @Mapping(target = "postId", source = "entity.post.id")
-    @Mapping(target = "isAnonymous", source = "entity.isAnonymous")
+    @Mapping(target = "writerName", source = "comment.writer.name")
+    @Mapping(target = "writerAdmissionYear", source = "comment.writer.admissionYear")
+    @Mapping(target = "writerProfileImages", source = "comment.writer.profileImages")
+    @Mapping(target = "postId", source = "comment.post.id")
+    @Mapping(target = "isAnonymous", source = "comment.isAnonymous")
     @Mapping(target ="numLike", source = "numCommentLike")
-    CommentResponseDto toCommentResponseDto(Comment entity, Long numChildComment, Long numCommentLike, List<ChildCommentResponseDto> childCommentList, Boolean updatable, Boolean deletable);
+    CommentResponseDto toCommentResponseDto(Comment comment, Long numChildComment, Long numCommentLike, List<ChildCommentResponseDto> childCommentList, Boolean updatable, Boolean deletable);
 
-    @CommonWriterMappings
-    @Mapping(target = "isAnonymous", source = "entity.isAnonymous")
+    @Mapping(target = "writerName", source = "childComment.writer.name")
+    @Mapping(target = "writerAdmissionYear", source = "childComment.writer.admissionYear")
+    @Mapping(target = "writerProfileImages", source = "childComment.writer.profileImages")
+    @Mapping(target = "isAnonymous", source = "childComment.isAnonymous")
     @Mapping(target ="numLike", source = "numChildCommentLike")
-    ChildCommentResponseDto toChildCommentResponseDto(ChildComment entity, Long numChildCommentLike,  Boolean updatable, Boolean deletable);
+    ChildCommentResponseDto toChildCommentResponseDto(ChildComment childComment, Long numChildCommentLike, Boolean updatable, Boolean deletable);
 
     @Mapping(target = "boardId", source = "entity.id")
     @Mapping(target = "boardName", source = "entity.name")
@@ -120,8 +124,8 @@ public interface DtoMapper{
      */
 
     // User
-    @Mapping(target = "email", source = "entity.email")
-    UserFindIdResponseDto toUserfindIdResponseDto(User entity);
+    @Mapping(target = "email", source = "user.email")
+    UserFindIdResponseDto toUserfindIdResponseDto(User user);
 
     @Mapping(target = "id", source = "user.id")
     @Mapping(target = "email", source = "user.email")
@@ -141,14 +145,14 @@ public interface DtoMapper{
     UserResponseDto toUserResponseDto(User user, List<String> circleIdIfLeader, List<String> circleNameIfLeader);
     // circleIdIfLeader, circleNameIfLeader는 경우에 따라 null을 할당합니다.(기존 UserResponseDto.from을 사용하는 경우)
 
-    @Mapping(target = "id", source = "entity.id")
-    @Mapping(target = "email", source = "entity.email")
-    @Mapping(target = "name", source = "entity.name")
-    @Mapping(target = "studentId", source = "entity.studentId")
-    @Mapping(target = "admissionYear", source = "entity.admissionYear")
-    @Mapping(target = "profileImages", source = "entity.profileImages")
+    @Mapping(target = "id", source = "user.id")
+    @Mapping(target = "email", source = "user.email")
+    @Mapping(target = "name", source = "user.name")
+    @Mapping(target = "studentId", source = "user.studentId")
+    @Mapping(target = "admissionYear", source = "user.admissionYear")
+    @Mapping(target = "profileImages", source = "user.profileImages")
     @Mapping(target = "posts", source = "post")
-    UserPostsResponseDto toUserPostsResponseDto(User entity, Page<PostsResponseDto> post);
+    UserPostsResponseDto toUserPostsResponseDto(User user, Page<PostsResponseDto> post);
 
 
     @Mapping(target = "id", source = "post.id")
@@ -175,7 +179,6 @@ public interface DtoMapper{
     @Mapping(target = "updatedAt", source = "comment.updatedAt")
     @Mapping(target = "isDeleted", source = "comment.isDeleted")
     CommentsOfUserResponseDto toCommentsOfUserResponseDto(Comment comment, String boardId, String boardName, String postId, String postName, String circleId, String circleName);
-
     default UserPrivilegedResponseDto toUserPrivilegedResponseDto(
             List<UserResponseDto> president,
             List<UserResponseDto> vicePresident,
@@ -204,7 +207,6 @@ public interface DtoMapper{
     UserSignInResponseDto toUserSignInResponseDto(String accessToken, String refreshToken);
 
     DuplicatedCheckResponseDto toDuplicatedCheckResponseDto(Boolean result);
-
     @Mapping(target = "id", source = "userAdmission.id")
     @Mapping(target = "user", source = "userAdmission.user")
     @Mapping(target = "attachImage", source = "userAdmission.attachImage")

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -211,13 +211,13 @@ public class UserService {
 
         return DtoMapper.INSTANCE.toUserPostsResponseDto(
                 requestUser,
-                this.postRepository.findByUserId(requestUser.getId(), this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE)
-                ).map(post -> DtoMapper.INSTANCE.toPostsResponseDto(
-                        post,
-                        getNumOfComment(post),
-                        getNumOfPostLikes(post),
-                        getNumOfPostFavorites(post)
-                ))
+                this.favoritePostRepository.findByUserId(requestUser.getId(), this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE))
+                        .map(favoritePost -> DtoMapper.INSTANCE.toPostsResponseDto(
+                                favoritePost.getPost(),
+                                getNumOfComment(favoritePost.getPost()),
+                                getNumOfPostLikes(favoritePost.getPost()),
+                                getNumOfPostFavorites(favoritePost.getPost())
+                        ))
         );
     }
 

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -240,8 +240,9 @@ public class UserService {
         combinedPosts.addAll(postsFromComments.getContent());
         combinedPosts.addAll(postsFromChildComments.getContent());
 
-        //Set에서 Page로 타입 변환
+        //Set에서 Page로 타입 변환 및 정렬
         List<Post> combinedPostsList = new ArrayList<>(combinedPosts);
+        combinedPostsList.sort((post1, post2) -> post2.getCreatedAt().compareTo(post1.getCreatedAt()));
         Page<Post> combinedPostsPage = new PageImpl<>(combinedPostsList, pageable, combinedPostsList.size());
 
         return DtoMapper.INSTANCE.toUserPostsResponseDto(

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -190,7 +190,28 @@ public class UserService {
                 this.postRepository.findByUserId(requestUser.getId(), this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE)
                 ).map(post -> DtoMapper.INSTANCE.toPostsResponseDto(
                         post,
-                        this.postRepository.countAllCommentByPost_Id(post.getId()),
+                        getNumOfComment(post),
+                        getNumOfPostLikes(post),
+                        getNumOfPostFavorites(post)
+                ))
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public UserPostsResponseDto findFavoritePosts(User requestUser, Integer pageNum) {
+        Set<Role> roles = requestUser.getRoles();
+
+        ValidatorBucket.of()
+                .consistOf(UserRoleIsNoneValidator.of(roles))
+                .consistOf(UserStateValidator.of(requestUser.getState()))
+                .validate();
+
+        return DtoMapper.INSTANCE.toUserPostsResponseDto(
+                requestUser,
+                this.postRepository.findByUserId(requestUser.getId(), this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE)
+                ).map(post -> DtoMapper.INSTANCE.toPostsResponseDto(
+                        post,
+                        getNumOfComment(post),
                         getNumOfPostLikes(post),
                         getNumOfPostFavorites(post)
                 ))
@@ -1362,6 +1383,10 @@ public class UserService {
                         MessageUtil.BOARD_NOT_FOUND
                 )
         );
+    }
+
+    private Long getNumOfComment(Post post) {
+        return this.postRepository.countAllCommentByPost_Id(post.getId());
     }
 
     private Long getNumOfPostLikes(Post post){


### PR DESCRIPTION
### 🚩 관련사항
https://github.com/CAUCSE/CAUSW_backend/issues/596

### 📢 전달사항
- 노션의 기록 page를 위한 3가지 API를 작성하였습니다. ( 유저가 작성한 게시글 기록은 리팩토링, 나머지 2개는 새롭게 작성)

- 기존의 유저가 작성한 게시글 기록은 API 가 /posts 였었는데, 새로운 기록 API를 추가하면서 동일한 기능의 API를 의미를 명확히 하기 위해 /posts/written으로 변경하였습니다. 기존과의 호환성 때문에 기존의 API를 Controller단에 남겨 두기는 하였지만, 추후에 이 API를 삭제해도 될것 같습니다. 해당 부분은 주석으로 FIXME 처리 해 놓았습니다. 

- 가장 최근의 Develop랑 충돌 해결 완료 했고, Mapper의 필드명을 분명하게 수정완료했습니다.

- 오류가 나는 nativeQuery를 동일한 기능의 JPQL 쿼리로 변경하였습니다.
 
-  PostsResponseDto에 content 속성을 새롭게 추가하였습니다. Post 관련 ResponseDTO에  투표가 있는지, 설문지가 있는지 여부를 나타내는 Bool Type 변수를 추후 추가하여야 합니다.

- 기록 API의 경우 에브리타임처럼 최신 게시글일수록 먼저 조회되게 수정 작업 완료했습니다.

### 📸 스크린샷
1. 유저가 작성한 게시글 기록
![유저가 작성한 댓글의 게시글 기록1](https://github.com/user-attachments/assets/44a81314-3fcf-4839-a6af-17eb89cf7176)
![게시글 작성 조회1](https://github.com/user-attachments/assets/d71944f2-94bb-4f39-ada3-edfadf8ff5d2)
![게시글 작성 조회2](https://github.com/user-attachments/assets/3973ca9a-1be2-45eb-a653-58b51eb98248)

게시글 생성 기준 최신글 먼저 조회

2. 유저가 즐겨찾기한 게시글 기록 (수정 후 테스트)
![유저가 즐겨찾기한 게시글 기록1](https://github.com/user-attachments/assets/0d0a96a4-d24a-4df3-872f-cc97d5501f80)
![수정2](https://github.com/user-attachments/assets/1d2cd172-03c0-4c7a-88c8-4d6d7587d15a)
![수정3](https://github.com/user-attachments/assets/3a5154b7-327f-4b8e-83c5-aeacf9654f04)

게시글 생성 기준 최신 글이 먼저 조회 되게 수정.


3. 유저가 단 댓글들의 게시글 목록 기록 ( 수정 후 테스트)
![유저가 작성한 댓글의 게시글 기록1](https://github.com/user-attachments/assets/4c86b7cd-324a-443f-99be-ada5daee963d)
![1](https://github.com/user-attachments/assets/7de70a20-c2ba-44f8-ac45-e6803144008b)
![2](https://github.com/user-attachments/assets/09207895-9e64-4aa2-86c1-cbaad21c763a)


게시글 생성 기준 최신 글이 먼저 조회 되게 수정.

### 📃 진행사항
- [x] 기록용 API 3개 완성(유저가 작성한 게시글, 유저가 즐겨찾기한 게시글 , 유저가 단 댓글들의 게시글 목록)
- [x] 기존의 Post랑 Comment, ChildComment API들에 오류가 없는지 Test 진행중입니다. 오류 발생시 오류 수정하여 새로운 pull Request 날리겠습니다. 


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 