### PR TITLE
feat : 게시글 및 댓글에 알림 추가

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/board/Board.java
+++ b/src/main/java/net/causw/adapter/persistence/board/Board.java
@@ -56,6 +56,9 @@ public class Board extends BaseEntity {
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
     private Set<Post> postSet;
 
+    @Column(name = "is_default_notice", nullable = false)
+    @ColumnDefault("false")
+    private Boolean isDefaultNotice; // 모두에게 알림이 가야 하는 게시판인지?
 
     private Board(
             String id,
@@ -116,6 +119,7 @@ public class Board extends BaseEntity {
                 .is_anonymous_allowed(is_anonymous_allowed)
                 .circle(circle)
                 .postSet(new HashSet<>())
+                .isDefaultNotice(false)
                 .build();
     }
 

--- a/src/main/java/net/causw/adapter/persistence/notification/Notification.java
+++ b/src/main/java/net/causw/adapter/persistence/notification/Notification.java
@@ -1,0 +1,48 @@
+package net.causw.adapter.persistence.notification;
+
+import jakarta.persistence.*;
+import lombok.*;
+import net.causw.adapter.persistence.base.BaseEntity;
+import net.causw.adapter.persistence.user.User;
+import net.causw.domain.model.enums.NoticeType;
+import org.hibernate.annotations.ColumnDefault;
+
+@Getter
+@Setter
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "tb_notification")
+public class Notification extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = true)
+    private User user;
+
+    @Column(name = "content")
+    private String content;
+
+    @Column(name = "notice_type")
+    @Enumerated(EnumType.STRING)
+    private NoticeType noticeType;
+
+    @Column(name = "is_global")
+    @ColumnDefault("false")
+    private Boolean isGlobal;
+
+    public static Notification of(
+            User user,
+            String content,
+            NoticeType noticeType,
+            Boolean isGlobal
+    ) {
+        return Notification.builder()
+                .user(user)
+                .content(content)
+                .noticeType(noticeType)
+                .isGlobal(isGlobal)
+                .build();
+    }
+
+}

--- a/src/main/java/net/causw/adapter/persistence/notification/UserBoardSubscribe.java
+++ b/src/main/java/net/causw/adapter/persistence/notification/UserBoardSubscribe.java
@@ -1,0 +1,46 @@
+package net.causw.adapter.persistence.notification;
+
+import jakarta.persistence.*;
+import lombok.*;
+import net.causw.adapter.persistence.base.BaseEntity;
+import net.causw.adapter.persistence.board.Board;
+import net.causw.adapter.persistence.user.User;
+
+@Getter
+@Setter
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "tb_user_board_subscribe")
+public class UserBoardSubscribe extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    private Board board;
+
+    @Column(name = "is_subscribed")
+    private Boolean isSubscribed;
+
+    public UserBoardSubscribe toggle() {
+        this.setIsSubscribed(!this.getIsSubscribed());
+        return this;
+    }
+
+    public static UserBoardSubscribe of(
+            User user,
+            Board board,
+            Boolean isSubscribed
+    ) {
+        return UserBoardSubscribe.builder()
+                .user(user)
+                .board(board)
+                .isSubscribed(isSubscribed)
+                .build();
+    }
+
+}

--- a/src/main/java/net/causw/adapter/persistence/repository/notification/NotificationRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/notification/NotificationRepository.java
@@ -1,0 +1,20 @@
+package net.causw.adapter.persistence.repository.notification;
+
+import net.causw.adapter.persistence.notification.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, String> {
+    @Query(
+            value = "SELECT * " +
+                    "FROM tb_notification " +
+                    "WHERE user_id = :userId OR is_global = true " +
+                    "ORDER BY created_at DESC " +
+                    "LIMIT 4", nativeQuery = true)
+    List<Notification> findUserNotice(@Param("userId") String userId);
+}

--- a/src/main/java/net/causw/adapter/persistence/repository/notification/UserBoardSubscribeRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/notification/UserBoardSubscribeRepository.java
@@ -1,0 +1,15 @@
+package net.causw.adapter.persistence.repository.notification;
+
+import net.causw.adapter.persistence.notification.UserBoardSubscribe;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserBoardSubscribeRepository extends JpaRepository<UserBoardSubscribe, String> {
+    Optional<UserBoardSubscribe> findByUser_IdAndBoard_Id(String userId, String boardId);
+
+    List<UserBoardSubscribe> findByBoard_Id(String boardId);
+}

--- a/src/main/java/net/causw/adapter/web/NotificationController.java
+++ b/src/main/java/net/causw/adapter/web/NotificationController.java
@@ -1,0 +1,37 @@
+package net.causw.adapter.web;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import net.causw.application.dto.notification.NotificationResponseDto;
+import net.causw.application.notification.NotificationService;
+import net.causw.config.security.userdetails.CustomUserDetails;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notifications")
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "알림 조회", description = "알림을 조회합니다.")
+    @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified()")
+    public List<NotificationResponseDto> findNotice(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return notificationService.findUserNotice(userDetails.getUser());
+    }
+
+    @PutMapping("/{boardId}")
+    @Operation(summary = "알림 설정 변경", description = "알림 설정을 변경합니다.")
+    @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified()")
+    public void toggleNotice(
+            @PathVariable("boardId") String boardId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        notificationService.setNotice(userDetails.getUser(), boardId);
+    }
+}

--- a/src/main/java/net/causw/application/comment/ChildCommentService.java
+++ b/src/main/java/net/causw/application/comment/ChildCommentService.java
@@ -7,11 +7,13 @@ import net.causw.adapter.persistence.circle.CircleMember;
 import net.causw.adapter.persistence.comment.ChildComment;
 import net.causw.adapter.persistence.comment.Comment;
 import net.causw.adapter.persistence.comment.LikeChildComment;
+import net.causw.adapter.persistence.notification.Notification;
 import net.causw.adapter.persistence.post.Post;
 import net.causw.adapter.persistence.repository.circle.CircleMemberRepository;
 import net.causw.adapter.persistence.repository.comment.ChildCommentRepository;
 import net.causw.adapter.persistence.repository.comment.CommentRepository;
 import net.causw.adapter.persistence.repository.comment.LikeChildCommentRepository;
+import net.causw.adapter.persistence.repository.notification.NotificationRepository;
 import net.causw.adapter.persistence.repository.post.PostRepository;
 import net.causw.adapter.persistence.repository.user.UserRepository;
 import net.causw.adapter.persistence.user.User;
@@ -26,6 +28,7 @@ import net.causw.domain.exceptions.ErrorCode;
 import net.causw.domain.exceptions.InternalServerException;
 import net.causw.domain.exceptions.UnauthorizedException;
 import net.causw.domain.model.enums.CircleMemberStatus;
+import net.causw.domain.model.enums.NoticeType;
 import net.causw.domain.model.enums.Role;
 import net.causw.domain.model.util.MessageUtil;
 import net.causw.domain.model.util.StaticValue;
@@ -37,6 +40,7 @@ import jakarta.validation.Validator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+
 @MeasureTime
 @Service
 @RequiredArgsConstructor
@@ -48,6 +52,7 @@ public class ChildCommentService {
     private final CircleMemberRepository circleMemberRepository;
     private final PostRepository postRepository;
     private final LikeChildCommentRepository likeChildCommentRepository;
+    private final NotificationRepository notificationRepository;
     private final Validator validator;
 
     @Transactional
@@ -66,8 +71,18 @@ public class ChildCommentService {
         validatorBucket
                 .consistOf(ConstraintValidator.of(childComment, this.validator))
                 .consistOf(UserStateIsDeletedValidator.of(parentComment.getWriter().getState()));
-
         validatorBucket.validate();
+
+        if (!creator.getId().equals(childComment.getWriter().getId())) {
+            notificationRepository.save(
+                    Notification.of(
+                            parentComment.getWriter(),
+                            childComment.getContent(),
+                            NoticeType.COMMENT,
+                            false
+                    )
+            );
+        }
 
         return toChildCommentResponseDto(
                 childCommentRepository.save(childComment),

--- a/src/main/java/net/causw/application/dto/notification/NotificationResponseDto.java
+++ b/src/main/java/net/causw/application/dto/notification/NotificationResponseDto.java
@@ -1,0 +1,26 @@
+package net.causw.application.dto.notification;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import net.causw.domain.model.enums.NoticeType;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class NotificationResponseDto {
+    @Schema(description = "사용자 id", example = "uuid 형식의 String 값입니다.")
+    private String user_id;
+
+    @Schema(description = "알림 내용", example = "알림 내용입니다.")
+    private String content;
+
+    @Schema(description = "알림 종류", example = "POST")
+    private NoticeType noticeType;
+
+    @Schema(description = "전체 사용자 대상 알리 여부", example = "false")
+    private Boolean isGlobal;
+}

--- a/src/main/java/net/causw/application/dto/util/dtoMapper/NotificationDtoMapper.java
+++ b/src/main/java/net/causw/application/dto/util/dtoMapper/NotificationDtoMapper.java
@@ -1,0 +1,16 @@
+package net.causw.application.dto.util.dtoMapper;
+
+import net.causw.adapter.persistence.notification.Notification;
+import net.causw.application.dto.notification.NotificationResponseDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring")
+public interface NotificationDtoMapper {
+
+    NotificationDtoMapper INSTANCE = Mappers.getMapper(NotificationDtoMapper.class);
+
+    @Mapping(target = "user_id", source = "user.id")
+    NotificationResponseDto toNotificationResponseDto(Notification notification);
+}

--- a/src/main/java/net/causw/application/notification/NotificationService.java
+++ b/src/main/java/net/causw/application/notification/NotificationService.java
@@ -1,0 +1,54 @@
+package net.causw.application.notification;
+
+import lombok.RequiredArgsConstructor;
+import net.causw.adapter.persistence.board.Board;
+import net.causw.adapter.persistence.notification.UserBoardSubscribe;
+import net.causw.adapter.persistence.repository.board.BoardRepository;
+import net.causw.adapter.persistence.repository.notification.NotificationRepository;
+import net.causw.adapter.persistence.repository.notification.UserBoardSubscribeRepository;
+import net.causw.adapter.persistence.user.User;
+import net.causw.application.dto.notification.NotificationResponseDto;
+import net.causw.application.dto.util.dtoMapper.NotificationDtoMapper;
+import net.causw.domain.aop.annotation.MeasureTime;
+import net.causw.domain.exceptions.BadRequestException;
+import net.causw.domain.exceptions.ErrorCode;
+import net.causw.domain.model.util.MessageUtil;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@MeasureTime
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+    private final NotificationRepository notificationRepository;
+    private final UserBoardSubscribeRepository userBoardSubscribeRepository;
+    private final BoardRepository boardRepository;
+
+    @Transactional(readOnly = true)
+    public List<NotificationResponseDto> findUserNotice(User user) {
+        return notificationRepository.findUserNotice(user.getId()).stream()
+                .map(NotificationDtoMapper.INSTANCE::toNotificationResponseDto)
+                .toList();
+    }
+
+    @Transactional
+    public void setNotice(User user, String boardId) {
+        Board board = boardRepository.findById(boardId).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        MessageUtil.BOARD_NOT_FOUND
+                )
+        );
+
+        Optional<UserBoardSubscribe> find = userBoardSubscribeRepository.findByUser_IdAndBoard_Id(user.getId(), boardId);
+        if (find.isPresent()) {
+            UserBoardSubscribe userBoardSubscribe = find.get();
+            userBoardSubscribeRepository.save(userBoardSubscribe.toggle());
+        } else {
+            userBoardSubscribeRepository.save(UserBoardSubscribe.of(user, board, true));
+        }
+    }
+}

--- a/src/main/java/net/causw/domain/model/enums/NoticeType.java
+++ b/src/main/java/net/causw/domain/model/enums/NoticeType.java
@@ -1,0 +1,13 @@
+package net.causw.domain.model.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NoticeType {
+    POST("게시물 알림"),
+    COMMENT("댓글 알림");
+
+    private final String type;
+}


### PR DESCRIPTION
### 🚩 관련사항

#676 

### 📢 전달사항

- 전체 사용자 대상 알림 / 개별 사용자 대상 알림을 나눴습니다.
    - 전체 사용자 대상으로 알림이 필요할 때에 모든 사용자에 각각 Notification 객체를 생성하도록 하면 비효율적이라 생각하여 isGlobal 칼럼을 추가하였습니다.
    - 사용자의 알림 조회에는 [나에게 온 개별 알림] + [global 알림]으로 시간순으로 정렬하여 조회되도록 했습니다.
    - 게시판 알림 설정할 때에는 알림 켜기/끄기 API를 따로 두지 않고 토글 형태로 하였습니다.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.

<img width="1179" alt="image" src="https://github.com/user-attachments/assets/5ea73528-da1c-40ff-b32a-16d87b5c020c">


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 4시간