### PR TITLE
hotfix: toCircleResponseDto를 사용했을 때 mainImage가 null이 되는 오류 수정

### DIFF
--- a/src/main/java/net/causw/application/dto/util/dtoMapper/CircleDtoMapper.java
+++ b/src/main/java/net/causw/application/dto/util/dtoMapper/CircleDtoMapper.java
@@ -88,6 +88,7 @@ public interface CircleDtoMapper extends UuidFileToUrlDtoMapper {
     @Mapping(target = "leaderId", source = "leader.id")
     @Mapping(target = "leaderName", source = "leader.name")
     @Mapping(target = "createdAt", source = "circle.createdAt")
+    @Mapping(target = "mainImage", source = "circle.circleMainImage", qualifiedByName = "mapUuidFileToFileUrl")
     CircleResponseDto toCircleResponseDto(Circle circle, User leader);
 
     @Mapping(target = "email", source = "user.email")


### PR DESCRIPTION
### 🚩 관련사항


### 📢 전달사항
CircleDtoMapper의 toCircleResponseDto 메소드를 사용했을 때 mainImage가 매핑되어 있지 않아 null로 받는 오류가 있어
직접 매핑을 해주었습니다.

### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 