### PR TITLE
fix: Role 검사 로직 통합(SecurityService)

### DIFF
--- a/src/main/java/net/causw/adapter/web/BoardController.java
+++ b/src/main/java/net/causw/adapter/web/BoardController.java
@@ -110,8 +110,8 @@ public class BoardController {
     
     @PostMapping(value = "/create")
     @ResponseStatus(HttpStatus.CREATED)
-    @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() " +
-            "and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
+    @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "관리자/학생회장/부학생회장 전용 공지 게시판 생성 API", description = "관리자/학생회장/부학생회장이 별도의 신청 없이 생성할 수 있는 게시판을 만드는 API입니다. 게시판의 이름을 전달 받습니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "4000", description = "로그인된 사용자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
@@ -130,7 +130,8 @@ public class BoardController {
 
     @GetMapping(value = "/apply/list")
     @ResponseStatus(value = HttpStatus.OK)
-    @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
+    @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "게시판 생성 신청 조회(완료)", description = "게시판 생성 신청 목록을 조회하는 API입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "4000", description = "로그인된 사용자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
@@ -146,7 +147,8 @@ public class BoardController {
 
     @GetMapping(value = "/apply/{id}")
     @ResponseStatus(value = HttpStatus.OK)
-    @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
+    @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "게시판 생성 신청 단일 조회(완료)", description = "단일 게시판 생성 신청 내역을 조회하는 API입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "4000", description = "로그인된 사용자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
@@ -164,7 +166,8 @@ public class BoardController {
 
     @PutMapping(value = "/apply/{applyId}/accept")
     @ResponseStatus(value = HttpStatus.OK)
-    @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
+    @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "게시판 생성 신청 승인(완료)", description = "게시판 생성 신청을 승인하는 API입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "4000", description = "로그인된 사용자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
@@ -183,7 +186,8 @@ public class BoardController {
 
     @PutMapping(value = "/apply/{applyId}/reject")
     @ResponseStatus(value = HttpStatus.OK)
-    @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and hasAnyRole('ADMIN','PRESIDENT','VICE_PRESIDENT')")
+    @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "게시판 생성 신청 거부(완료)", description = "게시판 생성 신청을 거부하는 API입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json")),

--- a/src/main/java/net/causw/adapter/web/CalendarController.java
+++ b/src/main/java/net/causw/adapter/web/CalendarController.java
@@ -27,7 +27,7 @@ public class CalendarController {
     @GetMapping
     @Operation(summary = "캘린더 조회 API", description = "캘린더 조회 API 입니다.")
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "4000", description = "캘린더를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
@@ -42,7 +42,7 @@ public class CalendarController {
     @GetMapping("/{calendarId}")
     @Operation(summary = "캘린더 단일 조회 API", description = "캘린더 단일 조회 API 입니다.")
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "4000", description = "캘린더를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
@@ -72,7 +72,7 @@ public class CalendarController {
     @ResponseStatus(value = HttpStatus.CREATED)
     @Operation(summary = "캘린더 생성 API", description = "캘린더 생성 API 입니다.")
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "CREATED", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "4001", description = "이미 존재하는 캘린더 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
@@ -90,7 +90,7 @@ public class CalendarController {
     @PutMapping("/{calendarId}")
     @Operation(summary = "캘린더 수정 API", description = "캘린더 수정 API 입니다.")
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "CREATED", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "4000", description = "캘린더를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),

--- a/src/main/java/net/causw/adapter/web/CircleController.java
+++ b/src/main/java/net/causw/adapter/web/CircleController.java
@@ -54,12 +54,6 @@ public class CircleController {
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified()")
     @Operation(summary = "동아리 정보 조회 API / findById (완료)", description = "circleId에는 동아리 고유 id 값(PK)을 입력해주세요.")
-//    @ApiImplicitParam(name = "circleId",
-//            value = "동아리 ID",
-//            required = true,
-//            dataType = "string",
-//            paramType = "path"
-//    )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CircleResponseDto.class))),
             @ApiResponse(responseCode = "4000", description = "소모임을 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
@@ -105,12 +99,6 @@ public class CircleController {
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified()")
     @Operation(summary = "동아리 소속 게시판 조회 API / findBoards (완료)", description = "circleId에는 동아리 고유 id 값(PK)을 입력해주세요.")
-//    @ApiImplicitParam(name = "circleId",
-//            value = "동아리 ID",
-//            required = true,
-//            dataType = "string",
-//            paramType = "path"
-//    )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CircleBoardsResponseDto.class))),
             @ApiResponse(responseCode = "4000", description = "소모임을 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
@@ -138,14 +126,8 @@ public class CircleController {
     @GetMapping(value = "/{circleId}/num-member")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT', 'LEADER_CIRCLE')")
+            "@securityService.isAdminOrPresidentOrVicePresidentOrCircleLeader()")
     @Operation(summary = "동아리원 숫자 조회 API / getNumMember (완료)", description = "circleId에는 동아리 고유 id 값(PK)을 입력해주세요.")
-//    @ApiImplicitParam(name = "circleId",
-//            value = "동아리 ID",
-//            required = true,
-//            dataType = "string",
-//            paramType = "path"
-//    )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Long.class))),
             @ApiResponse(responseCode = "4000", description = "소모임을 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
@@ -166,24 +148,8 @@ public class CircleController {
     @GetMapping(value = "/{circleId}/users")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT', 'LEADER_CIRCLE')")
+            "@securityService.isAdminOrPresidentOrVicePresidentOrCircleLeader()")
     @Operation(summary = "동아리원 상태별 조회 API / getUserList (완료)", description = "circleId에는 동아리 고유 id 값(PK), circleMemberStatus 엔 조회하고자 하는 동아리원의 상태를 입력해주세요.")
-//    @ApiImplicitParams(
-//            {
-//                    @ApiImplicitParam(name = "circleId",
-//                            value = "동아리 ID",
-//                            required = true,
-//                            dataType = "string",
-//                            paramType = "path"
-//                    ),
-//                    @ApiImplicitParam(name = "circleMemberStatus",
-//                            value = "동아리원 상태",
-//                            required = true,
-//                            dataType = "string",
-//                            paramType = "query"
-//                    )
-//            }
-//    )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CircleMemberResponseDto.class), array = @io.swagger.v3.oas.annotations.media.ArraySchema(schema = @Schema(implementation = CircleMemberResponseDto.class)))),
             @ApiResponse(responseCode = "4000", description = "로그인된 사용자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
@@ -243,7 +209,7 @@ public class CircleController {
     @PostMapping
     @ResponseStatus(value = HttpStatus.CREATED)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(
             summary = "동아리 생성 API / create (완료)",
             description = "생성하고자 하는 동아리의 정보를 입력해주세요. 동아리장의 권한은 일반 유저만 가능하며, 생성 요청은 관리자(admin), 학생회장(president)만 가능합니다."
@@ -282,23 +248,13 @@ public class CircleController {
     @PutMapping(value = "/{circleId}")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT', 'LEADER_CIRCLE')")
+            "@securityService.isAdminOrPresidentOrVicePresidentOrCircleLeader()")
     @Operation(
             summary = "동아리 수정 API / update (완료)",
             description = "circleId 에는 수정하고자 하는 동아리의 UUID 형식의 ID String 값을 입력해주세요.\n" +
                     "circleUpdateRequestDto 에는 수정하고자 하는 동아리의 정보를 입력해주세요.\n" +
                     "동아리장의 권한은 일반 유저만 가능하며, 생성 요청은 관리자(admin), 학생회장(president)만 가능합니다."
     )
-//    @ApiImplicitParams(
-//            {
-//                    @ApiImplicitParam(name = "circleId",
-//                            value = "동아리 ID",
-//                            required = true,
-//                            dataType = "string",
-//                            paramType = "path",
-//                            defaultValue = "none"),
-//            }
-//    )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CircleResponseDto.class))),
             @ApiResponse(responseCode = "4000", description = "수정할 소모임을 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
@@ -334,7 +290,7 @@ public class CircleController {
     @DeleteMapping(value = "/{circleId}")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT', 'LEADER_CIRCLE')")
+            "@securityService.isAdminOrPresidentOrVicePresidentOrCircleLeader()")
     @Operation(
             summary = "동아리 삭제 API",
             description = "동아리 삭제 API 입니다.\n" +
@@ -461,7 +417,7 @@ public class CircleController {
     @PutMapping(value = "/{circleId}/users/{userId}/drop")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT', 'LEADER_CIRCLE')")
+            "@securityService.isAdminOrPresidentOrVicePresidentOrCircleLeader()")
     @Operation(summary = "동아리원 제거 API",
             description = "동아리원을 제거하는 API 입니다. userId 에는 제거하려는 유저를, circleId 에는 타깃 동아리를 넣어주세요.")
     @ApiResponses(value = {
@@ -501,17 +457,7 @@ public class CircleController {
     @PutMapping(value = "/applications/{applicationId}/accept")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT', 'LEADER_CIRCLE')")
-//    @ApiImplicitParams(
-//            {
-//                    @ApiImplicitParam(name = "applicationId",
-//                            value = "동아리 가입 신청 ID",
-//                            required = true,
-//                            dataType = "string",
-//                            paramType = "path"
-//                    )
-//            }
-//    )
+            "@securityService.isAdminOrPresidentOrVicePresidentOrCircleLeader()")
     @Operation(summary = "동아리 가입 신청 수락 API",
             description = "동아리 가입 신청에 대해 수락하는 API 입니다.\n" +
                     "동아리 가입 신청 건수 고유의 ID 값(PK)을 입력해주세요.\n" +
@@ -544,17 +490,7 @@ public class CircleController {
     @PutMapping(value = "/applications/{applicationId}/reject")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT', 'LEADER_CIRCLE')")
-//    @ApiImplicitParams(
-//            {
-//                    @ApiImplicitParam(name = "applicationId",
-//                            value = "동아리 가입 신청 ID",
-//                            required = true,
-//                            dataType = "string",
-//                            paramType = "path"
-//                    )
-//            }
-//    )
+            "@securityService.isAdminOrPresidentOrVicePresidentOrCircleLeader()")
     @Operation(summary = "동아리 가입 신청 거절 API",
             description = "동아리 가입 신청에 대해 거절하는 API 입니다.\n" +
                     "동아리 가입 신청 건수 고유의 ID 값(PK)을 입력해주세요.\n" +
@@ -588,7 +524,7 @@ public class CircleController {
     @PutMapping(value = "/{circleId}/users/{userId}/restore")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT', 'LEADER_CIRCLE')")
+            "@securityService.isAdminOrPresidentOrVicePresidentOrCircleLeader()")
     @Operation(summary = "추방된 동아리원 복구 API",
             description = "추방된 동아리원을 복구 시키는 API 입니다. 복구 시 동아리원으로 바꿔줍니다.\n" +
                     "해당하는 동아리 고유의 ID 값(PK)과 복구하려는 유저 고유의 ID 값(PK)를 입력해주세요.\n" +
@@ -619,7 +555,7 @@ public class CircleController {
     @GetMapping(value = "/{circleId}/users/excel")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT', 'LEADER_CIRCLE')")
+            "@securityService.isAdminOrPresidentOrVicePresidentOrCircleLeader()")
     @Operation(
             summary = "동아리원 엑셀 다운로드 API",
             description = "동아리원 정보를 엑셀로 다운로드 하는 API 입니다.\n" +
@@ -636,7 +572,7 @@ public class CircleController {
     @PostMapping(value = "/{circleId}/apply/application")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('LEADER_CIRCLE')")
+            "@securityService.isCircleLeader()")
     @Operation(
             summary = "동아리 가입 신청서 생성/수정 API",
             description = "동아리 가입 신청서를 수정하는 API 입니다.\n" +
@@ -684,7 +620,7 @@ public class CircleController {
     @GetMapping(value = "/{circleId}/apply/application/all")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT', 'LEADER_CIRCLE')")
+            "@securityService.isAdminOrPresidentOrVicePresidentOrCircleLeader()")
     @Operation(
             summary = "모든 동아리 가입 신청서 페이징 조회 API",
             description = "모든 동아리 가입 신청서를 조회하는 API 입니다.\n" +

--- a/src/main/java/net/causw/adapter/web/CommonController.java
+++ b/src/main/java/net/causw/adapter/web/CommonController.java
@@ -52,7 +52,7 @@ public class CommonController {
 
     @PostMapping("/api/v1/flag")
     @ResponseStatus(value = HttpStatus.OK)
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@securityService.isAdmin()")
     public Boolean createFlag(
             @RequestParam("key") String key,
             @RequestParam("value") Boolean value
@@ -65,7 +65,7 @@ public class CommonController {
 
     @PutMapping("/api/v1/flag")
     @ResponseStatus(value = HttpStatus.OK)
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@securityService.isAdmin()")
     public Boolean updateFlag(
             @RequestParam("key") String key,
             @RequestParam("value") Boolean value

--- a/src/main/java/net/causw/adapter/web/EventController.java
+++ b/src/main/java/net/causw/adapter/web/EventController.java
@@ -46,7 +46,7 @@ public class EventController {
             @ApiResponse(responseCode = "5000", description = "User id checked, but exception occurred", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
     })
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     public EventResponseDto createEvent(
             @RequestPart(value = "eventCreateRequestDto") @Valid EventCreateRequestDto eventCreateRequestDto,
             @RequestPart(value = "eventImage") MultipartFile eventImage
@@ -64,7 +64,7 @@ public class EventController {
             @ApiResponse(responseCode = "5000", description = "User id checked, but exception occurred", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
     })
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     public EventResponseDto updateEvent(
             @PathVariable("eventId") String eventId,
             @RequestPart(value = "eventUpdateRequestDto") @Valid EventUpdateRequestDto eventUpdateRequestDto,
@@ -83,7 +83,7 @@ public class EventController {
             @ApiResponse(responseCode = "5000", description = "User id checked, but exception occurred", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
     })
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     public EventResponseDto deleteEvent(@PathVariable("eventId") String eventId) {
         return eventService.deleteEvent(eventId);
     }

--- a/src/main/java/net/causw/adapter/web/FormController.java
+++ b/src/main/java/net/causw/adapter/web/FormController.java
@@ -101,7 +101,7 @@ public class FormController {
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "동아리 신청서 답변 유저별 조회", description = "각 유저의 동아리 신청서에 대한 답변을 조회합니다.")
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT', 'LEADER_CIRCLE')")
+            "@securityService.isAdminOrPresidentOrVicePresidentOrCircleLeader()")
     public List<UserReplyResponseDto> findReplyByUserAndCircle(
             @PathVariable(name = "userId") String userId,
             @PathVariable(name = "circleId") String circleId

--- a/src/main/java/net/causw/adapter/web/LockerController.java
+++ b/src/main/java/net/causw/adapter/web/LockerController.java
@@ -52,7 +52,7 @@ public class LockerController {
     @Operation(summary = "사물함 생성 Api(관리자/회장 전용)", description = "사물함을 생성하는 Api입니다.")
     @ResponseStatus(value = HttpStatus.CREATED)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     public LockerResponseDto create(
             @Valid @RequestBody LockerCreateRequestDto lockerCreateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -80,7 +80,7 @@ public class LockerController {
     @PutMapping(value = "/{lockerId}/move")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "사물함 위치 이동 Api(관리자/회장 전용)", description = "사물함의 위치(locker location)를 이동(변경)시키는 Api입니다. ex) 1번 사물함에 있어서 1층 1번 -> 2층 1번, 층만 바뀜")
     public LockerResponseDto move(
             @PathVariable("lockerId") String lockerId,
@@ -97,7 +97,7 @@ public class LockerController {
     @DeleteMapping(value = "/{lockerId}")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "사물함 삭제 Api(관리자/회장 전용)", description = "사물함을 삭제하는 Api입니다.")
     public LockerResponseDto delete(
             @PathVariable("lockerId") String lockerId,
@@ -129,7 +129,7 @@ public class LockerController {
     @Operation(summary = "사물함 위치 생성 API(관리자/회장 전용)", description = "사물함 특정 층 생성 API 입니다.")
     @ResponseStatus(value = HttpStatus.CREATED)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     public LockerLocationResponseDto createLocation(
             @Valid @RequestBody LockerLocationCreateRequestDto lockerLocationCreateRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -141,7 +141,7 @@ public class LockerController {
     @Operation(summary = "사물함 위치 업데이트 API(관리자/회장 전용)", description = "사물함 특정 층 업데이트 API 입니다.")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     public LockerLocationResponseDto updateLocation(
             @PathVariable("locationId") String locationId,
             @Valid @RequestBody LockerLocationUpdateRequestDto lockerLocationUpdateRequestDto,
@@ -158,7 +158,7 @@ public class LockerController {
     @Operation(summary = "사물함 위치 삭제 API(관리자/회장 전용)", description = "사물함 특정 층 삭제 API 입니다.")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     public LockerLocationResponseDto deleteLocation(
             @PathVariable("locationId") String locationId,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -170,7 +170,7 @@ public class LockerController {
     @ResponseStatus(value = HttpStatus.OK)
     @Operation(summary = "사물함 로그 조회 API(관리자/회장 전용)", description = "사물함 로그를 조회하는 API입니다.")
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     public List<LockerLogResponseDto> findLog(
             @PathVariable("lockerId") String lockerId
     ) {
@@ -181,7 +181,7 @@ public class LockerController {
     @Operation(summary = "사물함 만료 기한 설정 Api(관리자/회장 전용)", description = "사물함 만료 기한을 설정하는 API입니다.(학생회장만 가능)")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     public void setExpireDate(
             @Valid @RequestBody LockerExpiredAtRequestDto lockerExpiredAtRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -193,7 +193,7 @@ public class LockerController {
     @Operation(summary = "사물함 전체 생성 API(관리자/회장 전용)" , description = "현재 존재하는 모든 사물함을 생성하는 API입니다.")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     public void createAllLockers(@AuthenticationPrincipal CustomUserDetails userDetails){
         this.lockerService.createAllLockers(userDetails.getUser());
     }

--- a/src/main/java/net/causw/adapter/web/SemesterController.java
+++ b/src/main/java/net/causw/adapter/web/SemesterController.java
@@ -22,7 +22,7 @@ public class SemesterController {
 
     @GetMapping("/current")
     @ResponseStatus(HttpStatus.OK)
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@securityService.isAdmin()")
     @Operation(summary = "현재 학기 조회(개발 테스트 및 관리자용)", description = "현재 진행 중인 학기를 조회합니다.")
     public CurrentSemesterResponseDto getCurrentSemester() {
         return semesterService.getCurrentSemester();
@@ -30,7 +30,7 @@ public class SemesterController {
 
     @GetMapping("/list")
     @ResponseStatus(HttpStatus.OK)
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@securityService.isAdmin()")
     @Operation(summary = "학기 목록 조회(개발 테스트 및 관리자용)", description = "모든 학기 목록을 조회합니다.")
     public List<CurrentSemesterResponseDto> getSemesterList() {
         return semesterService.getSemesterList();
@@ -38,7 +38,7 @@ public class SemesterController {
 
     @PostMapping("/create")
     @ResponseStatus(HttpStatus.CREATED)
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@securityService.isAdmin()")
     @Operation(summary = "학기 생성(개발 테스트 및 관리자용)", description = "새로운 학기를 생성합니다.")
     public void createSemester(
             @RequestBody CreateSemesterRequestDto createSemesterRequestDto,
@@ -53,9 +53,8 @@ public class SemesterController {
      */
     @PostMapping("/create/next")
     @ResponseStatus(HttpStatus.CREATED)
-    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and " +
-            "@securityService.isAcademicRecordCertified() and " +
-            "hasAnyRole('ROLE_ADMIN', 'ROLE_PRESIDENT', 'ROLE_VICE_PRESIDENT')")
+    @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "다음 학기 생성(재학 인증 일괄 요청)", description = "다음 학기를 생성합니다. 자동으로 재학 인증도 일괄 요청 됩니다.")
     public void createNextSemester(
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -65,7 +64,7 @@ public class SemesterController {
 
     @DeleteMapping("/{semesterId}")
     @ResponseStatus(HttpStatus.OK)
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@securityService.isAdmin()")
     @Operation(summary = "학기 삭제(개발 테스트 및 관리자용)", description = "특정 학기를 삭제합니다.")
     public void deleteSemester(
             @PathVariable(value = "semesterId") String semesterId

--- a/src/main/java/net/causw/adapter/web/StorageController.java
+++ b/src/main/java/net/causw/adapter/web/StorageController.java
@@ -18,7 +18,7 @@ public class StorageController {
     private final UuidFileService uuidFileService;
 
     @PostMapping(value = "/upload", consumes = "multipart/form-data")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("@securityService.isAdmin()")
     public FileResponseDto post(
             @RequestPart("file") MultipartFile multipartFile,
             @RequestParam("type") FilePath filePath

--- a/src/main/java/net/causw/adapter/web/UserAcademicRecordApplicationController.java
+++ b/src/main/java/net/causw/adapter/web/UserAcademicRecordApplicationController.java
@@ -32,7 +32,7 @@ public class UserAcademicRecordApplicationController {
     @GetMapping("/export")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "학적 정보 엑셀 파일로 내보내기(관리자용)",
             description = "학적 정보를 엑셀 파일로 내보냅니다.")
     public void exportUserAcademicRecord(
@@ -58,7 +58,7 @@ public class UserAcademicRecordApplicationController {
     @GetMapping("/list/active-users")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUser() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "전체 유저의 학적 정보 목록 조회(관리자용)",
             description = "전체 유저의 학적 정보 목록을 조회합니다.")
     public Page<UserAcademicRecordListResponseDto> getAllUserAcademicRecordPage(
@@ -75,7 +75,7 @@ public class UserAcademicRecordApplicationController {
     @GetMapping("/list/await")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUser() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "전체 학적 인증 승인 대기 목록 조회(관리자용)",
             description = "전체 학적 인증 승인 대기 목록 조회합니다.")
     public Page<UserAcademicRecordApplicationListResponseDto> getAllUserAwaitingAcademicRecordPage(
@@ -92,7 +92,7 @@ public class UserAcademicRecordApplicationController {
     @GetMapping("/record/{userId}")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUser() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "유저 학적 정보 상세 보기(관리자용)",
             description = "유저 학적 정보 상세를 조회합니다.")
     public UserAcademicRecordInfoResponseDto getUserAcademicRecordInfo(
@@ -110,7 +110,7 @@ public class UserAcademicRecordApplicationController {
     @PutMapping("/record/{userId}")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUser() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "유저 학적 정보 노트 변경(관리자용)",
             description = "유저 학적 정보 노트를 변경합니다.")
     public UserAcademicRecordInfoResponseDto updateUserAcademicRecordNote(
@@ -129,7 +129,7 @@ public class UserAcademicRecordApplicationController {
     @GetMapping("/application/{userId}/{applicationId}")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUser() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "유저 학적 승인 요청 상세 보기(관리자용)",
             description = "유저 학적 승인 요청 상세를 조회합니다.")
     public UserAcademicRecordApplicationInfoResponseDto getUserAcademicRecordApplicationInfo(
@@ -148,7 +148,7 @@ public class UserAcademicRecordApplicationController {
     @PutMapping("/update")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUser() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "유저 학적 정보 상태 변경(관리자용)",
             description = "유저 학적 정보 상태를 변경합니다.")
     public UserAcademicRecordInfoResponseDto updateUserAcademicStatus(
@@ -167,7 +167,7 @@ public class UserAcademicRecordApplicationController {
     @PutMapping("/application/admin")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUser() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "유저 학적 인증 승인 상태 변경(승인/거부)(관리자용)",
             description = "유저 학적 인증 승인 상태를 변경합니다.")
     public UserAcademicRecordApplicationResponseDto updateUserAcademicRecordApplicationStatus(
@@ -226,28 +226,5 @@ public class UserAcademicRecordApplicationController {
     ) {
         return userAcademicRecordApplicationService.createUserAcademicRecordApplication(userDetails.getUser(), createUserAcademicRecordApplicationRequestDto, imageFileList);
     }
-
-    /*
-    FIXME: FE 미사용으로 주석 처리
-
-     * 사용자 본인의 학적 증빙 서류 수정
-     * @param userDetails
-     * @param createUserAcademicRecordApplicationRequestDto
-     * @param imageFileList
-     * @return
-
-    @PutMapping(value = "/application/update")
-    @ResponseStatus(HttpStatus.OK)
-    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
-    @Operation(summary = "사용자 본인의 학적 증빙 서류 수정",
-            description = "사용자 본인의 학적 증빙 서류를 수정합니다.")
-    public UserAcademicRecordApplicationResponseDto updateUserAcademicRecordApplication(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestPart(value = "createUserAcademicRecordApplicationRequestDto") @Valid CreateUserAcademicRecordApplicationRequestDto createUserAcademicRecordApplicationRequestDto,
-            @RequestPart(value = "imageFileList", required = false) List<MultipartFile> imageFileList
-    ) {
-        return userAcademicRecordApplicationService.updateUserAcademicRecordApplication(userDetails.getUser(), createUserAcademicRecordApplicationRequestDto, imageFileList);
-    }
-    */
 
 }

--- a/src/main/java/net/causw/adapter/web/UserController.java
+++ b/src/main/java/net/causw/adapter/web/UserController.java
@@ -39,7 +39,7 @@ public class UserController {
     @GetMapping(value = "/{userId}")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT', 'LEADER_CIRCLE')")
+            "@securityService.isAdminOrPresidentOrVicePresidentOrCircleLeader()")
     @Operation(summary = "사용자 정보 조회 API (완료)",
             description = "userId에는 사용자 고유 id 값을 입력해주세요.")
     @ApiResponses({
@@ -169,7 +169,7 @@ public class UserController {
     @GetMapping(value = "/name/{name}")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT', 'LEADER_CIRCLE')")
+            "@securityService.isSpecialPrivileged()")
     @Operation(summary = "유저 관리 시 사용자 이름으로 검색 API(완료)")
     public List<UserResponseDto> findByName(
             @PathVariable("name") String name,
@@ -181,7 +181,7 @@ public class UserController {
     @GetMapping(value = "/privileged")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "특별한 권한을 가진 사용자 목록 확인 API(완료)", description = "학생회장, 부학생회장, 학생회, 학년대표, 동문회장 역할을 가지는 사용자를 반환합니다. \n 권한 역임을 할 수 있기 때문에 중복되는 사용자가 존재합니다.(ex. PRESIDENT_N_LEADER_CIRCLE)")
     public UserPrivilegedResponseDto findPrivilegedUsers(
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -192,7 +192,7 @@ public class UserController {
     @GetMapping(value = "/state/{state}")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "유저 관리 시 사용자의 상태(ACTIVE, INACTIVE 등) 에 따라 검색하는 API(완료)", description = "유저를 관리할 때 사용자가 활성, 비활성 상태인지에 따라서 분류하여 검색할 수 있습니다. \n state 는 ACTIVE, INACTIVE, AWAIT, REJECT, DROP 으로 검색가능합니다.")
     public Page<UserResponseDto> findByState(
             @PathVariable("state") String state,
@@ -336,7 +336,7 @@ public class UserController {
     @PutMapping(value = "/{granteeId}/role")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "역할 업데이트 API(완료)", description = "grantorId 에는 관리자의 고유 id값, granteeId 에는 권한이 업데이트될 사용자의 고유 id 값을 넣어주세요")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
@@ -391,7 +391,7 @@ public class UserController {
     @DeleteMapping
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('COMMON','PROFESSOR')")
+            "@securityService.isAbleToLeave()")
     @Operation(summary = "사용자 탈퇴 API (완료)")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
@@ -417,7 +417,7 @@ public class UserController {
     @DeleteMapping(value = "{id}/delete")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "사용자 삭제 API (완료)")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
@@ -434,7 +434,7 @@ public class UserController {
     @PutMapping(value = "{id}/drop")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "사용자 추방 및 사물함 반환 API (완료)")
     public UserResponseDto drop(
             @PathVariable("id") String id,
@@ -456,7 +456,7 @@ public class UserController {
     @GetMapping(value = "/admissions/{id}")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "가입 대기 사용자 정보 확인 API (완료)")
     public UserAdmissionResponseDto findAdmissionById(
             @PathVariable("id") String id,
@@ -469,7 +469,7 @@ public class UserController {
     @GetMapping(value = "/admissions")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "모든 가입 대기 사용자 목록 확인 API (완료)")
     public Page<UserAdmissionsResponseDto> findAllAdmissions(
             @RequestParam(name = "pageNum",defaultValue = "0") Integer pageNum,
@@ -508,7 +508,7 @@ public class UserController {
 
     @PutMapping(value = "/admissions/{id}/accept")
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "신청 승인 API (완료)", description = "id 에는 승인 고유 id 값(admission id)을 넣어주세요.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = String.class))),
@@ -535,7 +535,7 @@ public class UserController {
      */
     @PutMapping(value = "/admissions/{id}/reject")
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "신청 거절 API (완료)", description = "id 에는 승인 고유 id 값(admission id)을 넣어주세요.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = String.class))),
@@ -561,7 +561,7 @@ public class UserController {
     @PutMapping(value = "/restore/{id}")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "사용자 복구 API(완료)", description = "복구할 사용자의 id를 넣어주세요")
     public UserResponseDto restore(
             @PathVariable("id") String id,
@@ -630,7 +630,7 @@ public class UserController {
     @GetMapping(value = "/export")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "사용자 정보 엑셀 다운로드 API(완료)", description = "사용자 정보를 엑셀로 다운로드")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", schema = @Schema(implementation = Workbook.class))),

--- a/src/main/java/net/causw/adapter/web/UserCouncilFeeController.java
+++ b/src/main/java/net/causw/adapter/web/UserCouncilFeeController.java
@@ -34,7 +34,7 @@ public class UserCouncilFeeController {
     @GetMapping("/export/excel")
     @ResponseStatus(HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "학생회비 엑셀 다운로드",
         description = "학생회비 엑셀 파일을 다운로드합니다.")
     @ApiResponses({
@@ -51,7 +51,7 @@ public class UserCouncilFeeController {
     @GetMapping("/list")
     @ResponseStatus(HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "학생회비 납부자 목록 조회",
         description = "학생회비 납부자 목록을 조회합니다.")
     @ApiResponses({
@@ -68,7 +68,7 @@ public class UserCouncilFeeController {
     @GetMapping("/info/{userCouncilFeeId}")
     @ResponseStatus(HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "학생회비 납부자 상세 조회",
         description = "학생회비 납부자 상세 정보를 조회합니다.")
     @ApiResponses({
@@ -85,7 +85,7 @@ public class UserCouncilFeeController {
     @PostMapping("/create-user")
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "학생회비 납부자 등록(가입 유저 대상)",
         description = "동문네트워크 가입자 대상으로 학생회비 납부자를 등록합니다.")
     @ApiResponses({
@@ -106,7 +106,7 @@ public class UserCouncilFeeController {
     @PostMapping("/create-fake-user")
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "학생회비 납부자 등록(미가입자 대상)",
         description = "동문네트워크 미 가입자 대상으로 학생회비 납부자를 등록합니다.")
     @ApiResponses({
@@ -127,7 +127,7 @@ public class UserCouncilFeeController {
     @PutMapping("/update-user")
     @ResponseStatus(HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "학생회비 납부자 수정(가입 유저 대상)",
         description = "학생회비 납부자를 수정합니다.(가입 유저 대상)")
     @ApiResponses({
@@ -153,7 +153,7 @@ public class UserCouncilFeeController {
     @PutMapping("/update-fake-user")
     @ResponseStatus(HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "학생회비 납부자 수정(미가입자 대상)",
         description = "학생회비 납부자를 수정합니다.")
     @ApiResponses({
@@ -179,7 +179,7 @@ public class UserCouncilFeeController {
     @DeleteMapping("/delete")
     @ResponseStatus(HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "학생회비 납부자 삭제",
         description = "학생회비 납부자를 삭제합니다.")
     @ApiResponses({
@@ -197,7 +197,7 @@ public class UserCouncilFeeController {
     @GetMapping("/getUserIdByStudentId")
     @ResponseStatus(HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "학번으로 사용자 id 조회",
         description = "학번으로 사용자 id를 조회합니다.")
     @ApiResponses({
@@ -214,7 +214,7 @@ public class UserCouncilFeeController {
     @GetMapping("/isCurrentSemesterApplied")
     @ResponseStatus(HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified() and " +
-            "hasAnyRole('ADMIN','PERSIDENT', 'VICE_PRESIDENT')")
+            "@securityService.isAdminOrPresidentOrVicePresident()")
     @Operation(summary = "특정 사용자가 현재 학생회비 적용 학기인지 여부 조회",
         description = "특정 사용자가 현재 학생회비 적용 학기인지 여부를 조회합니다.")
     @ApiResponses({

--- a/src/main/java/net/causw/config/security/SecurityService.java
+++ b/src/main/java/net/causw/config/security/SecurityService.java
@@ -61,42 +61,86 @@ public class SecurityService {
         return isActiveAndNotNoneUser() && isAcademicRecordCertified();
     }
 
-    public boolean isAdminOrPresidentOrVicePresident() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-            return false;
+    public boolean isAdmin() {
+        Set<String> userRoleSet = getUserRoleSet();
+
+        if (userRoleSet != null) {
+            return userRoleSet.contains(Role.ADMIN.getValue());
         }
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        return false;
+    }
 
-        Set<String> userRoleSet = userDetails.getUser().getRoles()
-                .stream()
-                .map(Role::getValue)
-                .collect(Collectors.toSet());
+    public boolean isAdminOrPresidentOrVicePresident() {
+        Set<String> userRoleSet = getUserRoleSet();
 
-        return userRoleSet.contains(Role.ADMIN.getValue()) ||
-                userRoleSet.contains(Role.PRESIDENT.getValue()) ||
-                userRoleSet.contains(Role.VICE_PRESIDENT.getValue());
+        if (userRoleSet != null) {
+            return userRoleSet.contains(Role.ADMIN.getValue()) ||
+                    userRoleSet.contains(Role.PRESIDENT.getValue()) ||
+                    userRoleSet.contains(Role.VICE_PRESIDENT.getValue());
+        }
+        return false;
     }
 
     public boolean isAdminOrPresidentOrVicePresidentOrCircleLeader() {
+        Set<String> userRoleSet = getUserRoleSet();
+
+        if (userRoleSet != null) {
+            return userRoleSet.contains(Role.ADMIN.getValue()) ||
+                    userRoleSet.contains(Role.PRESIDENT.getValue()) ||
+                    userRoleSet.contains(Role.VICE_PRESIDENT.getValue()) ||
+                    userRoleSet.contains(Role.LEADER_CIRCLE.getValue());
+        }
+        return false;
+    }
+
+    public boolean isCircleLeader() {
+        Set<String> userRoleSet = getUserRoleSet();
+
+        if (userRoleSet != null) {
+            return userRoleSet.contains(Role.LEADER_CIRCLE.getValue());
+        }
+        return false;
+    }
+
+    public boolean isAbleToLeave() {
+        Set<String> userRoleSet = getUserRoleSet();
+
+        if (userRoleSet != null) {
+            return userRoleSet.contains(Role.COMMON.getValue()) ||
+                    userRoleSet.contains(Role.PROFESSOR.getValue());
+        }
+        return false;
+    }
+
+    public boolean isSpecialPrivileged() {
+        Set<String> userRoleSet = getUserRoleSet();
+
+        if (userRoleSet != null) {
+            return userRoleSet.contains(Role.ADMIN.getValue()) ||
+                    userRoleSet.contains(Role.PRESIDENT.getValue()) ||
+                    userRoleSet.contains(Role.VICE_PRESIDENT.getValue()) ||
+                    userRoleSet.contains(Role.COUNCIL.getValue()) ||
+                    userRoleSet.contains(Role.LEADER_CIRCLE.getValue()) ||
+                    userRoleSet.contains(Role.LEADER_1.getValue()) ||
+                    userRoleSet.contains(Role.LEADER_2.getValue()) ||
+                    userRoleSet.contains(Role.LEADER_3.getValue()) ||
+                    userRoleSet.contains(Role.LEADER_4.getValue()) ||
+                    userRoleSet.contains(Role.LEADER_ALUMNI.getValue());
+        }
+        return false;
+    }
+
+    private Set<String> getUserRoleSet() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated()) {
-            return false;
+            return null;
         }
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
 
-        Set<String> userRoleSet = userDetails.getUser().getRoles()
+        return userDetails.getUser().getRoles()
                 .stream()
                 .map(Role::getValue)
                 .collect(Collectors.toSet());
-
-        return userRoleSet.contains(Role.ADMIN.getValue()) ||
-                userRoleSet.contains(Role.PRESIDENT.getValue()) ||
-                userRoleSet.contains(Role.VICE_PRESIDENT.getValue()) ||
-                userRoleSet.contains(Role.LEADER_CIRCLE.getValue());
     }
 
-    private int convertSemesterToGrade(int semester) {
-        return (semester + 1) / 2;
-    }
 }


### PR DESCRIPTION
### 📢 전달사항
![image](https://github.com/user-attachments/assets/0a45f6d9-5e0d-4254-8cc0-72c9ec32cc0d)
해당 API에서 발생하는 에러를 조사하던 중, `hasAnyRole('ADMIN', PERSIDENT', ...)` 해당 코드에서 **PERSIDENT**로 작성이 된 오타 때문에 에러가 발생하는 것을 발견했습니다.

단순히 오타만 수정하면 에러는 해결되겠지만, 추후 유지 보수나 기능 확장 시 기존 방식과 같이 단순히 SpEL에 텍스트를 넣는 건 휴먼 에러 발생 가능성이 높다고 판단되어 SpEL 내부에서 Role enum 클래스의 name을 참조하는 방식을 사용하려 했으나,
```java
// SpEL은 별도의 context를 사용하기 때문에 import 문이 소용 없어서 class 경로를 직접 지정해줘야 함
hasAnyRole(T(net.causw.domain.model.enums.user.Role).ADMIN.toString(), T(net.causw.domain.model.enums.user.Role).PRESIDENT.toString(), T(net.causw.domain.model.enums.user.Role).VICEPRESIDENT.toString())
```
이런 방식으로 사용해야하는 문제가 있었습니다.

따라서 비록 hasAnyRole처럼 간단하게 다양한 Role 조합 검사를 수행할 수 있는 편리성을 떨어지지만, `SecurityService.java`에 공통 메서드를 등록해 사용하는 방식이 낫겠다 판단되어 해당 방식으로 에러 수정 및 리펙토링을 진행했습니다.

### 📃 진행사항
- [x] `SecurityService.java`에 공통 Role 검사 메서드 구현
- [x] Controller에 Role 검사 메서드 SecurityService 호출 방식으로 리펙토링 


개발기간: 3시간