### PR TITLE
fix: user admission 거절 시 user state 관리 및 user academic status 로직 수정

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/repository/userAcademicRecord/UserAcademicRecordApplicationRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/userAcademicRecord/UserAcademicRecordApplicationRepository.java
@@ -28,4 +28,5 @@ public interface UserAcademicRecordApplicationRepository extends JpaRepository<U
 
     List<UserAcademicRecordApplication> findByUserId(String userId);
 
+    List<UserAcademicRecordApplication> findByUserAndAcademicRecordRequestStatus(User user, AcademicRecordRequestStatus academicRecordRequestStatus);
 }

--- a/src/main/java/net/causw/adapter/web/UserAcademicRecordApplicationController.java
+++ b/src/main/java/net/causw/adapter/web/UserAcademicRecordApplicationController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import net.causw.application.dto.semester.CurrentSemesterResponseDto;
 import net.causw.application.dto.userAcademicRecordApplication.*;
+import net.causw.application.semester.SemesterService;
 import net.causw.application.userAcademicRecord.UserAcademicRecordApplicationService;
 import net.causw.config.security.userdetails.CustomUserDetails;
 import net.causw.domain.model.enums.userAcademicRecord.AcademicStatus;
@@ -26,6 +27,7 @@ import java.util.List;
 public class UserAcademicRecordApplicationController {
 
     private final UserAcademicRecordApplicationService userAcademicRecordApplicationService;
+    private final SemesterService semesterService;
 
     @GetMapping("/export")
     @ResponseStatus(value = HttpStatus.OK)
@@ -45,7 +47,7 @@ public class UserAcademicRecordApplicationController {
     @Operation(summary = "현재 학기 조회",
             description = "현재 학기를 조회합니다.")
     public CurrentSemesterResponseDto getCurrentSemesterYearAndType() {
-        return userAcademicRecordApplicationService.getCurrentSemesterYearAndType();
+        return semesterService.getCurrentSemester();
     }
 
     /**
@@ -225,13 +227,15 @@ public class UserAcademicRecordApplicationController {
         return userAcademicRecordApplicationService.createUserAcademicRecordApplication(userDetails.getUser(), createUserAcademicRecordApplicationRequestDto, imageFileList);
     }
 
-    /**
+    /*
+    FIXME: FE 미사용으로 주석 처리
+
      * 사용자 본인의 학적 증빙 서류 수정
      * @param userDetails
      * @param createUserAcademicRecordApplicationRequestDto
      * @param imageFileList
      * @return
-     */
+
     @PutMapping(value = "/application/update")
     @ResponseStatus(HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
@@ -244,5 +248,6 @@ public class UserAcademicRecordApplicationController {
     ) {
         return userAcademicRecordApplicationService.updateUserAcademicRecordApplication(userDetails.getUser(), createUserAcademicRecordApplicationRequestDto, imageFileList);
     }
+    */
 
 }

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -1263,7 +1263,7 @@ public class UserService {
             );
         }
 
-        if ( !(user.getState().equals(UserState.AWAIT) || user.getState().equals(UserState.ACTIVE)) ) {
+        if ( !(user.getState().equals(UserState.AWAIT) || user.getState().equals(UserState.REJECT)) ) {
             throw new BadRequestException(
                     ErrorCode.INVALID_REQUEST_USER_STATE,
                     MessageUtil.INVALID_USER_APPLICATION_USER_STATE
@@ -1391,7 +1391,7 @@ public class UserService {
 
         targetUser.updateRejectionOrDropReason(rejectReason);
 
-        targetUser = this.updateState(targetUser.getId(), UserState.AWAIT)
+        targetUser = this.updateState(targetUser.getId(), UserState.REJECT)
                 .orElseThrow(() -> new InternalServerException(
                         ErrorCode.INTERNAL_SERVER,
                         MessageUtil.ADMISSION_EXCEPTION

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -1290,6 +1290,13 @@ public class UserService {
                 .consistOf(ConstraintValidator.of(userAdmission, this.validator))
                 .validate();
 
+        userRepository.save(updateState(user.getId(), UserState.AWAIT)
+                .orElseThrow(() -> new InternalServerException(
+                        ErrorCode.INTERNAL_SERVER,
+                        MessageUtil.ADMISSION_EXCEPTION
+                ))
+        );
+
         return UserDtoMapper.INSTANCE.toUserAdmissionResponseDto(this.userAdmissionRepository.save(userAdmission));
     }
 


### PR DESCRIPTION
### 🚩 관련사항
관련된 이슈번호 혹은 PR 번호를 기록합니다.


### 📢 전달사항
- user admission
  - user admission 거절 시 user state AWAIT로 변경
- user academic record
  - user academic record create 시 대상 사용자의 변경 타겟 학적 상태가 재학인 경우, 대기 중인 이미 신청한 학적 정보 신청서가 있는지 확인하고, 있다면 닫음 처리
  - semester service 사용, 중복 메서드 제거


### 📸 스크린샷


### 📃 진행사항

### ⚙️ 기타사항

개발기간: 1시간