### PR TITLE
fix: uuidfile 객체 OneToOne -> ManyToOne으로 버그 픽스

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/uuidFile/joinEntity/UserAcademicRecordLogAttachImage.java
+++ b/src/main/java/net/causw/adapter/persistence/uuidFile/joinEntity/UserAcademicRecordLogAttachImage.java
@@ -19,8 +19,8 @@ public class UserAcademicRecordLogAttachImage extends JoinEntity {
 
     @Getter
     @Setter(AccessLevel.PUBLIC)
-    @OneToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "uuid_file_id", nullable = false, unique = true)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "uuid_file_id", nullable = false, unique = false)
     public UuidFile uuidFile;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/net/causw/adapter/persistence/uuidFile/joinEntity/UserAdmissionLogAttachImage.java
+++ b/src/main/java/net/causw/adapter/persistence/uuidFile/joinEntity/UserAdmissionLogAttachImage.java
@@ -19,8 +19,8 @@ public class UserAdmissionLogAttachImage extends JoinEntity {
 
     @Getter
     @Setter(AccessLevel.PUBLIC)
-    @OneToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "uuid_file_id", nullable = false, unique = true)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "uuid_file_id", nullable = false, unique = false)
     public UuidFile uuidFile;
 
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
### 🚩 관련사항


### 📢 전달사항
academic record log가 동일한 파일 entity row를 fk로 참조하지 못했던 문제를 @OneToOne에서 @ManyToOne으로 바꿔 해결했습니다. (unique 제약 조건 제거)

### 📸 스크린샷


### 📃 진행사항


### ⚙️ 기타사항

개발기간: 1일