### PR TITLE
feature : 탈퇴 회원 계정 삭제

### DIFF
--- a/src/main/java/net/causw/CauswApplication.java
+++ b/src/main/java/net/causw/CauswApplication.java
@@ -5,10 +5,13 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import jakarta.annotation.PostConstruct;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
 import java.util.TimeZone;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class CauswApplication {
 
     static {

--- a/src/main/java/net/causw/adapter/persistence/repository/UserRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/UserRepository.java
@@ -28,10 +28,7 @@ public interface UserRepository extends JpaRepository<User, String> {
 
     List<User> findByName(String name);
 
-    @Query("SELECT u " +
-            "FROM User u " +
-            "WHERE u.state = 'INACTIVE'")
-    List<User> findInactiveUser();
+    List<User> findAllByState(UserState state);
 
     Optional<User> findByStudentIdAndNameAndPhoneNumber(String studentId, String name, String phoneNumber);
 

--- a/src/main/java/net/causw/adapter/persistence/repository/UserRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/UserRepository.java
@@ -28,6 +28,11 @@ public interface UserRepository extends JpaRepository<User, String> {
 
     List<User> findByName(String name);
 
+    @Query("SELECT u " +
+            "FROM User u " +
+            "WHERE u.state = 'INACTIVE'")
+    List<User> findInactiveUser();
+
     Optional<User> findByStudentIdAndNameAndPhoneNumber(String studentId, String name, String phoneNumber);
 
     List<User> findByStudentIdAndStateAndAcademicStatus(String studentId, UserState userState, AcademicStatus academicStatus);

--- a/src/main/java/net/causw/adapter/persistence/user/User.java
+++ b/src/main/java/net/causw/adapter/persistence/user/User.java
@@ -105,6 +105,19 @@ public class User extends BaseEntity {
         this.state = state;
     }
 
+    public void delete() {
+        this.email = "deleted_" + this.getId();
+        this.name = "탈퇴한 사용자";
+        this.phoneNumber = null;
+        this.studentId = null;
+        this.nickname = null;
+        this.major = null;
+        this.profileImages = null;
+        this.graduationYear = null;
+        this.graduationMonth = null;
+        this.state = UserState.DELETED;
+    }
+
     public static User from(UserDomainModel userDomainModel) {
         return new User(
                 userDomainModel.getId(),

--- a/src/main/java/net/causw/application/comment/CommentService.java
+++ b/src/main/java/net/causw/application/comment/CommentService.java
@@ -24,14 +24,7 @@ import net.causw.domain.model.enums.CircleMemberStatus;
 import net.causw.domain.model.enums.Role;
 import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
-import net.causw.domain.validation.CircleMemberStatusValidator;
-import net.causw.domain.validation.ConstraintValidator;
-import net.causw.domain.validation.ContentsAdminValidator;
-import net.causw.domain.validation.TargetIsDeletedValidator;
-import net.causw.domain.validation.UserEqualValidator;
-import net.causw.domain.validation.UserRoleIsNoneValidator;
-import net.causw.domain.validation.UserStateValidator;
-import net.causw.domain.validation.ValidatorBucket;
+import net.causw.domain.validation.*;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -177,6 +170,11 @@ public class CommentService {
     @Transactional
     public void likeComment(User user, String commentId) {
         Comment comment = getComment(commentId);
+
+        ValidatorBucket validatorBucket = ValidatorBucket.of();
+        validatorBucket
+                .consistOf(UserStateIsDeletedValidator.of(comment.getWriter().getState()))
+                .validate();
 
         if (isCommentAlreadyLike(user, commentId)) {
             throw new BadRequestException(ErrorCode.ROW_ALREADY_EXIST, MessageUtil.COMMENT_ALREADY_LIKED);

--- a/src/main/java/net/causw/application/post/PostService.java
+++ b/src/main/java/net/causw/application/post/PostService.java
@@ -24,17 +24,7 @@ import net.causw.domain.model.enums.CircleMemberStatus;
 import net.causw.domain.model.enums.Role;
 import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
-import net.causw.domain.validation.CircleMemberStatusValidator;
-import net.causw.domain.validation.ConstraintValidator;
-import net.causw.domain.validation.ContentsAdminValidator;
-import net.causw.domain.validation.PostNumberOfAttachmentsValidator;
-import net.causw.domain.validation.TargetIsDeletedValidator;
-import net.causw.domain.validation.UserEqualValidator;
-import net.causw.domain.validation.UserRoleIsNoneValidator;
-import net.causw.domain.validation.UserRoleValidator;
-import net.causw.domain.validation.UserStateValidator;
-import net.causw.domain.validation.ValidatorBucket;
-import net.causw.domain.validation.TargetIsNotDeletedValidator;
+import net.causw.domain.validation.*;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -403,6 +393,11 @@ public class PostService {
     @Transactional
     public void likePost(User user, String postId) {
         Post post = getPost(postId);
+
+        ValidatorBucket validatorBucket = ValidatorBucket.of();
+        validatorBucket
+                .consistOf(UserStateIsDeletedValidator.of(post.getWriter().getState()))
+                .validate();
 
         if (isPostAlreadyLike(user, postId)) {
             throw new BadRequestException(ErrorCode.ROW_ALREADY_EXIST, MessageUtil.POST_ALREADY_LIKED);

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -928,16 +928,14 @@ public class UserService {
 
     @Scheduled(cron = "0 0 0 * * ?")
     public void deleteUser() {
-        List<User> users = userRepository.findInactiveUser();
+        LocalDateTime dueDate = LocalDateTime.now().minusYears(5);
 
-        for (User user : users) {
-            System.out.println(user.getEmail());
-            LocalDateTime dueDate = LocalDateTime.now().minusYears(5);
-            if (user.getUpdatedAt().isBefore(dueDate)) {
-                user.delete();
-                userRepository.save(user);
-            }
-        }
+        userRepository.findAllByState(UserState.INACTIVE).stream()
+                .filter(user -> user.getUpdatedAt().isBefore(dueDate))
+                .forEach(user -> {
+                    user.delete();
+                    userRepository.save(user);
+                });
     }
 
     private Optional<CircleMember> updateStatus(String applicationId, CircleMemberStatus targetStatus) {

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -46,12 +46,14 @@ import net.causw.infrastructure.GoogleMailSender;
 import net.causw.infrastructure.PasswordGenerator;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.validation.Validator;
 
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -924,6 +926,19 @@ public class UserService {
         ));
     }
 
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void deleteUser() {
+        List<User> users = userRepository.findInactiveUser();
+
+        for (User user : users) {
+            System.out.println(user.getEmail());
+            LocalDateTime dueDate = LocalDateTime.now().minusYears(5);
+            if (user.getUpdatedAt().isBefore(dueDate)) {
+                user.delete();
+                userRepository.save(user);
+            }
+        }
+    }
 
     private Optional<CircleMember> updateStatus(String applicationId, CircleMemberStatus targetStatus) {
         return this.circleMemberRepository.findById(applicationId).map(

--- a/src/main/java/net/causw/domain/exceptions/ErrorCode.java
+++ b/src/main/java/net/causw/domain/exceptions/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
     NOT_MEMBER(4108),
     REJECT_USER(4109),
     EXPIRED_JWT(4110),
+    DELETED_USER(4111),
 
     /**
      * 500 Internal Server Error

--- a/src/main/java/net/causw/domain/model/enums/UserState.java
+++ b/src/main/java/net/causw/domain/model/enums/UserState.java
@@ -12,7 +12,8 @@ public enum UserState {
     ACTIVE("ACTIVE"),
     INACTIVE("INACTIVE"),
     REJECT("REJECT"),
-    DROP("DROP");
+    DROP("DROP"),
+    DELETED("DELETED");
 
     private final String value;
 

--- a/src/main/java/net/causw/domain/validation/UserStateIsDeletedValidator.java
+++ b/src/main/java/net/causw/domain/validation/UserStateIsDeletedValidator.java
@@ -1,0 +1,28 @@
+package net.causw.domain.validation;
+
+import net.causw.domain.exceptions.ErrorCode;
+import net.causw.domain.exceptions.UnauthorizedException;
+import net.causw.domain.model.enums.UserState;
+
+public class UserStateIsDeletedValidator extends AbstractValidator {
+
+    private final UserState userState;
+
+    private UserStateIsDeletedValidator(UserState userState) {
+        this.userState = userState;
+    }
+
+    public static UserStateIsDeletedValidator of(UserState userState) {
+        return new UserStateIsDeletedValidator(userState);
+    }
+
+    @Override
+    public void validate() {
+        if (this.userState.equals(UserState.DELETED)) {
+            throw new UnauthorizedException(
+                    ErrorCode.DELETED_USER,
+                    "삭제된 사용자 입니다."
+            );
+        }
+    }
+}

--- a/src/main/java/net/causw/domain/validation/UserStateIsDropOrIsInActiveValidator.java
+++ b/src/main/java/net/causw/domain/validation/UserStateIsDropOrIsInActiveValidator.java
@@ -17,7 +17,7 @@ public class UserStateIsDropOrIsInActiveValidator extends AbstractValidator {
 
     @Override
     public void validate() {
-        if (!(this.userState.equals(UserState.DROP) || this.userState.equals(UserState.INACTIVE))) {
+        if (!(this.userState.equals(UserState.DROP) || this.userState.equals(UserState.INACTIVE) || this.userState.equals(UserState.DELETED))) {
             throw new UnauthorizedException(
                     ErrorCode.BLOCKED_USER,
                     "등록된 사용자가 아닙니다."

--- a/src/main/java/net/causw/domain/validation/UserStateValidator.java
+++ b/src/main/java/net/causw/domain/validation/UserStateValidator.java
@@ -32,6 +32,13 @@ public class UserStateValidator extends AbstractValidator {
             );
         }
 
+        if (this.userState == UserState.DELETED) {
+            throw new UnauthorizedException(
+                    ErrorCode.DELETED_USER,
+                    "삭제된 사용자 입니다."
+            );
+        }
+
         if (this.userState == UserState.AWAIT) {
             throw new UnauthorizedException(
                     ErrorCode.AWAITING_USER,


### PR DESCRIPTION
### 🚩 관련사항

#591 


### 📢 전달사항

Scheduler로 자정마다 state가 INACTIVE인 사용자들 중에 updated_at이 현재 시점으로부터 5년 이상 차이나면 개인정보를 삭제하도록 하였으며 state를 DELETED로 업데이트 되도록 하였습니다.

추가적으로, DELETED 상태인 사용자가 작성하였던 게시물이나 댓글, 대댓글에는 더 이상 좋아요를 추가할 수 없도록 하였고 댓글에는 새로운 대댓글을 추가하지 못하도록 Validator를 추가하였습니다.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [x] Scheduler 설정
- [x] Validator 생성


### ⚙️ 기타사항

UserState DELETED가 추가된 것을 프론트 측에는 아직 적용되지 않았기 때문에 임시적으로 테스트하였던 DELETED로 변경된 컬럼을 INACTIVE로 변경해 두었습니다.

개발기간: 2일