### PR TITLE
feat : locker 연장 구현

### DIFF
--- a/src/main/java/net/causw/application/locker/LockerActionExtend.java
+++ b/src/main/java/net/causw/application/locker/LockerActionExtend.java
@@ -2,23 +2,25 @@ package net.causw.application.locker;
 
 import lombok.NoArgsConstructor;
 import net.causw.adapter.persistence.locker.Locker;
+import net.causw.adapter.persistence.locker.LockerLog;
 import net.causw.adapter.persistence.user.User;
 import net.causw.application.common.CommonService;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
+import net.causw.domain.model.enums.LockerLogAction;
 import net.causw.domain.model.enums.Role;
 import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
-import net.causw.domain.validation.ExtendLockerExpiredAtValidator;
-import net.causw.domain.validation.UserRoleValidator;
-import net.causw.domain.validation.ValidatorBucket;
+import net.causw.domain.validation.*;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+
+import static net.causw.domain.model.util.StaticValue.LOCKER_EXTEND;
 
 @NoArgsConstructor
 public class LockerActionExtend implements LockerAction {
@@ -36,11 +38,18 @@ public class LockerActionExtend implements LockerAction {
             );
         }
 
+        // 사물함 보유자와 신청자가 같은지 확인
         if (!user.getId().equals(locker.getUser().get().getId()))
             ValidatorBucket.of()
                     .consistOf(UserRoleValidator.of(user.getRoles(), Set.of()))
                     .validate();
-
+        // 연장 신청 기간인지 확인
+        if (!user.getRoles().contains(Role.ADMIN)) {
+            ValidatorBucket.of()
+                    .consistOf(LockerExtendAccessValidator.of(commonService.findByKeyInFlag(LOCKER_EXTEND).orElse(false)))
+                    .validate();
+        }
+        // 연장일 확인
         LocalDateTime expiredAtToExtend = LocalDateTime.parse(commonService.findByKeyInTextField(StaticValue.EXPIRED_AT).orElseThrow(
                 () -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
@@ -55,9 +64,7 @@ public class LockerActionExtend implements LockerAction {
                                 expiredAtToExtend))
                         .validate());
 
-
         locker.extendExpireDate(expiredAtToExtend);
-
         return Optional.of(locker);
     }
 }

--- a/src/main/java/net/causw/application/locker/LockerActionRegister.java
+++ b/src/main/java/net/causw/application/locker/LockerActionRegister.java
@@ -57,7 +57,7 @@ public class LockerActionRegister implements LockerAction {
                         user.getEmail(),
                         user.getName(),
                         LockerLogAction.RETURN,
-                        ""
+                        "사물함 반납"
                 );
             });
         }

--- a/src/main/java/net/causw/domain/model/util/MessageUtil.java
+++ b/src/main/java/net/causw/domain/model/util/MessageUtil.java
@@ -57,8 +57,11 @@ public class MessageUtil {
     public static final String LOCKER_ALREADY_EXIST = "사물함 위치에 사물함이 존재합니다.";
     public static final String LOCKER_RETURN_TIME_NOT_SET = "사물함 반납 시간이 설정되지 않았습니다.";
     public static final String LOCKER_UNUSED = "사용 중인 사물함이 아닙니다.";
+    public static final String LOCKER_USED = "사용 중인 사물함입니다.";
     public static final String LOCKER_DELETED = "사물함 삭제";
     public static final String LOCKER_ACTION_ERROR = "사물함 액션 실행 중 에러가 발생하였습니다.";
+    public static final String LOCKER_EXTEND_NOT_ALLOWED = "사물함 연장 신청 기간이 아닙니다. 공지를 확인해주세요.";
+    public static final String LOCKER_INVALID_EXPIRE_DATE = "잘못된 반납일 입니다.";
 
 
     // User

--- a/src/main/java/net/causw/domain/model/util/StaticValue.java
+++ b/src/main/java/net/causw/domain/model/util/StaticValue.java
@@ -43,6 +43,7 @@ public class StaticValue {
 
     // Flag
     public static final String LOCKER_ACCESS = "LOCKER_ACCESS";
+    public static final String LOCKER_EXTEND = "LOCKER_EXTEND";
 
     // Text Field
     public static final String EXPIRED_AT = "EXPIRE_DATE";

--- a/src/main/java/net/causw/domain/validation/ExtendLockerExpiredAtValidator.java
+++ b/src/main/java/net/causw/domain/validation/ExtendLockerExpiredAtValidator.java
@@ -29,7 +29,7 @@ public class ExtendLockerExpiredAtValidator extends AbstractValidator {
         if (src.isEqual(dst)) {
             throw new BadRequestException(
                     ErrorCode.INVALID_EXPIRE_DATE,
-                    "아직 반납기한을 확장할 수 없습니다."
+                    "이미 사물함 반납을 연장하였습니다."
             );
         }
     }

--- a/src/main/java/net/causw/domain/validation/LockerExpiredAtValidator.java
+++ b/src/main/java/net/causw/domain/validation/LockerExpiredAtValidator.java
@@ -2,6 +2,7 @@ package net.causw.domain.validation;
 
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
+import net.causw.domain.model.util.MessageUtil;
 
 import java.time.LocalDateTime;
 
@@ -29,7 +30,7 @@ public class LockerExpiredAtValidator extends AbstractValidator {
         if (src.isAfter(dst)) {
             throw new BadRequestException(
                     ErrorCode.INVALID_EXPIRE_DATE,
-                    "잘못된 반납날 입니다."
+                    MessageUtil.LOCKER_INVALID_EXPIRE_DATE
             );
         }
     }

--- a/src/main/java/net/causw/domain/validation/LockerExtendAccessValidator.java
+++ b/src/main/java/net/causw/domain/validation/LockerExtendAccessValidator.java
@@ -1,0 +1,26 @@
+package net.causw.domain.validation;
+
+import net.causw.domain.exceptions.BadRequestException;
+import net.causw.domain.exceptions.ErrorCode;
+
+public class LockerExtendAccessValidator extends AbstractValidator {
+    private final Boolean flag;
+
+    private LockerExtendAccessValidator(Boolean flag) {
+        this.flag = flag;
+    }
+
+    public static LockerExtendAccessValidator of(Boolean flag) {
+        return new LockerExtendAccessValidator(flag);
+    }
+
+    @Override
+    public void validate() {
+        if (!flag) {
+            throw new BadRequestException(
+                    ErrorCode.FLAG_NOT_AVAILABLE,
+                    "사물함 연장 신청 기간이 아닙니다. 공지를 확인해주세요."
+            );
+        }
+    }
+}

--- a/src/main/java/net/causw/domain/validation/LockerExtendAccessValidator.java
+++ b/src/main/java/net/causw/domain/validation/LockerExtendAccessValidator.java
@@ -2,6 +2,7 @@ package net.causw.domain.validation;
 
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
+import net.causw.domain.model.util.MessageUtil;
 
 public class LockerExtendAccessValidator extends AbstractValidator {
     private final Boolean flag;
@@ -19,8 +20,7 @@ public class LockerExtendAccessValidator extends AbstractValidator {
         if (!flag) {
             throw new BadRequestException(
                     ErrorCode.FLAG_NOT_AVAILABLE,
-                    "사물함 연장 신청 기간이 아닙니다. 공지를 확인해주세요."
-            );
+                    MessageUtil.LOCKER_EXTEND_NOT_ALLOWED);
         }
     }
 }

--- a/src/main/java/net/causw/domain/validation/LockerInUseValidator.java
+++ b/src/main/java/net/causw/domain/validation/LockerInUseValidator.java
@@ -2,6 +2,7 @@ package net.causw.domain.validation;
 
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
+import net.causw.domain.model.util.MessageUtil;
 
 public class LockerInUseValidator extends AbstractValidator {
     private final Boolean isInUse;
@@ -19,7 +20,7 @@ public class LockerInUseValidator extends AbstractValidator {
         if (isInUse) {
             throw new BadRequestException(
                     ErrorCode.CANNOT_PERFORMED,
-                    "사용 중인 사물함입니다."
+                    MessageUtil.LOCKER_USED
             );
         }
     }


### PR DESCRIPTION
### 🚩 관련사항
#583 

### 📢 전달사항
사물함의 연장날짜가 expiredat과 동일하면 이미 연장했다고 다루도록 로직 변경
flag에 LOCKER_EXTEND 추가(연장 날짜에 맞는지 확인하기 위함)

### 📃 진행사항
- [ ] 프론트와의 연동(내일 오픈 전까지)

### ⚙️ 기타사항
없습니다. 
