### PR TITLE
 [FIX] 비밀번호 재발급 정상 작동 검증 및 로직 개선 

### DIFF
--- a/src/main/java/net/causw/adapter/web/UserController.java
+++ b/src/main/java/net/causw/adapter/web/UserController.java
@@ -368,8 +368,8 @@ public class UserController {
     @PutMapping(value = "/password/find")
     @ResponseStatus(value = HttpStatus.OK)
     @Operation(summary = "비밀번호 찾기 API (완료)", description = "비밀번호 재설정 이메일 전송 API입니다.")
-    public UserResponseDto findPassword(@Valid @RequestBody UserFindPasswordRequestDto userFindPasswordRequestDto) {
-        return this.userService.findPassword(userFindPasswordRequestDto);
+    public void findPassword(@Valid @RequestBody UserFindPasswordRequestDto userFindPasswordRequestDto) {
+        this.userService.findPassword(userFindPasswordRequestDto);
     }
 
     @PutMapping(value = "/password")

--- a/src/main/java/net/causw/domain/exceptions/NotFoundException.java
+++ b/src/main/java/net/causw/domain/exceptions/NotFoundException.java
@@ -1,0 +1,7 @@
+package net.causw.domain.exceptions;
+
+public class NotFoundException extends BaseRuntimeException {
+    public NotFoundException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}


### PR DESCRIPTION
#748 <- 해당 이슈에 검증 과정 기록해 놓았습니다.

## Description
이번 PR에서는 다음과 같은 변경 사항이 적용되었습니다:

- 에러 클래스 추가:
NotFoundException 클래스를 새로 생성하여, BadRequestException 대신 사용하도록 수정했습니다.
더 정확한 예외 처리를 위해, 리소스가 존재하지 않을 때 NotFoundException을 사용합니다.

- 비밀번호 찾기 API 개선:
UserService에서 비밀번호 변경 전에 메일 전송을 먼저 수행하도록 로직 순서를 수정했습니다.
dirty checking을 활용하여 userRepository.save() 호출을 제거했습니다.
findByEmailAndNameAndStudentIdAndPhoneNumber 메서드 호출 시, DTO 필드 값에 trim()을 적용해 불필요한 공백이 제거되도록 했습니다.

- Controller 리턴 타입 변경:
findPassword 메서드의 리턴 타입을 UserResponseDto에서 void로 수정했습니다. 이 메서드는 비밀번호 재설정 메일 전송을 담당하기 때문에, 별도의 응답 DTO가 필요하지 않습니다.
