### PR TITLE
fix: 회원가입 API 유효하지 않은 요청 예외처리 추가

### DIFF
--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -521,6 +521,14 @@ public class UserService {
     public UserResponseDto signUp(UserCreateRequestDto userCreateRequestDto) {
         // Make domain model for generalized data model and validate the format of request parameter
 
+        // 학번 앞 4자리와 입학년도가 다른 경우 잘못된 요청이므로 예외처리
+        if (!userCreateRequestDto.getStudentId().substring(0, 4).equals(userCreateRequestDto.getAdmissionYear().toString())) {
+            throw new BadRequestException(
+                    ErrorCode.INVALID_USER_DATA_REQUEST,
+                    MessageUtil.INVALID_USER_DATA_REQUEST
+            );
+        }
+
         this.userRepository.findByEmail(userCreateRequestDto.getEmail()).ifPresent(
                 email -> {
                     throw new BadRequestException(

--- a/src/main/java/net/causw/domain/model/util/MessageUtil.java
+++ b/src/main/java/net/causw/domain/model/util/MessageUtil.java
@@ -13,6 +13,7 @@ public class MessageUtil {
     public static final String INVALID_TOKEN = "잘못된 AccessToken 입니다";
     public static final String EXPIRED_TOKEN = "만료된 AccessToken 입니다";
     public static final String DOES_NOT_HAVE_PERMISSION = "권한이 없습니다.";
+    public static final String INVALID_USER_DATA_REQUEST = "유저의 가입 및 수정 정보가 유효하지 않습니다.";
 
     // Form
     public static final String IS_NEED_COUNCIL_FEE_REQUIRED = "학생회비 납부 여부를 선택해 주세요.";


### PR DESCRIPTION
### 🚩 관련사항
- #774

### 📢 전달사항
* 기존 회원가입 API는 입학년도(즉, 학번의 앞 4자리)와 학번이 동일하지 않는 잘못된 요청을 그대로 처리하고 있었습니다. 이를 방지하고자 학번 앞 4자리와 입학년도를 매핑하여 예외처리를 추가하였습니다.

### 📸 스크린샷


### 📃 진행사항
- [x] 예외처리 추가

### ⚙️ 기타사항
