### PR TITLE
hotfix: 신청서 결과 요약 조회 시 중복 응답 가능 여부와 총 응답수를 반환하도록 변경

### DIFF
--- a/src/main/java/net/causw/application/dto/form/response/QuestionSummaryResponseDto.java
+++ b/src/main/java/net/causw/application/dto/form/response/QuestionSummaryResponseDto.java
@@ -31,7 +31,7 @@ public class QuestionSummaryResponseDto {
     private List<OptionSummaryResponseDto> optionSummarieList;
 
     @Schema(description = "총 응답 수", example = "10")
-    private Integer numOfReply;
+    private Long numOfReply;
 
     @Schema(description = "복수 정답 여부(객관식일 때만)", defaultValue = "false", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private Boolean isMultiple;

--- a/src/main/java/net/causw/application/dto/form/response/QuestionSummaryResponseDto.java
+++ b/src/main/java/net/causw/application/dto/form/response/QuestionSummaryResponseDto.java
@@ -30,4 +30,10 @@ public class QuestionSummaryResponseDto {
     @Schema(description = "질문 답변 정보 List(객관식 질문일 경우)", example = "[OptionSummaryResponseDto, OptionSummaryResponseDto, ...]")
     private List<OptionSummaryResponseDto> optionSummarieList;
 
+    @Schema(description = "총 응답 수", example = "10")
+    private Integer numOfReply;
+
+    @Schema(description = "복수 정답 여부(객관식일 때만)", defaultValue = "false", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private Boolean isMultiple;
+
 }

--- a/src/main/java/net/causw/application/dto/util/dtoMapper/FormDtoMapper.java
+++ b/src/main/java/net/causw/application/dto/util/dtoMapper/FormDtoMapper.java
@@ -100,7 +100,9 @@ public interface FormDtoMapper {
     @Mapping(target = "questionText", source = "formQuestion.questionText")
     @Mapping(target = "questionAnswerList", source = "questionAnswerList")
     @Mapping(target = "optionSummarieList", source = "optionSummaryResponseDtoList")
-    QuestionSummaryResponseDto toQuestionSummaryResponseDto(FormQuestion formQuestion, List<String> questionAnswerList, List<OptionSummaryResponseDto> optionSummaryResponseDtoList) ;
+    @Mapping(target = "numOfReply", source = "numOfReply")
+    @Mapping(target = "isMultiple", source = "isMultiple")
+    QuestionSummaryResponseDto toQuestionSummaryResponseDto(FormQuestion formQuestion, List<String> questionAnswerList, List<OptionSummaryResponseDto> optionSummaryResponseDtoList, Integer numOfReply, Boolean isMultiple) ;
 
     @Mapping(target = "userId", source = "user.id")
     @Mapping(target = "email", source = "user.email")

--- a/src/main/java/net/causw/application/dto/util/dtoMapper/FormDtoMapper.java
+++ b/src/main/java/net/causw/application/dto/util/dtoMapper/FormDtoMapper.java
@@ -102,7 +102,7 @@ public interface FormDtoMapper {
     @Mapping(target = "optionSummarieList", source = "optionSummaryResponseDtoList")
     @Mapping(target = "numOfReply", source = "numOfReply")
     @Mapping(target = "isMultiple", source = "isMultiple")
-    QuestionSummaryResponseDto toQuestionSummaryResponseDto(FormQuestion formQuestion, List<String> questionAnswerList, List<OptionSummaryResponseDto> optionSummaryResponseDtoList, Integer numOfReply, Boolean isMultiple) ;
+    QuestionSummaryResponseDto toQuestionSummaryResponseDto(FormQuestion formQuestion, List<String> questionAnswerList, List<OptionSummaryResponseDto> optionSummaryResponseDtoList, Long numOfReply, Boolean isMultiple) ;
 
     @Mapping(target = "userId", source = "user.id")
     @Mapping(target = "email", source = "user.email")

--- a/src/main/java/net/causw/application/form/FormService.java
+++ b/src/main/java/net/causw/application/form/FormService.java
@@ -665,37 +665,43 @@ public class FormService {
             List<ReplyQuestion> replyQuestionList
     ) {
         if (formQuestion.getQuestionType().equals(QuestionType.SUBJECTIVE)) {
+            List<String> answerList = replyQuestionList.stream()
+                    .map(ReplyQuestion::getQuestionAnswer)
+                    .toList();
             return FormDtoMapper.INSTANCE.toQuestionSummaryResponseDto(
                     formQuestion,
-                    replyQuestionList.stream()
-                            .map(ReplyQuestion::getQuestionAnswer)
-                            .toList(),
+                    answerList,
                     null,
-                    findNumOfReply(replyQuestionList),
+                    (long) answerList.size(),
                     findIsMultiple(formQuestion)
             );
         } else {
+            List<OptionSummaryResponseDto> answerList = formQuestion.getFormQuestionOptionList().stream()
+                    .map(formQuestionOption -> {
+                        Long selectedCount = replyQuestionList
+                                .stream()
+                                .filter(replyQuestion -> replyQuestion.getSelectedOptionList().contains(formQuestionOption.getNumber()))
+                                .count();
+                        return toOptionSummaryResponseDto(formQuestionOption, selectedCount);
+                    })
+                    .toList();
             return FormDtoMapper.INSTANCE.toQuestionSummaryResponseDto(
                     formQuestion,
                     null,
-                    formQuestion.getFormQuestionOptionList().stream()
-                            .map(formQuestionOption -> {
-                                Long selectedCount = replyQuestionList
-                                        .stream()
-                                        .filter(replyQuestion -> replyQuestion.getSelectedOptionList().contains(formQuestionOption.getNumber()))
-                                        .count();
-                                return toOptionSummaryResponseDto(formQuestionOption, selectedCount);
-                            })
-                            .toList(),
-                    findNumOfReply(replyQuestionList),
+                    answerList,
+                    findNumOfReply(answerList),
                     findIsMultiple(formQuestion)
             );
         }
 
     }
 
-    private Integer findNumOfReply(List<ReplyQuestion> replyQuestionList) {
-        return replyQuestionList.size();
+    private Long findNumOfReply(List<OptionSummaryResponseDto> answerList) {
+        Long numOfReply = 0L;
+        for (OptionSummaryResponseDto optionSummaryResponseDto : answerList) {
+            numOfReply += optionSummaryResponseDto.getSelectedCount();
+        }
+        return numOfReply;
     }
 
     private Boolean findIsMultiple(FormQuestion formQuestion) {

--- a/src/main/java/net/causw/application/form/FormService.java
+++ b/src/main/java/net/causw/application/form/FormService.java
@@ -670,7 +670,9 @@ public class FormService {
                     replyQuestionList.stream()
                             .map(ReplyQuestion::getQuestionAnswer)
                             .toList(),
-                    null
+                    null,
+                    findNumOfReply(replyQuestionList),
+                    findIsMultiple(formQuestion)
             );
         } else {
             return FormDtoMapper.INSTANCE.toQuestionSummaryResponseDto(
@@ -684,10 +686,20 @@ public class FormService {
                                         .count();
                                 return toOptionSummaryResponseDto(formQuestionOption, selectedCount);
                             })
-                            .toList()
+                            .toList(),
+                    findNumOfReply(replyQuestionList),
+                    findIsMultiple(formQuestion)
             );
         }
 
+    }
+
+    private Integer findNumOfReply(List<ReplyQuestion> replyQuestionList) {
+        return replyQuestionList.size();
+    }
+
+    private Boolean findIsMultiple(FormQuestion formQuestion) {
+        return formQuestion.getIsMultiple();
     }
 
     private OptionSummaryResponseDto toOptionSummaryResponseDto(


### PR DESCRIPTION
### 🚩 관련사항


### 📢 전달사항
신청서 결과 요약 조회 시 반환하는 Dto에 중복 응답 가능 여부와 총 응답수를 나타내는 필드를 추가하였습니다.
또한 결과 요약 조회를 하는 메소드에서 각 필드에 값을 할당하도록 하였습니다.

### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 