### PR TITLE
hotfix: 유저 삭제시 재학인증 기록, 이미지 미삭제 오류 해결

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/repository/userAcademicRecord/UserAcademicRecordApplicationRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/userAcademicRecord/UserAcademicRecordApplicationRepository.java
@@ -26,4 +26,6 @@ public interface UserAcademicRecordApplicationRepository extends JpaRepository<U
             User user
     );
 
+    List<UserAcademicRecordApplication> findByUserId(String userId);
+
 }

--- a/src/main/java/net/causw/adapter/persistence/repository/uuidFile/UserAcademicRecordApplicationAttachImageRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/uuidFile/UserAcademicRecordApplicationAttachImageRepository.java
@@ -4,6 +4,9 @@ import net.causw.adapter.persistence.uuidFile.joinEntity.UserAcademicRecordAppli
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface UserAcademicRecordApplicationAttachImageRepository extends JpaRepository<UserAcademicRecordApplicationAttachImage, Long> {
+    List<UserAcademicRecordApplicationAttachImage> findByUserAcademicRecordApplicationId(String userAcademicRecordApplicationId);
 }

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -3,10 +3,13 @@ package net.causw.application.user;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import net.causw.adapter.persistence.base.BaseEntity;
 import net.causw.adapter.persistence.board.Board;
 import net.causw.adapter.persistence.circle.Circle;
 import net.causw.adapter.persistence.circle.CircleMember;
 import net.causw.adapter.persistence.locker.LockerLog;
+import net.causw.adapter.persistence.repository.userAcademicRecord.UserAcademicRecordApplicationRepository;
+import net.causw.adapter.persistence.repository.uuidFile.UserAcademicRecordApplicationAttachImageRepository;
 import net.causw.adapter.persistence.repository.uuidFile.UserProfileImageRepository;
 import net.causw.adapter.persistence.uuidFile.joinEntity.UserAdmissionAttachImage;
 import net.causw.adapter.persistence.uuidFile.joinEntity.UserProfileImage;
@@ -114,6 +117,8 @@ public class UserService {
     private final LikePostRepository likePostRepository;
     private final UserProfileImageRepository userProfileImageRepository;
     private final UserExcelService userExcelService;
+    private final UserAcademicRecordApplicationRepository userAcademicRecordApplicationRepository;
+    private final UserAcademicRecordApplicationAttachImageRepository userAcademicRecordApplicationAttachImageRepository;
 
     @Transactional
     public UserResponseDto findPassword(
@@ -1062,6 +1067,17 @@ public class UserService {
                         this.updateStatus(circleMember.getId(), CircleMemberStatus.LEAVE)
                 );
 
+        // 재학 인증 신청 이미지 파일이 있다면 삭제
+        this.userAcademicRecordApplicationRepository.findByUserId(deleteUser.getId()).stream()
+                .map(BaseEntity::getId)
+                .forEach(userAcademicRecordApplicationId -> {
+                    this.userAcademicRecordApplicationAttachImageRepository.deleteAll(
+                            this.userAcademicRecordApplicationAttachImageRepository.findByUserAcademicRecordApplicationId(userAcademicRecordApplicationId)
+                    );
+                });
+
+        // 재학 인증 신청 기록이 있다면 삭제
+        this.userAcademicRecordApplicationRepository.deleteAll(this.userAcademicRecordApplicationRepository.findByUserId(deleteUser.getId()));
         this.userRepository.delete(deleteUser);
 
         return UserDtoMapper.INSTANCE.toUserResponseDto(deleteUser, null, null);


### PR DESCRIPTION
### 🚩 관련사항


### 📢 전달사항
유저 삭제 시 해당 유저가 재학 인증 기록과 재학 인증 이미지가 있을 때 삭제되지 않는 오류를 해결하였습니다.
유저가 삭제될 때 해당 기록과 이미지도 함께 삭제되도록 하였습니다.

### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 