### PR TITLE
hotfix: 프로밀 및 증빙서류 이미지 null값 에러 수정

### DIFF
--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -699,15 +699,9 @@ public class UserService {
             );
         }
 
-        // User profile 이미지 nullable임 -> null로 요청 시 기존 이미지 삭제
-        UserProfileImage userProfileImage = null;
+        UserProfileImage userProfileImage = srcUser.getUserProfileImage();
 
-        if (profileImage.isEmpty()) {
-            if (user.getUserProfileImage() != null) {
-                uuidFileService.deleteFile(srcUser.getUserProfileImage().getUuidFile());
-                userProfileImageRepository.delete(srcUser.getUserProfileImage());
-            }
-        } else {
+        if (profileImage != null && !profileImage.isEmpty()) {
             if (srcUser.getUserProfileImage() == null) {
                 userProfileImage = UserProfileImage.of(
                         user,


### PR DESCRIPTION
### 🚩 관련사항
https://github.com/CAUCSE/CAUSW_backend/issues/690


### 📢 전달사항
프로필 이미지 null값 넣을 시 에러가 발생해서 해당 오류 수정하였습니다.

기본적으로 user의 프로필 이미지를 받아오며 해당api(개인정보 수정)에서 프로필 사진을 보내지 않았을 경우 수정하지 않도록 로직 수정하였습니다.


### 📸 스크린샷
이미 프로필 사진이 있는 사람이 파일을 안보냈을 경우 기존의 사진을 유지
![image](https://github.com/user-attachments/assets/f2c1a0b2-f328-405c-9fe3-efb0b61a6745)

프로필 이미지가 없는 사람이 파일을 안보냈을 경우 null값 유지(기본 이미지)
![image](https://github.com/user-attachments/assets/925d7845-fe75-49ec-bf25-1cfe8f9a1338)


### 📃 진행사항



### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 