### PR TITLE
fix: User Admission API 수정

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/repository/user/UserAdmissionRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/user/UserAdmissionRepository.java
@@ -1,6 +1,7 @@
 package net.causw.adapter.persistence.repository.user;
 
 import net.causw.adapter.persistence.user.UserAdmission;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -25,5 +26,10 @@ public interface UserAdmissionRepository extends JpaRepository<UserAdmission, St
             "LEFT JOIN tb_user AS u ON ua.user_id = u.id " +
             "LEFT JOIN tb_user_admission_attach_image_uuid_file AS uai ON ua.id = uai.user_admission_id " +
             "WHERE u.state = :user_state AND (:name IS NULL OR u.name LIKE %:name%) ORDER BY ua.created_at DESC", nativeQuery = true)
-    Page<UserAdmission> findAllWithName(@Param("user_state") String userState, @Param("name") String name, Pageable pageable);
+    Page<UserAdmission> findAllWithStateAneName(@Param("user_state") String userState, @Param("name") String name, Pageable pageable);
+
+    @NotNull Page<UserAdmission> findAll(@NotNull Pageable pageable);
+
+    Page<UserAdmission> findAllByUserName(String name, Pageable pageable);
+
 }

--- a/src/main/java/net/causw/adapter/web/UserController.java
+++ b/src/main/java/net/causw/adapter/web/UserController.java
@@ -506,16 +506,6 @@ public class UserController {
         return this.userService.getCurrentUserAdmission(userDetails.getUser());
     }
 
-    @PutMapping(value = "/admissions/apply")
-    @ResponseStatus(value = HttpStatus.OK)
-    public UserAdmissionResponseDto updateAdmission(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestPart(value = "userAdmissionCreateRequestDto") @Valid UserAdmissionCreateRequestDto userAdmissionCreateRequestDto,
-            @RequestPart(value = "userAdmissionAttachImageList") List<MultipartFile> userAdmissionAttachImageList
-    ) {
-        return userService.updateAdmission(userDetails.getUser(), userAdmissionCreateRequestDto, userAdmissionAttachImageList);
-    }
-
     @PutMapping(value = "/admissions/{id}/accept")
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
             "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -1234,8 +1234,13 @@ public class UserService {
                 .consistOf(UserRoleValidator.of(roles, Set.of()))
                 .validate();
 
-        return this.userAdmissionRepository.findAllWithName(UserState.AWAIT.getValue(), name, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_PAGE_SIZE))
-                .map(UserDtoMapper.INSTANCE::toUserAdmissionsResponseDto);
+        if (name == null) {
+            return userAdmissionRepository.findAll(this.pageableFactory.create(pageNum, StaticValue.DEFAULT_PAGE_SIZE))
+                    .map(UserDtoMapper.INSTANCE::toUserAdmissionsResponseDto);
+        } else {
+            return this.userAdmissionRepository.findAllByUserName(name, this.pageableFactory.create(pageNum, StaticValue.DEFAULT_PAGE_SIZE))
+                    .map(UserDtoMapper.INSTANCE::toUserAdmissionsResponseDto);
+        }
     }
 
     @Transactional
@@ -1414,7 +1419,7 @@ public class UserService {
 
         this.userAdmissionRepository.delete(userAdmission);
 
-        requestUser.updateRejectionOrDropReason(rejectReason);
+        userAdmission.getUser().updateRejectionOrDropReason(rejectReason);
         this.userRepository.save(requestUser);
 
         return UserDtoMapper.INSTANCE.toUserAdmissionResponseDto(

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -1263,6 +1263,13 @@ public class UserService {
             );
         }
 
+        if ( !(user.getState().equals(UserState.AWAIT) || user.getState().equals(UserState.ACTIVE)) ) {
+            throw new BadRequestException(
+                    ErrorCode.INVALID_REQUEST_USER_STATE,
+                    MessageUtil.INVALID_USER_APPLICATION_USER_STATE
+            );
+        }
+
         if (userAdmissionAttachImageList.isEmpty()) {
             throw new BadRequestException(
                     ErrorCode.INVALID_PARAMETER,

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -1397,7 +1397,7 @@ public class UserService {
                         MessageUtil.ADMISSION_EXCEPTION
                 ));
 
-        userRepository.save(targetUser);`
+        userRepository.save(targetUser);
 
         return UserDtoMapper.INSTANCE.toUserAdmissionResponseDto(
                 userAdmissionLog,

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -1391,13 +1391,13 @@ public class UserService {
 
         targetUser.updateRejectionOrDropReason(rejectReason);
 
-        targetUser = this.updateState(targetUser.getId(), UserState.REJECT)
+        targetUser = this.updateState(targetUser.getId(), UserState.AWAIT)
                 .orElseThrow(() -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
                         MessageUtil.ADMISSION_EXCEPTION
                 ));
 
-        userRepository.save(targetUser);
+        userRepository.save(targetUser);`
 
         return UserDtoMapper.INSTANCE.toUserAdmissionResponseDto(
                 userAdmissionLog,

--- a/src/main/java/net/causw/domain/model/util/MessageUtil.java
+++ b/src/main/java/net/causw/domain/model/util/MessageUtil.java
@@ -102,6 +102,7 @@ public class MessageUtil {
     public static final String USER_ADMISSION_MUST_HAVE_IMAGE = "입학 증빙 사진은 필수 입니다.";
     public static final String STUDENT_ID_ALREADY_EXIST = "이미 존재하는 학번입니다.";
     public static final String PHONE_NUMBER_ALREADY_EXIST = "이미 존재하는 전화번호입니다.";
+    public static final String INVALID_USER_APPLICATION_USER_STATE = "사용자 인증을 할 수 없는 상태의 사용자입니다(AWAIT / REJECT 상태만 인증 가능합니다).";
 
     // Flag
     public static final String FLAG_UPDATE_FAILED = "플래그 업데이트에 실패했습니다.";


### PR DESCRIPTION
### 🚩 관련사항


### 📢 전달사항
- PUT: updateAdmission API 삭제(미사용, createAdmission으로 전체 대체)
- createAdmission에 UserState AWAIT / REJECT일 때만 가능하도록 validation 추가


### 📸 스크린샷


### 📃 진행사항

### ⚙️ 기타사항

개발기간: 1시간