### PR TITLE
fix: 댓글+대댓글의 수가 올바르도록 수정

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/repository/post/PostRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/post/PostRepository.java
@@ -54,6 +54,7 @@ public interface PostRepository extends JpaRepository<Post, String> {
     @Query("SELECT COUNT(cc) FROM ChildComment cc WHERE cc.parentComment.post.id = :postId AND cc.isDeleted = false")
     Long countChildCommentsByPostId(@Param("postId") String postId);
 
+    // 게시글에 작성된 모든댓글(댓글 + 대댓글)의 수 반환
     default Long countAllCommentByPost_Id(String postId) {
         Long commentCount = countCommentsByPostId(postId);
         Long childCommentCount = countChildCommentsByPostId(postId);


### PR DESCRIPTION
### 🚩 관련사항
관련된 이슈번호 혹은 pr번호를 기록합니다.


### 📢 전달사항
QA Test 도중 총댓글의 수가 잘못 나타나는 버그가 발견되어 총 댓글의 수가 올바르게 반환되도록 쿼리문을 수정하였습니다.


### 📸 스크린샷
기존
![댓글1](https://github.com/user-attachments/assets/8f4dec29-402f-42a5-aedc-388f26f2519c)
![4개](https://github.com/user-attachments/assets/2817e8b0-0771-4978-9902-a2fec0f35d63)
4개인데 댓글 수 3개로 표시

수정 후
![댓글수](https://github.com/user-attachments/assets/3a83dcbc-b811-4f4b-ad40-f2fb9735d658)

수정후 댓글수가 올바르게 4개 반환됨을 확인 할 수 있습니다.

### 📃 진행사항
- [x] 댓글 수 계산 쿼리문 변경


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 