### PR TITLE
경조사 기능 구현 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ dump.rdb
 **/resources/application-local.yml
 **/resources/application-test.yml
 **/resources/application-qa.yml
+**/resources/dongnae_firebase_key.json
 
 Dockerfile
 docker-compose.yaml

--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,9 @@ dependencies {
     // Retry 관련
     // https://mvnrepository.com/artifact/org.springframework.retry/spring-retry
     implementation 'org.springframework.retry:spring-retry:1.0.3.RELEASE'
+
+    //FCM
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
 }
 
 test {

--- a/src/main/java/net/causw/adapter/persistence/locker/LockerLocation.java
+++ b/src/main/java/net/causw/adapter/persistence/locker/LockerLocation.java
@@ -1,11 +1,8 @@
 package net.causw.adapter.persistence.locker;
 
+import jakarta.persistence.*;
 import lombok.*;
 import net.causw.adapter.persistence.base.BaseEntity;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
 
 @Getter
 @Entity
@@ -14,16 +11,20 @@ import jakarta.persistence.Table;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "TB_LOCKER_LOCATION")
 public class LockerLocation extends BaseEntity {
+    @Enumerated(EnumType.STRING)
     @Column(name = "name", unique = true, nullable = false)
-    private String name;
+    private LockerName name;
 
-    public static LockerLocation of(String name){
+    public static LockerLocation of(LockerName name) {
         return LockerLocation.builder()
                 .name(name)
                 .build();
     }
 
-    public void update(String name){
+    public void update(LockerName name) {
         this.name = name;
+    }
+    public String getName(){
+        return this.name.name();
     }
 }

--- a/src/main/java/net/causw/adapter/persistence/locker/LockerName.java
+++ b/src/main/java/net/causw/adapter/persistence/locker/LockerName.java
@@ -1,0 +1,7 @@
+package net.causw.adapter.persistence.locker;
+
+public enum LockerName {
+    SECOND,
+    THIRD,
+    FOURTH;
+}

--- a/src/main/java/net/causw/adapter/persistence/push/Ceremony.java
+++ b/src/main/java/net/causw/adapter/persistence/push/Ceremony.java
@@ -1,0 +1,119 @@
+package net.causw.adapter.persistence.push;
+
+import jakarta.persistence.*;
+import lombok.*;
+import net.causw.adapter.persistence.base.BaseEntity;
+import net.causw.adapter.persistence.comment.ChildComment;
+import net.causw.adapter.persistence.comment.Comment;
+import net.causw.adapter.persistence.user.User;
+//import net.causw.adapter.persistence.uuidFile.joinEntity.CeremonyAttachImage;
+import net.causw.adapter.persistence.uuidFile.UuidFile;
+import net.causw.adapter.persistence.uuidFile.joinEntity.CeremonyAttachImage;
+import net.causw.domain.model.enums.ceremony.CeremonyCategory;
+import net.causw.domain.model.enums.ceremony.CeremonyState;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Getter
+@Builder(access = AccessLevel.PROTECTED)
+@Entity
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Ceremony extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ceremony_category", nullable = false)
+    private CeremonyCategory ceremonyCategory;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ceremony_state", nullable = false)
+    private CeremonyState ceremonyState = CeremonyState.AWAIT;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Column(name = "note", nullable = true)
+    private String note = "";
+
+    @Setter(value = AccessLevel.PRIVATE)
+    @OneToMany(cascade = { CascadeType.PERSIST, CascadeType.MERGE }, mappedBy = "ceremony")
+    @Builder.Default
+    private List<CeremonyAttachImage> ceremonyAttachImageList = new ArrayList<>();
+
+    public void approve() {
+        this.ceremonyState = CeremonyState.ACCEPT;
+    }
+
+    public void reject() {
+        this.ceremonyState = CeremonyState.REJECT;
+    }
+
+    public static Ceremony of(
+            User user,
+            CeremonyCategory ceremonyCategory,
+            String description,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        return Ceremony.builder()
+                .user(user)
+                .ceremonyCategory(ceremonyCategory)
+                .description(description)
+                .startDate(startDate)
+                .endDate(endDate)
+                .build();
+    }
+
+    public static Ceremony createWithImages(
+            User user,
+            CeremonyCategory ceremonyCategory,
+            String description,
+            LocalDate startDate,
+            LocalDate endDate,
+            List<UuidFile> ceremonyAttachImageUuidFileList
+    ) {
+        // Create a Ceremony object using the 'of' method
+        Ceremony ceremony = Ceremony.of(
+                user,
+                ceremonyCategory,
+                description,
+                startDate,
+                endDate
+        );
+
+        // Map UUID files to CeremonyAttachImage and associate them with the ceremony
+        List<CeremonyAttachImage> ceremonyAttachImageList = ceremonyAttachImageUuidFileList.stream()
+                .map(uuidFile -> CeremonyAttachImage.of(ceremony, uuidFile))
+                .toList();
+
+        // Assuming there's a setter or method to add images to ceremony
+        ceremony.updateCeremonyAttachImageList(ceremonyAttachImageList);
+
+        return ceremony;
+    }
+
+    public void updateCeremonyState(CeremonyState ceremonyState){
+        this.ceremonyState = ceremonyState;
+    }
+
+    public void updateNote(String note){
+        this.note = note;
+    }
+
+    public void updateCeremonyAttachImageList(List<CeremonyAttachImage> ceremonyAttachImageList) {
+        this.ceremonyAttachImageList = ceremonyAttachImageList;
+    }
+}

--- a/src/main/java/net/causw/adapter/persistence/repository/push/CeremonyRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/push/CeremonyRepository.java
@@ -1,0 +1,16 @@
+package net.causw.adapter.persistence.repository.push;
+
+
+import net.causw.adapter.persistence.push.Ceremony;
+import net.causw.adapter.persistence.user.User;
+import net.causw.domain.model.enums.ceremony.CeremonyState;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CeremonyRepository extends JpaRepository<Ceremony, String> {
+    List<Ceremony> findAllByUser(User user);
+    Page<Ceremony> findByCeremonyState(CeremonyState ceremonyState, Pageable pageable);
+}

--- a/src/main/java/net/causw/adapter/persistence/user/User.java
+++ b/src/main/java/net/causw/adapter/persistence/user/User.java
@@ -96,6 +96,9 @@ public class User extends BaseEntity {
     @Builder.Default
     private Boolean isV2 = true;
 
+    @Column(name = "fcm_token")
+    private String fcmToken;
+
     public void delete() {
         this.email = "deleted_" + this.getId();
         this.name = "탈퇴한 사용자";

--- a/src/main/java/net/causw/adapter/persistence/uuidFile/joinEntity/CeremonyAttachImage.java
+++ b/src/main/java/net/causw/adapter/persistence/uuidFile/joinEntity/CeremonyAttachImage.java
@@ -1,0 +1,36 @@
+package net.causw.adapter.persistence.uuidFile.joinEntity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import net.causw.adapter.persistence.push.Ceremony;
+import net.causw.adapter.persistence.uuidFile.UuidFile;
+
+@Getter
+@Builder(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(name = "tb_ceremony_attach_image_uuid_file",
+        indexes = {
+                @Index(name = "idx_ceremony_attach_image_ceremony_id", columnList = "ceremony_id"),
+                @Index(name = "idx_ceremony_attach_image_uuid_file_id", columnList = "uuid_file_id")
+        })
+public class CeremonyAttachImage extends JoinEntity {
+    @Getter
+    @Setter(AccessLevel.PUBLIC)
+    @OneToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "uuid_file_id", nullable = false, unique = true)
+    public UuidFile uuidFile;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ceremony_id", nullable = false)
+    private Ceremony ceremony;
+
+    public static CeremonyAttachImage of(Ceremony ceremony, UuidFile uuidFile) {
+        return CeremonyAttachImage.builder()
+                .uuidFile(uuidFile)
+                .ceremony(ceremony)
+                .build();
+    }
+}
+

--- a/src/main/java/net/causw/adapter/web/CeremonyController.java
+++ b/src/main/java/net/causw/adapter/web/CeremonyController.java
@@ -1,0 +1,98 @@
+package net.causw.adapter.web;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import net.causw.application.ceremony.CeremonyService;
+import net.causw.application.dto.ceremony.CeremonyResponseDTO;
+import net.causw.application.dto.ceremony.CreateCeremonyRequestDTO;
+import net.causw.application.dto.ceremony.UpdateCeremonyStateRequestDto;
+import net.causw.application.dto.userAcademicRecordApplication.CurrentUserAcademicRecordApplicationResponseDto;
+import net.causw.config.security.userdetails.CustomUserDetails;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/ceremony")
+public class CeremonyController {
+    private final CeremonyService ceremonyService;
+
+    /**
+     * 사용자 본인의 경조사 생성
+     * @param userDetails
+     * @param createCeremonyRequestDTO
+     * @param imageFileList
+     * @return
+     */
+
+    @PostMapping( consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(value = HttpStatus.CREATED)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
+    @Operation(summary = "사용자 본인의 경조사 생성",
+            description = "사용자 본인의 경조사 생성합니다.")
+    public CeremonyResponseDTO createUserAcademicRecordApplication(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestPart(value = "createCeremonyRequestDTO") @Valid CreateCeremonyRequestDTO createCeremonyRequestDTO,
+            @RequestPart(value = "imageFileList", required = false) List<MultipartFile> imageFileList
+    ) {
+        return ceremonyService.createCeremony(userDetails.getUser(), createCeremonyRequestDTO, imageFileList);
+    }
+
+    @GetMapping
+    @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
+    @Operation(summary = "사용자 본인의 경조사 신청 내역 조회",
+            description = "사용자 본인의 경조사 신청 내역을 조회합니다.")
+    public List<CeremonyResponseDTO> getUserCeremonyResponsesDTO(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return ceremonyService.getUserCeremonyResponsesDTO(userDetails.getUser());
+    }
+
+
+    @GetMapping("/list/await")
+    @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and " +
+            "@securityService.isAdminOrPresidentOrVicePresident()")
+    @Operation(summary = "전체 경조사 승인 대기 목록 조회(관리자용)",
+            description = "전체 경조사 승인 대기 목록을 조회합니다.")
+    public Page<CeremonyResponseDTO> getAllUserAwaitingCeremonyPage(
+            @ParameterObject Pageable pageable
+    ) {
+        return ceremonyService.getAllUserAwaitingCeremonyPage(pageable);
+    }
+
+    @GetMapping("/{ceremonyId}")
+    @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser()")
+    @Operation(summary = "유저 경조사 정보 상세 보기",
+            description = "유저 경조사 정보를 조회합니다.")
+    public CeremonyResponseDTO getUserCeremonyInfo(
+            @PathVariable("ceremonyId") String ceremonyId
+    ) {
+        return ceremonyService.getCeremony(ceremonyId);
+    }
+
+    @PutMapping("/state")
+    @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUser() and " +
+            "@securityService.isAdminOrPresidentOrVicePresident()")
+    @Operation(summary = "유저 경조사 승인 상태 변경(승인/거부)(관리자용)",
+            description = "유저 경조사 승인 상태를 변경합니다.")
+    public CeremonyResponseDTO updateUserCeremonyStatus(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid UpdateCeremonyStateRequestDto updateCeremonyStateRequestDto
+    ) {
+        return ceremonyService.updateUserCeremonyStatus(userDetails.getUser(), updateCeremonyStateRequestDto);
+    }
+
+}

--- a/src/main/java/net/causw/adapter/web/PushController.java
+++ b/src/main/java/net/causw/adapter/web/PushController.java
@@ -1,0 +1,22 @@
+package net.causw.adapter.web;
+import lombok.RequiredArgsConstructor;
+import net.causw.application.notification.FirebasePushNotificationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/fcm")
+public class PushController {
+    private final FirebasePushNotificationService fcmService;
+
+    @PostMapping("/send")
+    public ResponseEntity<String> sendTestNotification(
+            @RequestParam String token,
+            @RequestParam String title,
+            @RequestParam String body
+    ) {
+        fcmService.sendNotification(token, title, body);
+        return ResponseEntity.ok("Notification sent successfully!");
+    }
+}

--- a/src/main/java/net/causw/application/ceremony/CeremonyService.java
+++ b/src/main/java/net/causw/application/ceremony/CeremonyService.java
@@ -1,0 +1,106 @@
+package net.causw.application.ceremony;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import net.causw.adapter.persistence.push.Ceremony;
+import net.causw.adapter.persistence.repository.push.CeremonyRepository;
+import net.causw.adapter.persistence.user.User;
+import net.causw.adapter.persistence.uuidFile.UuidFile;
+import net.causw.application.dto.ceremony.CeremonyResponseDTO;
+import net.causw.application.dto.ceremony.CreateCeremonyRequestDTO;
+import net.causw.application.dto.ceremony.UpdateCeremonyStateRequestDto;
+import net.causw.application.uuidFile.UuidFileService;
+import net.causw.domain.exceptions.BadRequestException;
+import net.causw.domain.exceptions.ErrorCode;
+import net.causw.domain.model.enums.ceremony.CeremonyState;
+import net.causw.domain.model.enums.uuidFile.FilePath;
+import net.causw.domain.model.util.MessageUtil;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CeremonyService {
+    private final CeremonyRepository ceremonyRepository;
+    private final UuidFileService uuidFileService;
+    @Transactional
+    public CeremonyResponseDTO createCeremony(
+            User user,
+            @Valid CreateCeremonyRequestDTO createCeremonyRequestDTO,
+            List<MultipartFile> imageFileList
+    ) {
+        List<UuidFile> uuidFileList = uuidFileService.saveFileList(imageFileList, FilePath.USER_ACADEMIC_RECORD_APPLICATION);
+        Ceremony ceremony = Ceremony.createWithImages(
+                user,
+                createCeremonyRequestDTO.getCategory(),
+                createCeremonyRequestDTO.getDescription(),
+                createCeremonyRequestDTO.getStartDate(),
+                createCeremonyRequestDTO.getEndDate(),
+                uuidFileList
+        );
+        ceremonyRepository.save(ceremony);
+
+        return CeremonyResponseDTO.from(ceremony);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CeremonyResponseDTO> getUserCeremonyResponsesDTO(User user) {
+        List<Ceremony> ceremonies = ceremonyRepository.findAllByUser(user);
+        return ceremonies.stream()
+                .map(CeremonyResponseDTO::from) // Assuming from method exists in DTO
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public Page<CeremonyResponseDTO> getAllUserAwaitingCeremonyPage(Pageable pageable) {
+        Page<Ceremony> ceremoniesPage = ceremonyRepository.findByCeremonyState(CeremonyState.AWAIT, pageable);
+        return ceremoniesPage.map(CeremonyResponseDTO::from);
+    }
+
+    @Transactional(readOnly = true)
+    public CeremonyResponseDTO getCeremony(String ceremonyId){
+        Ceremony ceremony = ceremonyRepository.findById(ceremonyId).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        MessageUtil.CEREMONY_NOT_FOUND
+                )
+        );
+        return CeremonyResponseDTO.from(ceremony);
+    }
+
+    @Transactional
+    public CeremonyResponseDTO updateUserCeremonyStatus(User user, UpdateCeremonyStateRequestDto updateDto) {
+        // 대상 경조사 조회
+        Ceremony ceremony = ceremonyRepository.findById(updateDto.getCeremonyId()).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        MessageUtil.CEREMONY_NOT_FOUND
+                )
+        );
+        ceremony.updateCeremonyState(updateDto.getTargetCeremonyState());
+
+        if (updateDto.getTargetCeremonyState() == CeremonyState.REJECT) {
+            ceremony.updateNote(updateDto.getRejectMessage());
+        }
+        ceremonyRepository.save(ceremony);
+
+        return CeremonyResponseDTO.from(ceremony);
+    }
+
+    @Transactional
+    public void approveCeremonyRequest(Long requestId) {
+
+        // Logic to notify users
+    }
+
+    @Transactional
+    public void denyCeremonyRequest(Long requestId) {
+
+    }
+}

--- a/src/main/java/net/causw/application/dto/ceremony/CeremonyResponseDTO.java
+++ b/src/main/java/net/causw/application/dto/ceremony/CeremonyResponseDTO.java
@@ -1,0 +1,47 @@
+package net.causw.application.dto.ceremony;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import net.causw.domain.model.enums.ceremony.CeremonyCategory;
+import net.causw.adapter.persistence.push.Ceremony;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CeremonyResponseDTO {
+
+    @Schema(description = "행사 설명", example = "연례 졸업식")
+    private String description;
+
+    @Schema(description = "행사 시작 날짜", example = "2025-05-01")
+    private LocalDate startDate;
+
+    @Schema(description = "행사 종료 날짜", example = "2025-05-02")
+    private LocalDate endDate;
+
+    @Schema(description = "행사 카테고리", example = "GRADUATION")
+    private CeremonyCategory category;
+
+    @Schema(description = "첨부 이미지 URL 리스트")
+    private List<String> attachedImageUrlList;
+
+    public static CeremonyResponseDTO from(Ceremony ceremony) {
+        List<String> attachedImageUrlList = ceremony.getCeremonyAttachImageList().stream()
+                .map(image -> image.getUuidFile().getFileUrl()) // Get URL from UuidFile
+                .collect(Collectors.toList());
+
+        return CeremonyResponseDTO.builder()
+                .description(ceremony.getDescription())
+                .startDate(ceremony.getStartDate())
+                .endDate(ceremony.getEndDate())
+                .category(ceremony.getCeremonyCategory())
+                .attachedImageUrlList(attachedImageUrlList)
+                .build();
+    }
+}

--- a/src/main/java/net/causw/application/dto/ceremony/CreateCeremonyRequestDTO.java
+++ b/src/main/java/net/causw/application/dto/ceremony/CreateCeremonyRequestDTO.java
@@ -1,0 +1,28 @@
+package net.causw.application.dto.ceremony;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import net.causw.domain.model.enums.ceremony.CeremonyCategory;
+
+import java.time.LocalDate;
+
+@Getter
+public class CreateCeremonyRequestDTO {
+
+    @Schema(description = "행사 설명", requiredMode = Schema.RequiredMode.REQUIRED, example = "연례 졸업식")
+    @NotNull(message = "설명은 필수 입력 값입니다.")
+    private String description;
+
+    @Schema(description = "행사 시작 날짜", requiredMode = Schema.RequiredMode.REQUIRED, example = "2025-05-01")
+    @NotNull(message = "시작 날짜는 필수 입력 값입니다.")
+    private LocalDate startDate;
+
+    @Schema(description = "행사 종료 날짜", requiredMode = Schema.RequiredMode.REQUIRED, example = "2025-05-02")
+    @NotNull(message = "종료 날짜는 필수 입력 값입니다.")
+    private LocalDate endDate;
+
+    @Schema(description = "행사 카테고리", requiredMode = Schema.RequiredMode.REQUIRED, example = "MARRIAGE")
+    @NotNull(message = "카테고리는 필수 입력 값입니다.")
+    private CeremonyCategory category;
+}

--- a/src/main/java/net/causw/application/locker/LockerService.java
+++ b/src/main/java/net/causw/application/locker/LockerService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import net.causw.adapter.persistence.locker.Locker;
 import net.causw.adapter.persistence.locker.LockerLocation;
 import net.causw.adapter.persistence.locker.LockerLog;
+import net.causw.adapter.persistence.locker.LockerName;
 import net.causw.adapter.persistence.repository.locker.LockerLocationRepository;
 import net.causw.adapter.persistence.repository.locker.LockerLogRepository;
 import net.causw.adapter.persistence.repository.locker.LockerRepository;
@@ -273,7 +274,7 @@ public class LockerService {
         }
 
         LockerLocation lockerLocation = LockerLocation.of(
-                lockerLocationCreateRequestDto.getName()
+                LockerName.valueOf(lockerLocationCreateRequestDto.getName())
         );
 
         ValidatorBucket.of()
@@ -282,7 +283,7 @@ public class LockerService {
                 .consistOf(UserRoleValidator.of(roles, Set.of()))
                 .consistOf(ConstraintValidator.of(lockerLocation, this.validator))
                 .validate();
-        LockerLocation location = LockerLocation.of(lockerLocationCreateRequestDto.getName());
+        LockerLocation location = LockerLocation.of(LockerName.valueOf(lockerLocationCreateRequestDto.getName()));
 
         return LockerLocationResponseDto.of(
                 location,
@@ -315,7 +316,7 @@ public class LockerService {
         }
 
         lockerLocation.update(
-                lockerLocationRequestDto.getName()
+                LockerName.valueOf(lockerLocationRequestDto.getName())
         );
 
         ValidatorBucket.of()
@@ -411,13 +412,13 @@ public class LockerService {
         ValidatorBucket validatorBucket = ValidatorBucket.of();
 
 
-        LockerLocation lockerLocationSecondFloor = LockerLocation.of("Second Floor");
+        LockerLocation lockerLocationSecondFloor = LockerLocation.of(LockerName.valueOf("Second"));
         lockerLocationRepository.save(lockerLocationSecondFloor);
 
-        LockerLocation lockerLocationThirdFloor = LockerLocation.of("Third Floor");
+        LockerLocation lockerLocationThirdFloor = LockerLocation.of(LockerName.valueOf("Third"));
         lockerLocationRepository.save(lockerLocationThirdFloor);
 
-        LockerLocation lockerLocationFourthFloor = LockerLocation.of("Fourth Floor");
+        LockerLocation lockerLocationFourthFloor = LockerLocation.of(LockerName.valueOf("Fourth"));
         lockerLocationRepository.save(lockerLocationFourthFloor);
 
         createLockerByLockerLocationAndEndLockerNumber(lockerLocationSecondFloor, validatorBucket, user, 136L);

--- a/src/main/java/net/causw/application/notification/FirebasePushNotificationService.java
+++ b/src/main/java/net/causw/application/notification/FirebasePushNotificationService.java
@@ -1,0 +1,31 @@
+package net.causw.application.notification;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class FirebasePushNotificationService {
+
+    public void sendNotification(String targetToken, String title, String body) {
+        Notification notification = Notification.builder()
+                .setTitle(title)
+                .setBody(body)
+                .build();
+
+        Message message = Message.builder()
+                .setToken(targetToken)
+                .setNotification(notification)
+                .build();
+
+        try {
+            String response = FirebaseMessaging.getInstance().send(message);
+            log.info("Successfully sent message: " + response);
+        } catch (Exception e) {
+            log.error("Error sending FCM message: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/net/causw/config/firebase/FirebaseConfig.java
+++ b/src/main/java/net/causw/config/firebase/FirebaseConfig.java
@@ -1,0 +1,33 @@
+package net.causw.config.firebase;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.io.InputStream;
+
+@Configuration
+public class FirebaseConfig {
+
+    @PostConstruct
+    public void initialize() {
+        try {
+            if (FirebaseApp.getApps().isEmpty()) {
+                // resources 폴더에서 서비스 계정 JSON 파일 로드
+                InputStream serviceAccount = new ClassPathResource("dongnae_firebase_key.json").getInputStream();
+
+                FirebaseOptions options = FirebaseOptions.builder()
+                        .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                        .build();
+
+                FirebaseApp.initializeApp(options);
+                System.out.println("Firebase가 성공적으로 초기화되었습니다.");
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Firebase 초기화 실패", e);
+        }
+    }
+}

--- a/src/main/java/net/causw/config/security/WebSecurityConfig.java
+++ b/src/main/java/net/causw/config/security/WebSecurityConfig.java
@@ -68,6 +68,7 @@ public class WebSecurityConfig {
                                 "/api/v1/users/password/find",
                                 "/api/v1/users/user-id/find",
                                 "/swagger-ui/**",
+                                "/api/v1/fcm/send",
                                 "/v3/api-docs/**",
                                 "/actuator/**"
                         ).permitAll()

--- a/src/main/java/net/causw/domain/model/enums/ceremony/CeremonyCategory.java
+++ b/src/main/java/net/causw/domain/model/enums/ceremony/CeremonyCategory.java
@@ -1,0 +1,7 @@
+package net.causw.domain.model.enums.ceremony;
+
+public enum CeremonyCategory {
+    MARRIAGE, //결혼
+    FUNERAL, //장례식
+    ETC //기타
+}

--- a/src/main/java/net/causw/domain/model/enums/ceremony/CeremonyState.java
+++ b/src/main/java/net/causw/domain/model/enums/ceremony/CeremonyState.java
@@ -1,0 +1,8 @@
+package net.causw.domain.model.enums.ceremony;
+
+public enum CeremonyState {
+    ACCEPT, // 승인
+    REJECT, // 거절
+    AWAIT, // 대기
+    CLOSE // 종료
+}

--- a/src/main/java/net/causw/domain/model/util/MessageUtil.java
+++ b/src/main/java/net/causw/domain/model/util/MessageUtil.java
@@ -152,6 +152,9 @@ public class MessageUtil {
     // CouncilFeeFakeUser
     public static final String INVALID_COUNCIL_FEE_FAKE_USER_INFO = "유효하지 않은 가짜 사용자 정보입니다.";
 
+    // Ceremony
+    public static final String CEREMONY_NOT_FOUND = "존재하지 않는 경조사입니다.";
+
     // Vote
     public static final String VOTE_OPTION_NOT_FOUND = "존재하지 않는 투표 옵션입니다.";
     public static final String VOTE_OPTION_NOT_PROVIDED = "투표 옵션이 제공되지 않았습니다.";


### PR DESCRIPTION
### 🚩 관련사항
경조사 기능 구현 및 사물함 dto 변경입니다.

### 📢 전달사항
사물함 Dto의 경우에는 LockeName이라는 필드를 추가하여 second, third, fourth로 층 정보를 얻을 수 있게 변경하였습니다.
경조사 api를 구현하였습니다.
푸시알람에 대한 일반적인 config를 추가하였고, 경조사 api를 일단 프론트와 맞춰보고, 푸시알람을 붙히는 방향으로 일단 개발하였습니다.


### 📃 진행사항
- [ ] 다양한 상황에 대한 푸시알람이 구현되어야합니다. (추후)
- [ ] 현재 알람에 대한 entity와 푸시알람을 연동하여 로그를 남기는 방향으로 엔티티와 controller를 변경해야합니다.(notification controller와 푸시알람이 합쳐져야합니다.)
- [ ] 유저의 경조사에 대한 푸시알람 설정은 위에 부분이 완료되면 개발하도록 하곘습니다.


### ⚙️ 기타사항
경조사 api를 연동하여 안정화 한 뒤 푸시알람 설정 및 배치 기능을 붙히겠습니다.
