### PR TITLE
fix: logback 익셉션 디스코드 웹훅 설정 업데이트

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -39,7 +39,7 @@
         <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
             <webhookUri>${DISCORD_WEBHOOK_URL}</webhookUri>
             <layout class="ch.qos.logback.classic.PatternLayout">
-                <pattern>%d{HH:mm:ss} [%thread] [%-5level] %logger{36} - %msg%n```%ex{105}```</pattern>
+                <pattern>%d{HH:mm:ss} [%thread] [%-5level] %logger{36} - %msg%n```%ex{10}```</pattern>
             </layout>
             <username>BACKEND-ERROR!</username>
             <tts>false</tts>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -30,15 +30,16 @@
         </root>
     </springProfile>
 
-    <!-- QA 환경 -->
-    <springProfile name="qa">
+    <!-- 개발 환경 -->
+    <springProfile name="dev">
         <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
+        <!-- Discord 알림 관련 -->
         <springProperty name="DISCORD_WEBHOOK_URL" source="logging.discord.webhook-uri"/>
         <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
             <webhookUri>${DISCORD_WEBHOOK_URL}</webhookUri>
             <layout class="ch.qos.logback.classic.PatternLayout">
-                <pattern>%d{HH:mm:ss} [%thread] [%-5level] %logger{36} - %msg%n```%ex{full}```</pattern>
+                <pattern>%d{HH:mm:ss} [%thread] [%-5level] %logger{36} - %msg%n```%ex{105}```</pattern>
             </layout>
             <username>BACKEND-ERROR!</username>
             <tts>false</tts>
@@ -57,8 +58,8 @@
         </root>
     </springProfile>
 
-    <!-- 개발 및 로컬 환경 -->
-    <springProfile name="dev|local">
+    <!-- 로컬 환경 -->
+    <springProfile name="local">
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
         </root>


### PR DESCRIPTION
### 📢 전달사항
기존 logback.xml에서는 `QA` 서버 오류만 디스코드로 출력하고 있었는데, 
`dev` 서버 익셉션을 출력하도록 바꿨습니다.

### 🏴 추가사항
기존에는 익셉션 스택 트레이스를 전부 출력했는데,
보기 쉽도록 상위 10줄만 출력하게 바꿔봤습니다