### PR TITLE
fix: 이벤트 순서 정렬 기준 명시

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/repository/event/EventRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/event/EventRepository.java
@@ -9,5 +9,5 @@ import java.util.List;
 @Repository
 public interface EventRepository extends JpaRepository<Event, String> {
 
-    List<Event> findByIsDeletedIsFalse();
+    List<Event> findByIsDeletedIsFalseOrderByCreatedAtDesc();
 }

--- a/src/main/java/net/causw/application/event/EventService.java
+++ b/src/main/java/net/causw/application/event/EventService.java
@@ -31,7 +31,7 @@ public class EventService {
 
     @Transactional(readOnly = true)
     public EventsResponseDto findEvents() {
-        List<EventResponseDto> events = eventRepository.findByIsDeletedIsFalse().stream()
+        List<EventResponseDto> events = eventRepository.findByIsDeletedIsFalseOrderByCreatedAtDesc().stream()
                 .map(EventDtoMapper.INSTANCE::toEventResponseDto)
                 .toList();
 
@@ -43,7 +43,7 @@ public class EventService {
 
     @Transactional
     public EventResponseDto createEvent(EventCreateRequestDto eventCreateRequestDto, MultipartFile eventImage) {
-        if (eventRepository.findByIsDeletedIsFalse().size() >= StaticValue.MAX_NUM_EVENT) {
+        if (eventRepository.findByIsDeletedIsFalseOrderByCreatedAtDesc().size() >= StaticValue.MAX_NUM_EVENT) {
             throw new BadRequestException(
                     ErrorCode.CANNOT_PERFORMED,
                     MessageUtil.EVENT_MAX_CREATED

--- a/src/test/java/net/causw/application/event/EventServiceTest.java
+++ b/src/test/java/net/causw/application/event/EventServiceTest.java
@@ -81,7 +81,7 @@ public class EventServiceTest {
       // then
       assertThat(result).isNotNull();
       assertThat(result.getEvents().size()).isEqualTo(2);
-      assertThat(result.getEvents().getFirst().getUrl()).isEqualTo("url2");
+      assertThat(result.getEvents().get(0).getUrl()).isEqualTo("url2");
     }
 
     @Test

--- a/src/test/java/net/causw/application/event/EventServiceTest.java
+++ b/src/test/java/net/causw/application/event/EventServiceTest.java
@@ -1,0 +1,90 @@
+package net.causw.application.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.Optional;
+import net.causw.adapter.persistence.calendar.Calendar;
+import net.causw.adapter.persistence.event.Event;
+import net.causw.adapter.persistence.repository.event.EventRepository;
+import net.causw.adapter.persistence.uuidFile.UuidFile;
+import net.causw.application.dto.event.EventResponseDto;
+import net.causw.application.dto.event.EventsResponseDto;
+import net.causw.application.uuidFile.UuidFileService;
+import net.causw.domain.model.enums.uuidFile.FilePath;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class EventServiceTest {
+
+  @InjectMocks
+  private EventService eventService;
+
+  @Mock
+  private EventRepository eventRepository;
+
+  @Mock
+  private UuidFileService uuidFileService;
+
+  @Nested
+  @DisplayName("배너 리스트 테스트")
+  class EventListTest {
+
+    List<Event> mockEvents;
+
+    @BeforeEach
+    void setUp() {
+      UuidFile mockUuidFile = UuidFile.of(
+          "uuid",
+          "fileKey",
+          "fileUrl",
+          "rawFileName",
+          "png",
+          FilePath.CALENDAR
+      );
+      mockEvents = List.of(
+          Event.of("url1", mockUuidFile, false),
+          Event.of("url2", mockUuidFile, false)
+      );
+    }
+
+    @Test
+    @DisplayName("배너 리스트 성공")
+    void listEventBannerSuccess() {
+
+      // given
+      given(eventRepository.findByIsDeletedIsFalse()).willReturn(mockEvents);
+
+      // when
+      EventsResponseDto result = eventService.findEvents();
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(result.getEvents().size()).isEqualTo(2);
+      assertThat(result.getEvents().getFirst().getUrl()).isEqualTo("url1");
+    }
+
+    @Test
+    @DisplayName("이벤트가 없을 때 빈 리스트 반환")
+    void listEventBannerEmpty() {
+      // given
+      given(eventRepository.findByIsDeletedIsFalse()).willReturn(List.of());
+
+      // when
+      EventsResponseDto result = eventService.findEvents();
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(result.getEvents()).isEmpty();
+    }
+
+  }
+}

--- a/src/test/java/net/causw/application/event/EventServiceTest.java
+++ b/src/test/java/net/causw/application/event/EventServiceTest.java
@@ -4,12 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
 import java.util.List;
-import java.util.Optional;
-import net.causw.adapter.persistence.calendar.Calendar;
 import net.causw.adapter.persistence.event.Event;
 import net.causw.adapter.persistence.repository.event.EventRepository;
 import net.causw.adapter.persistence.uuidFile.UuidFile;
-import net.causw.application.dto.event.EventResponseDto;
 import net.causw.application.dto.event.EventsResponseDto;
 import net.causw.application.uuidFile.UuidFileService;
 import net.causw.domain.model.enums.uuidFile.FilePath;
@@ -48,11 +45,11 @@ public class EventServiceTest {
           "fileUrl",
           "rawFileName",
           "png",
-          FilePath.CALENDAR
+          FilePath.EVENT
       );
       mockEvents = List.of(
-          Event.of("url1", mockUuidFile, false),
-          Event.of("url2", mockUuidFile, false)
+          Event.of("url2", mockUuidFile, false),
+          Event.of("url1", mockUuidFile, false)
       );
     }
 
@@ -61,7 +58,7 @@ public class EventServiceTest {
     void listEventBannerSuccess() {
 
       // given
-      given(eventRepository.findByIsDeletedIsFalse()).willReturn(mockEvents);
+      given(eventRepository.findByIsDeletedIsFalseOrderByCreatedAtDesc()).willReturn(mockEvents);
 
       // when
       EventsResponseDto result = eventService.findEvents();
@@ -69,14 +66,14 @@ public class EventServiceTest {
       // then
       assertThat(result).isNotNull();
       assertThat(result.getEvents().size()).isEqualTo(2);
-      assertThat(result.getEvents().getFirst().getUrl()).isEqualTo("url1");
+      assertThat(result.getEvents().getFirst().getUrl()).isEqualTo("url2");
     }
 
     @Test
     @DisplayName("이벤트가 없을 때 빈 리스트 반환")
     void listEventBannerEmpty() {
       // given
-      given(eventRepository.findByIsDeletedIsFalse()).willReturn(List.of());
+      given(eventRepository.findByIsDeletedIsFalseOrderByCreatedAtDesc()).willReturn(List.of());
 
       // when
       EventsResponseDto result = eventService.findEvents();


### PR DESCRIPTION
### 🚩 관련사항
https://www.notion.so/1b93d138d33c813782a5f5045e07401e?pvs=4

노션을 통해 배정받은 `배너 반환 시 등록시간 역순으로 정렬` 이슈에 대한 풀리퀘스트 입니다.
해당 업무 수행하면서 관련된 `EventService` 의 단위 테스트 코드 또한 작성했습니다.
확인해주시면 감사하겠습니다.


### 📢 전달사항


### 📸 스크린샷
<img width="313" alt="image" src="https://github.com/user-attachments/assets/37000c0d-28ea-4fef-a7c0-09587512269e" />
<img width="1063" alt="image" src="https://github.com/user-attachments/assets/23d75b75-4139-45de-8b6e-0c78374cd185" />
<img width="827" alt="image" src="https://github.com/user-attachments/assets/876c8960-4efd-4637-a4dc-bb72846e5766" />



### 📃 진행사항
- [x] 이벤트 최신순 정렬 확인
- [x] 이벤트 서비스 테스트 코드 작성 및 테스트 완료


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 약 3일