### PR TITLE
feat : 사물함 로직 수정 및 사물함 신청 상태 dto 추가 

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/repository/flag/FlagRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/flag/FlagRepository.java
@@ -2,9 +2,13 @@ package net.causw.adapter.persistence.repository.flag;
 
 import net.causw.adapter.persistence.flag.Flag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface FlagRepository extends JpaRepository<Flag, String> {
     Optional<Flag> findByKey(String key);
+
+    Optional<Flag> findByValue(Boolean value);
 }

--- a/src/main/java/net/causw/application/dto/locker/LockersResponseDto.java
+++ b/src/main/java/net/causw/application/dto/locker/LockersResponseDto.java
@@ -11,11 +11,13 @@ import java.util.List;
 @Builder
 public class LockersResponseDto {
     private String locationName;
+    private String lockerPeriod;
     private List<LockerResponseDto> lockerList;
 
-    public static LockersResponseDto of(String locationName, List<LockerResponseDto> lockerList) {
+    public static LockersResponseDto of(String locationName, String lockerPeriod, List<LockerResponseDto> lockerList) {
         return LockersResponseDto.builder()
                 .locationName(locationName)
+                .lockerPeriod(lockerPeriod)
                 .lockerList(lockerList)
                 .build();
     }

--- a/src/main/java/net/causw/application/locker/LockerActionRegister.java
+++ b/src/main/java/net/causw/application/locker/LockerActionRegister.java
@@ -42,8 +42,8 @@ public class LockerActionRegister implements LockerAction {
                     .validate();
 
             lockerService.findByUserId(user.getId()).ifPresent(existingLocker -> {
-                existingLocker.returnLocker();
-                LockerLog lockerLog = LockerLog.of(
+                lockerService.returnAndSaveLocker(existingLocker);
+               LockerLog lockerLog = LockerLog.of(
                         existingLocker.getLockerNumber(),
                         existingLocker.getLocation().getName(),
                         user.getEmail(),


### PR DESCRIPTION
### 🚩 관련사항
관련된 이슈번호 혹은 PR 번호를 기록합니다.


### 📢 전달사항
기존 사물함을 가지고 있을 경우 다른 사물함을 선택할 때 자동으로 변경되는 로직에 문제가 발생하여 강제로 flush를 통해 db가 업데이트 되게 하였습니다.

dto에는 lockerPeriod를 사용하여 현재 사물함의 신청 상태를 반환합니다.(LOCKER_ACCESS, LOCKER_EXTEND, NULL을 반환합니다

### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 