### PR TITLE
chore: AOP 기반 메서드별 이름/실행시간 로깅 #658

### DIFF
--- a/src/main/java/net/causw/application/board/BoardService.java
+++ b/src/main/java/net/causw/application/board/BoardService.java
@@ -18,6 +18,7 @@ import net.causw.application.dto.user.UserResponseDto;
 import net.causw.application.dto.util.dtoMapper.BoardDtoMapper;
 import net.causw.application.dto.util.dtoMapper.PostDtoMapper;
 import net.causw.application.dto.util.dtoMapper.UserDtoMapper;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.UnauthorizedException;
@@ -42,7 +43,7 @@ import jakarta.validation.Validator;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
+@MeasureTime
 @Service
 @RequiredArgsConstructor
 public class BoardService {

--- a/src/main/java/net/causw/application/calendar/CalendarService.java
+++ b/src/main/java/net/causw/application/calendar/CalendarService.java
@@ -11,6 +11,7 @@ import net.causw.application.dto.calendar.CalendarUpdateRequestDto;
 import net.causw.application.dto.calendar.CalendarsResponseDto;
 import net.causw.application.dto.util.dtoMapper.CalendarDtoMapper;
 import net.causw.application.uuidFile.UuidFileService;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.model.enums.FilePath;
@@ -20,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-
+@MeasureTime
 @Service
 @RequiredArgsConstructor
 public class CalendarService {

--- a/src/main/java/net/causw/application/circle/CircleMemberService.java
+++ b/src/main/java/net/causw/application/circle/CircleMemberService.java
@@ -5,6 +5,7 @@ import net.causw.adapter.persistence.circle.Circle;
 import net.causw.adapter.persistence.circle.CircleMember;
 import net.causw.adapter.persistence.repository.circle.CircleMemberRepository;
 import net.causw.adapter.persistence.user.User;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.model.enums.CircleMemberStatus;
 import org.springframework.stereotype.Service;
 
@@ -12,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
+@MeasureTime
 @Service
 @RequiredArgsConstructor
 public class CircleMemberService {

--- a/src/main/java/net/causw/application/circle/CircleService.java
+++ b/src/main/java/net/causw/application/circle/CircleService.java
@@ -23,6 +23,7 @@ import net.causw.application.dto.util.dtoMapper.CircleDtoMapper;
 import net.causw.application.dto.util.StatusUtil;
 import net.causw.application.excel.CircleExcelService;
 import net.causw.application.uuidFile.UuidFileService;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
@@ -45,7 +46,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static net.causw.application.dto.board.BoardOfCircleResponseDto.isWriteable;
-
+@MeasureTime
 @Service
 @RequiredArgsConstructor
 public class CircleService {

--- a/src/main/java/net/causw/application/comment/ChildCommentService.java
+++ b/src/main/java/net/causw/application/comment/ChildCommentService.java
@@ -20,6 +20,7 @@ import net.causw.application.dto.comment.ChildCommentResponseDto;
 import net.causw.application.dto.comment.ChildCommentUpdateRequestDto;
 import net.causw.application.dto.util.dtoMapper.CommentDtoMapper;
 import net.causw.application.dto.util.StatusUtil;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
@@ -36,7 +37,7 @@ import jakarta.validation.Validator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-
+@MeasureTime
 @Service
 @RequiredArgsConstructor
 public class ChildCommentService {

--- a/src/main/java/net/causw/application/comment/CommentService.java
+++ b/src/main/java/net/causw/application/comment/CommentService.java
@@ -23,6 +23,7 @@ import net.causw.application.dto.comment.CommentResponseDto;
 import net.causw.application.dto.comment.CommentUpdateRequestDto;
 import net.causw.application.dto.util.dtoMapper.CommentDtoMapper;
 import net.causw.application.dto.util.StatusUtil;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
@@ -41,7 +42,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
+@MeasureTime
 @Service
 @RequiredArgsConstructor
 public class CommentService {

--- a/src/main/java/net/causw/application/common/CommonService.java
+++ b/src/main/java/net/causw/application/common/CommonService.java
@@ -5,11 +5,12 @@ import net.causw.adapter.persistence.flag.Flag;
 import net.causw.adapter.persistence.repository.flag.FlagRepository;
 import net.causw.adapter.persistence.repository.textField.TextFieldRepository;
 import net.causw.adapter.persistence.textfield.TextField;
+import net.causw.domain.aop.annotation.MeasureTime;
 import org.springframework.stereotype.Service;
 
 import jakarta.transaction.Transactional;
 import java.util.Optional;
-
+@MeasureTime
 @Service
 @RequiredArgsConstructor
 public class CommonService {

--- a/src/main/java/net/causw/application/crawler/WebCrawlerService.java
+++ b/src/main/java/net/causw/application/crawler/WebCrawlerService.java
@@ -5,6 +5,7 @@ import net.causw.adapter.persistence.crawled.CrawledNotice;
 import net.causw.adapter.persistence.crawled.LatestCrawl;
 import net.causw.adapter.persistence.repository.crawled.CrawledNoticeRepository;
 import net.causw.adapter.persistence.repository.crawled.LatestCrawlRepository;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.model.enums.CrawlCategory;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -18,7 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-
+@MeasureTime
 @Service
 @RequiredArgsConstructor
 public class WebCrawlerService {

--- a/src/main/java/net/causw/application/event/EventService.java
+++ b/src/main/java/net/causw/application/event/EventService.java
@@ -11,6 +11,7 @@ import net.causw.application.dto.event.EventUpdateRequestDto;
 import net.causw.application.dto.event.EventsResponseDto;
 import net.causw.application.dto.util.dtoMapper.EventDtoMapper;
 import net.causw.application.uuidFile.UuidFileService;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.model.enums.FilePath;
@@ -21,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-
+@MeasureTime
 @Service
 @RequiredArgsConstructor
 public class EventService {

--- a/src/main/java/net/causw/application/excel/CircleExcelService.java
+++ b/src/main/java/net/causw/application/excel/CircleExcelService.java
@@ -3,6 +3,7 @@ package net.causw.application.excel;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletResponse;
 import net.causw.application.dto.circle.CircleMemberResponseDto;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
 import net.causw.domain.model.util.MessageUtil;
@@ -17,7 +18,7 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-
+@MeasureTime
 @Service
 public class CircleExcelService extends ExcelAbstractService<CircleMemberResponseDto> {
 

--- a/src/main/java/net/causw/application/excel/CouncilFeeExcelService.java
+++ b/src/main/java/net/causw/application/excel/CouncilFeeExcelService.java
@@ -1,13 +1,14 @@
 package net.causw.application.excel;
 
 import net.causw.application.dto.userCouncilFee.UserCouncilFeeResponseDto;
+import net.causw.domain.aop.annotation.MeasureTime;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-
+@MeasureTime
 @Service
 public class CouncilFeeExcelService extends ExcelAbstractService<UserCouncilFeeResponseDto> {
 

--- a/src/main/java/net/causw/application/form/FormService.java
+++ b/src/main/java/net/causw/application/form/FormService.java
@@ -14,6 +14,7 @@ import net.causw.adapter.persistence.repository.form.ReplyRepository;
 import net.causw.adapter.persistence.repository.user.UserRepository;
 import net.causw.application.dto.form.*;
 import net.causw.application.dto.util.dtoMapper.FormDtoMapper;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
@@ -32,7 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.stream.Collectors;
-
+@MeasureTime
 @Service
 @RequiredArgsConstructor
 public class FormService {

--- a/src/main/java/net/causw/application/homepage/HomePageService.java
+++ b/src/main/java/net/causw/application/homepage/HomePageService.java
@@ -15,6 +15,7 @@ import net.causw.application.dto.homepage.HomePageResponseDto;
 import net.causw.application.dto.board.BoardResponseDto;
 import net.causw.application.dto.util.dtoMapper.BoardDtoMapper;
 import net.causw.application.dto.util.dtoMapper.PostDtoMapper;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.model.enums.Role;
@@ -27,7 +28,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.*;
 import java.util.stream.Collectors;
-
+@MeasureTime
 @Service
 @RequiredArgsConstructor
 public class HomePageService {

--- a/src/main/java/net/causw/application/inquiry/InquiryService.java
+++ b/src/main/java/net/causw/application/inquiry/InquiryService.java
@@ -7,6 +7,7 @@ import net.causw.adapter.persistence.repository.user.UserRepository;
 import net.causw.adapter.persistence.user.User;
 import net.causw.application.dto.inquiry.InquiryCreateRequestDto;
 import net.causw.application.dto.inquiry.InquiryResponseDto;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.model.util.MessageUtil;
@@ -20,7 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.validation.Validator;
-
+@MeasureTime
 @Service
 @RequiredArgsConstructor
 public class InquiryService {

--- a/src/main/java/net/causw/application/locker/LockerService.java
+++ b/src/main/java/net/causw/application/locker/LockerService.java
@@ -21,6 +21,7 @@ import net.causw.application.dto.locker.LockerMoveRequestDto;
 import net.causw.application.dto.locker.LockerResponseDto;
 import net.causw.application.dto.locker.LockerUpdateRequestDto;
 import net.causw.application.dto.locker.LockersResponseDto;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
@@ -45,7 +46,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
+@MeasureTime
 @Service
 @RequiredArgsConstructor
 public class LockerService {

--- a/src/main/java/net/causw/application/post/PostService.java
+++ b/src/main/java/net/causw/application/post/PostService.java
@@ -32,6 +32,7 @@ import net.causw.application.dto.util.dtoMapper.CommentDtoMapper;
 import net.causw.application.dto.util.dtoMapper.PostDtoMapper;
 import net.causw.application.dto.util.StatusUtil;
 import net.causw.application.uuidFile.UuidFileService;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
@@ -51,7 +52,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.*;
 import java.util.stream.Collectors;
-
+@MeasureTime
 @Service
 @RequiredArgsConstructor
 public class PostService {

--- a/src/main/java/net/causw/application/semester/SemesterService.java
+++ b/src/main/java/net/causw/application/semester/SemesterService.java
@@ -12,6 +12,7 @@ import net.causw.adapter.persistence.userCouncilFee.UserCouncilFee;
 import net.causw.application.dto.semester.CreateSemesterRequestDto;
 import net.causw.application.dto.semester.CurrentSemesterResponseDto;
 import net.causw.application.dto.util.dtoMapper.SemesterDtoMapper;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.model.enums.AcademicStatus;
@@ -21,7 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-
+@MeasureTime
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/src/main/java/net/causw/application/storage/StorageManager.java
+++ b/src/main/java/net/causw/application/storage/StorageManager.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
 import net.causw.domain.model.enums.FilePath;
@@ -17,7 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
-
+@MeasureTime
 @Component
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class StorageManager {

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -37,6 +37,7 @@ import net.causw.application.dto.util.dtoMapper.PostDtoMapper;
 import net.causw.application.dto.util.dtoMapper.UserDtoMapper;
 import net.causw.application.uuidFile.UuidFileService;
 import net.causw.config.security.JwtTokenProvider;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
@@ -75,7 +76,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
-
+@MeasureTime
 @Service
 @RequiredArgsConstructor
 public class UserService {

--- a/src/main/java/net/causw/application/userAcademicRecord/UserAcademicRecordApplicationService.java
+++ b/src/main/java/net/causw/application/userAcademicRecord/UserAcademicRecordApplicationService.java
@@ -15,6 +15,7 @@ import net.causw.application.dto.userAcademicRecordApplication.*;
 import net.causw.application.dto.util.dtoMapper.SemesterDtoMapper;
 import net.causw.application.dto.util.dtoMapper.UserAcademicRecordDtoMapper;
 import net.causw.application.uuidFile.UuidFileService;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
@@ -31,7 +32,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
-
+@MeasureTime
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor

--- a/src/main/java/net/causw/application/userCouncilFee/UserCouncilFeeService.java
+++ b/src/main/java/net/causw/application/userCouncilFee/UserCouncilFeeService.java
@@ -14,6 +14,7 @@ import net.causw.application.dto.userCouncilFee.*;
 import net.causw.application.dto.util.dtoMapper.UserCouncilFeeDtoMapper;
 import net.causw.application.excel.CouncilFeeExcelService;
 import net.causw.application.semester.SemesterService;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.model.enums.CouncilFeeLogType;
@@ -24,7 +25,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-
+@MeasureTime
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/src/main/java/net/causw/application/uuidFile/CleanUnusedUuidFileService.java
+++ b/src/main/java/net/causw/application/uuidFile/CleanUnusedUuidFileService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.causw.adapter.persistence.repository.uuidFile.*;
 import net.causw.adapter.persistence.uuidFile.*;
 import net.causw.adapter.persistence.uuidFile.joinEntity.*;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.model.util.RedisUtils;
 import net.causw.domain.model.util.StaticValue;
 import org.springframework.batch.core.StepExecution;
@@ -16,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
+@MeasureTime
 @Slf4j
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/net/causw/application/uuidFile/UuidFileService.java
+++ b/src/main/java/net/causw/application/uuidFile/UuidFileService.java
@@ -8,6 +8,7 @@ import net.causw.adapter.persistence.repository.uuidFile.CircleMainImageReposito
 import net.causw.adapter.persistence.uuidFile.UuidFile;
 import net.causw.adapter.persistence.repository.uuidFile.UuidFileRepository;
 import net.causw.application.storage.StorageManager;
+import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
@@ -22,7 +23,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
+@MeasureTime
 @Service
 @Transactional(readOnly = true)
 public class UuidFileService extends StorageManager {

--- a/src/main/java/net/causw/domain/aop/LogAspect.java
+++ b/src/main/java/net/causw/domain/aop/LogAspect.java
@@ -1,0 +1,39 @@
+package net.causw.domain.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+@Slf4j
+@Aspect
+@Component
+public class LogAspect {
+
+    // @MeasureTime 애노테이션이 붙은 클래스의 메서드를 대상으로 설정
+    @Pointcut("@within(net.causw.domain.aop.annotation.MeasureTime)")
+    private void timer(){}
+
+    // 메서드 실행 전,후로 시간을 측정하고, 실행된 메서드와 실행시간을 로깅
+    @Around("timer()")
+    public Object loggingExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        StopWatch stopWatch = new StopWatch();
+
+        stopWatch.start();
+        Object result = joinPoint.proceed(); // 조인포인트의 메서드 실행
+        stopWatch.stop();
+
+        long totalTimeMillis = stopWatch.getTotalTimeMillis();
+
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String methodName = signature.getMethod().getName();
+
+        log.info("실행된 메서드: {}, 실행시간 = {}ms", methodName, totalTimeMillis);
+
+        return result;
+    }
+}

--- a/src/main/java/net/causw/domain/aop/annotation/MeasureTime.java
+++ b/src/main/java/net/causw/domain/aop/annotation/MeasureTime.java
@@ -1,0 +1,11 @@
+package net.causw.domain.aop.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MeasureTime {
+}


### PR DESCRIPTION
### 🚩 관련사항
- #658


### 📢 전달사항
> 현재 nohup.out에 기록된 로그를 분석하는 과정에서 어떤 메서드가 얼마나 실행되었는지 온전하게 분간하기 어렵습니다. 
> 가시성 높은 모니터링을 위해 Service 내부 모든 메서드가 실행될 때마다 아래와 같은 형태의 로그가 자동 출력되도록 설정했습니다. 
> "실행된 메서드: updateUser, 실행시간 = 5ms"

### 📃 진행사항
- [x] 커스텀 어노테이션 및 AOP 객체 도입
- [x] Service Layer에 적용 및 검증

### ⚙️ 기타사항
![image](https://github.com/user-attachments/assets/738bda46-d54f-40be-9e63-23ad770fbf8e)

위 이미지처럼 Service 내부 메서드 실행 시 자동으로 로깅됩니다.

개발기간: 1일