### PR TITLE
fix: 학생회비 등록 예외 핸들링 추가

### DIFF
--- a/src/main/java/net/causw/application/semester/SemesterService.java
+++ b/src/main/java/net/causw/application/semester/SemesterService.java
@@ -36,7 +36,7 @@ public class SemesterService {
     public CurrentSemesterResponseDto getCurrentSemester() {
         List<Semester> currentSemesterList = semesterRepository.findAllByIsCurrent(true);
         if (currentSemesterList.isEmpty()) {
-            return null;
+            throw new BadRequestException(ErrorCode.ROW_DOES_NOT_EXIST, MessageUtil.CURRENT_SEMESTER_DOES_NOT_EXIST);
         }
         return toCurrentSemesterResponseDto(currentSemesterList.get(0));
     }
@@ -44,7 +44,7 @@ public class SemesterService {
     public Semester getCurrentSemesterEntity() {
         List<Semester> currentSemesterList = semesterRepository.findAllByIsCurrent(true);
         if (currentSemesterList.isEmpty()) {
-            return null;
+            throw new BadRequestException(ErrorCode.ROW_DOES_NOT_EXIST, MessageUtil.CURRENT_SEMESTER_DOES_NOT_EXIST);
         }
         return currentSemesterList.get(0);
     }

--- a/src/main/java/net/causw/application/userCouncilFee/UserCouncilFeeService.java
+++ b/src/main/java/net/causw/application/userCouncilFee/UserCouncilFeeService.java
@@ -18,6 +18,8 @@ import net.causw.application.semester.SemesterService;
 import net.causw.domain.aop.annotation.MeasureTime;
 import net.causw.domain.exceptions.BadRequestException;
 import net.causw.domain.exceptions.ErrorCode;
+import net.causw.domain.model.enums.user.UserState;
+import net.causw.domain.model.enums.userAcademicRecord.AcademicStatus;
 import net.causw.domain.model.enums.userCouncilFee.CouncilFeeLogType;
 import net.causw.domain.model.util.MessageUtil;
 import org.springframework.data.domain.Page;
@@ -133,6 +135,10 @@ public class UserCouncilFeeService {
 
         if (userCouncilFeeRepository.existsByUser(targetUser)) {
             throw new BadRequestException(ErrorCode.INVALID_PARAMETER, MessageUtil.USER_COUNCIL_FEE_INFO_ALREADY_EXISTS);
+        }
+
+        if (targetUser.getCurrentCompletedSemester() == null) {
+            throw new BadRequestException(ErrorCode.ROW_DOES_NOT_EXIST, MessageUtil.USER_CURRENT_COMPLETE_SEMESTER_DOES_NOT_EXIST);
         }
 
         if (createUserCouncilFeeWithUserRequestDto.getIsRefunded() && createUserCouncilFeeWithUserRequestDto.getRefundedAt() == null) {

--- a/src/main/java/net/causw/domain/model/util/MessageUtil.java
+++ b/src/main/java/net/causw/domain/model/util/MessageUtil.java
@@ -139,6 +139,7 @@ public class MessageUtil {
     // Semester
     public static final String PRIOR_SEMESTER_NOT_FOUND = "이전 학기를 찾을 수 없습니다.";
     public static final String ACTIVE_SEMESTER_IS_DUPLICATED = "활성화된 학기가 중복되어 있습니다.";
+    public static final String CURRENT_SEMESTER_DOES_NOT_EXIST = "현재 학기가 존재하지 않습니다. 현재 학기를 등록해주세요";
 
     // UserCouncilFee
     public static final String INVALID_USER_COUNCIL_FEE_INFO = "유효하지 않은 학생회비 납부자 정보입니다.";
@@ -170,4 +171,5 @@ public class MessageUtil {
     public static final String FAIL_TO_CRAWL_CAU_SW_NOTICE_SITE = "소프트웨어학부 공지사항 크롤링 실패";
 
 
+    public static final String USER_CURRENT_COMPLETE_SEMESTER_DOES_NOT_EXIST = "사용자의 현재 등록 완료 학기 정보가 존재하지 않습니다.";
 }


### PR DESCRIPTION
### 🚩 관련사항


### 📢 전달사항
기존 학적 상태 등록(재학 등록)을 하지 않은 사용자에 대해 학생회비 등록을 시도할 시 바로 500번대 에러가 뜨는 상황에서 정확히 validation을 하도록 수정했습니다.


### 📸 스크린샷


### 📃 진행사항


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 