### PR TITLE
hotfix: 동아리 수정 시 mainImage가 null이고 현재 mainImage도 null인 경우 예외 발생

### DIFF
--- a/src/main/java/net/causw/application/circle/CircleService.java
+++ b/src/main/java/net/causw/application/circle/CircleService.java
@@ -358,13 +358,12 @@ public class CircleService {
                 .validate();
 
 
-        // 이미지가 없을 경우 기존 이미지를 삭제, 이미지가 있을 경우 새로운 이미지로 교체 (Circle의 이미지는 not null임)
+        // 이미지가 없을 경우 기존 이미지 그대로 유지, 이미지가 있을 경우 새로운 이미지로 교체 (Circle의 이미지는 not null임)
         CircleMainImage circleMainImage = null;
 
-        if (mainImage.isEmpty()) {
-            if (circle.getCircleMainImage() != null) {
-                uuidFileService.deleteFile(circle.getCircleMainImage().getUuidFile());
-                circleMainImageRepository.delete(circle.getCircleMainImage());
+        if (mainImage == null || mainImage.isEmpty()) {
+            if (circle.getCircleMainImage() == null) {
+                throw new BadRequestException(ErrorCode.API_NOT_ALLOWED, MessageUtil.FILE_IS_NULL);
             }
         } else {
             if (circle.getCircleMainImage() == null) {

--- a/src/main/java/net/causw/application/form/FormService.java
+++ b/src/main/java/net/causw/application/form/FormService.java
@@ -440,7 +440,7 @@ public class FormService {
     private void validateCanAccessFormResult(User user, Form form) {
         if (form.getFormType().equals(FormType.POST_FORM)) {
             Post post = getPost(form);
-            if (post.getWriter().equals(user)) {
+            if (!post.getWriter().equals(user)) {
                 throw new UnauthorizedException(
                         ErrorCode.API_NOT_ALLOWED,
                         MessageUtil.NOT_ALLOWED_TO_ACCESS_REPLY


### PR DESCRIPTION
### 🚩 관련사항


### 📢 전달사항
동아리 정보 수정 시 mainImage를 null로 보내면 500 에러가 발생하는 문제가 있었습니다.
이는 동아리 mainImage가 null이 아니어야 했기 때문이었으므로,
현재 동아리 mainImage가 null이고, 수정 시에도 mainImage를 null로 유지하는 경우 400번대 에러가 발생하도록 하였습니다.
또한 현재 동아리 mainImage가 null이 아니고, 수정 시 mainImage를 null로 설정하면,
동아리 mainImage가 바뀌지 않도록 설정하였습니다.

+ 추가로 신청서 관련 에러가 있어 수정한 후 이 pr에 함께 push하였습니다.

### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 