### PR TITLE
fix: 학생회비 납부자 목록 엑셀 내용 수정

### DIFF
--- a/src/main/java/net/causw/application/excel/CouncilFeeExcelService.java
+++ b/src/main/java/net/causw/application/excel/CouncilFeeExcelService.java
@@ -16,55 +16,57 @@ import java.util.List;
 @Service
 public class CouncilFeeExcelService extends ExcelAbstractService<UserCouncilFeeResponseDto> {
 
-    private static final List<Function<UserCouncilFeeResponseDto, String>> cellMappingFunctions = List.of(
-        userCouncilFee -> Optional.ofNullable(userCouncilFee.getIsJoinedService())
+    private static final Function<UserCouncilFeeResponseDto, List<String>> cellMappingFunction =
+        userCouncilFee -> List.of(
+        Optional.ofNullable(userCouncilFee.getIsJoinedService())
                                   .map(isRefunded -> isRefunded ? "O" : "X")
                                   .orElse(""),
-        userCouncilFee -> Optional.ofNullable(userCouncilFee.getEmail()).orElse(""),
-        userCouncilFee -> Optional.ofNullable(userCouncilFee.getUserName()).orElse(""),
-        userCouncilFee -> Optional.ofNullable(userCouncilFee.getStudentId()).orElse(""),
-        userCouncilFee -> Optional.ofNullable(userCouncilFee.getAdmissionYear())
-                                  .map(String::valueOf)
-                                  .orElse(""),
-        userCouncilFee -> Optional.ofNullable(userCouncilFee.getNickname()).orElse(""),
-        userCouncilFee -> Optional.ofNullable(userCouncilFee.getMajor()).orElse(""),
-        userCouncilFee -> Optional.ofNullable(userCouncilFee.getAcademicStatus())
-                                  .map(AcademicStatus::getValue)
-                                  .orElse(""),
-        userCouncilFee -> Optional.ofNullable(userCouncilFee.getCurrentCompletedSemester())
-                                  .map(String::valueOf)
-                                  .orElse(""),
-        userCouncilFee -> Optional.ofNullable(userCouncilFee.getGraduationYear())
-                                  .map(String::valueOf)
-                                  .orElse(""),
-        userCouncilFee -> Optional.ofNullable(userCouncilFee.getGraduationType())
-                                  .map(GraduationType::getValue)
-                                  .orElse(""),
-        userCouncilFee -> Optional.ofNullable(userCouncilFee.getPhoneNumber()).orElse(""),
-        userCouncilFee -> Optional.ofNullable(userCouncilFee.getJoinedAt())
-                                  .map(String::valueOf)
-                                  .orElse(""),
-        userCouncilFee -> Optional.ofNullable(userCouncilFee.getPaidAt())
-                                  .map(String::valueOf)
-                                  .orElse(""),
-        userCouncilFee -> Optional.ofNullable(userCouncilFee.getNumOfPaidSemester())
-                                  .map(String::valueOf)
-                                  .orElse(""),
-        userCouncilFee -> Optional.ofNullable(userCouncilFee.getIsRefunded())
-                                  .map(isRefunded -> isRefunded ? "O" : "X")
-                                  .orElse(""),
-        userCouncilFee -> Optional.ofNullable(userCouncilFee.getIsRefunded())
-                                  .filter(isRefunded -> isRefunded)
-                                  .map(isRefunded -> Optional.ofNullable(userCouncilFee.getRefundedAt())
-                                      .map(String::valueOf)
-                                      .orElse(""))
-                                  .orElse(""),
-        userCouncilFee -> Optional.ofNullable(userCouncilFee.getRestOfSemester())
-                                  .map(String::valueOf)
-                                  .orElse(""),
-        userCouncilFee -> Optional.ofNullable(userCouncilFee.getIsAppliedThisSemester())
-                                  .map(isRefunded -> isRefunded ? "O" : "X")
-                                  .orElse("")
+        Optional.ofNullable(userCouncilFee.getEmail()).orElse(""),
+        Optional.ofNullable(userCouncilFee.getUserName()).orElse(""),
+        Optional.ofNullable(userCouncilFee.getStudentId()).orElse(""),
+        Optional.ofNullable(userCouncilFee.getAdmissionYear())
+                .map(String::valueOf)
+                .orElse(""),
+        Optional.ofNullable(userCouncilFee.getNickname()).orElse(""),
+        Optional.ofNullable(userCouncilFee.getMajor()).orElse(""),
+        Optional.ofNullable(userCouncilFee.getAcademicStatus())
+                .map(AcademicStatus::getValue)
+                .orElse(""),
+        Optional.ofNullable(userCouncilFee.getCurrentCompletedSemester())
+                .map(String::valueOf)
+                .orElse(""),
+        Optional.ofNullable(userCouncilFee.getGraduationYear())
+                .map(String::valueOf)
+                .orElse(""),
+        Optional.ofNullable(userCouncilFee.getGraduationType())
+                .map(GraduationType::getValue)
+                .orElse(""),
+        Optional.ofNullable(userCouncilFee.getPhoneNumber()).orElse(""),
+        Optional.ofNullable(userCouncilFee.getJoinedAt())
+                .map(String::valueOf)
+                .orElse(""),
+        Optional.ofNullable(userCouncilFee.getPaidAt())
+                .map(String::valueOf)
+                .orElse(""),
+        Optional.ofNullable(userCouncilFee.getNumOfPaidSemester())
+                .map(String::valueOf)
+                .orElse(""),
+        Optional.ofNullable(userCouncilFee.getIsRefunded())
+                .map(isRefunded -> isRefunded ? "O" : "X")
+                .orElse(""),
+        Optional.ofNullable(userCouncilFee.getIsRefunded())
+                .filter(isRefunded -> isRefunded)
+                .map(isRefunded ->
+                    Optional.ofNullable(userCouncilFee.getRefundedAt())
+                            .map(String::valueOf)
+                            .orElse(""))
+                .orElse(""),
+        Optional.ofNullable(userCouncilFee.getRestOfSemester())
+                .map(String::valueOf)
+                .orElse(""),
+        Optional.ofNullable(userCouncilFee.getIsAppliedThisSemester())
+                .map(isRefunded -> isRefunded ? "O" : "X")
+                .orElse("")
     );
 
     @Override
@@ -74,9 +76,10 @@ public class CouncilFeeExcelService extends ExcelAbstractService<UserCouncilFeeR
             Row row = sheet.createRow(rowNum++);
 
             int colNum = 0;
-            for (Function<UserCouncilFeeResponseDto, String> func : cellMappingFunctions) {
+            List<String> cellValues = cellMappingFunction.apply(userCouncilFee);
+            for (String value : cellValues) {
                 Cell cell = row.createCell(colNum++);
-                cell.setCellValue(func.apply(userCouncilFee));
+                cell.setCellValue(value);
             }
         }
     }

--- a/src/main/java/net/causw/application/excel/CouncilFeeExcelService.java
+++ b/src/main/java/net/causw/application/excel/CouncilFeeExcelService.java
@@ -42,7 +42,7 @@ public class CouncilFeeExcelService extends ExcelAbstractService<UserCouncilFeeR
                     userCouncilFeeResponseDto.getMajor() != null ? userCouncilFeeResponseDto.getMajor() : ""
             );
             row.createCell(7).setCellValue(
-                    userCouncilFeeResponseDto.getAcademicStatus() != null ? userCouncilFeeResponseDto.getAcademicStatus().toString() : ""
+                    userCouncilFeeResponseDto.getAcademicStatus() != null ? userCouncilFeeResponseDto.getAcademicStatus().getValue() : ""
             );
             row.createCell(8).setCellValue(
                     userCouncilFeeResponseDto.getCurrentCompletedSemester() != null ? userCouncilFeeResponseDto.getCurrentCompletedSemester().toString() : ""
@@ -51,7 +51,7 @@ public class CouncilFeeExcelService extends ExcelAbstractService<UserCouncilFeeR
                     userCouncilFeeResponseDto.getGraduationYear() != null ? userCouncilFeeResponseDto.getGraduationYear().toString() : ""
             );
             row.createCell(10).setCellValue(
-                    userCouncilFeeResponseDto.getGraduationType() != null ? userCouncilFeeResponseDto.getGraduationType().toString() : ""
+                    userCouncilFeeResponseDto.getGraduationType() != null ? userCouncilFeeResponseDto.getGraduationType().getValue() : ""
             );
             row.createCell(11).setCellValue(
                     userCouncilFeeResponseDto.getPhoneNumber() != null ? userCouncilFeeResponseDto.getPhoneNumber() : ""
@@ -73,7 +73,11 @@ public class CouncilFeeExcelService extends ExcelAbstractService<UserCouncilFeeR
                             ""
             );
             row.createCell(16).setCellValue(
-                    userCouncilFeeResponseDto.getRefundedAt() != null ? userCouncilFeeResponseDto.getRefundedAt().toString() : ""
+                    (userCouncilFeeResponseDto.getRefundedAt() != null) ?
+                        (userCouncilFeeResponseDto.getIsRefunded() ?
+                                    userCouncilFeeResponseDto.getRefundedAt().toString() :
+                                    "") :
+                            ""
             );
             row.createCell(17).setCellValue(
                     userCouncilFeeResponseDto.getRestOfSemester() != null ? userCouncilFeeResponseDto.getRestOfSemester().toString() : ""

--- a/src/main/java/net/causw/application/excel/CouncilFeeExcelService.java
+++ b/src/main/java/net/causw/application/excel/CouncilFeeExcelService.java
@@ -1,7 +1,12 @@
 package net.causw.application.excel;
 
+import java.util.Optional;
+import java.util.function.Function;
 import net.causw.application.dto.userCouncilFee.UserCouncilFeeResponseDto;
 import net.causw.domain.aop.annotation.MeasureTime;
+import net.causw.domain.model.enums.user.GraduationType;
+import net.causw.domain.model.enums.userAcademicRecord.AcademicStatus;
+import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.springframework.stereotype.Service;
@@ -11,84 +16,68 @@ import java.util.List;
 @Service
 public class CouncilFeeExcelService extends ExcelAbstractService<UserCouncilFeeResponseDto> {
 
+    private static final List<Function<UserCouncilFeeResponseDto, String>> cellMappingFunctions = List.of(
+        userCouncilFee -> Optional.ofNullable(userCouncilFee.getIsJoinedService())
+                                  .map(isRefunded -> isRefunded ? "O" : "X")
+                                  .orElse(""),
+        userCouncilFee -> Optional.ofNullable(userCouncilFee.getEmail()).orElse(""),
+        userCouncilFee -> Optional.ofNullable(userCouncilFee.getUserName()).orElse(""),
+        userCouncilFee -> Optional.ofNullable(userCouncilFee.getStudentId()).orElse(""),
+        userCouncilFee -> Optional.ofNullable(userCouncilFee.getAdmissionYear())
+                                  .map(String::valueOf)
+                                  .orElse(""),
+        userCouncilFee -> Optional.ofNullable(userCouncilFee.getNickname()).orElse(""),
+        userCouncilFee -> Optional.ofNullable(userCouncilFee.getMajor()).orElse(""),
+        userCouncilFee -> Optional.ofNullable(userCouncilFee.getAcademicStatus())
+                                  .map(AcademicStatus::getValue)
+                                  .orElse(""),
+        userCouncilFee -> Optional.ofNullable(userCouncilFee.getCurrentCompletedSemester())
+                                  .map(String::valueOf)
+                                  .orElse(""),
+        userCouncilFee -> Optional.ofNullable(userCouncilFee.getGraduationYear())
+                                  .map(String::valueOf)
+                                  .orElse(""),
+        userCouncilFee -> Optional.ofNullable(userCouncilFee.getGraduationType())
+                                  .map(GraduationType::getValue)
+                                  .orElse(""),
+        userCouncilFee -> Optional.ofNullable(userCouncilFee.getPhoneNumber()).orElse(""),
+        userCouncilFee -> Optional.ofNullable(userCouncilFee.getJoinedAt())
+                                  .map(String::valueOf)
+                                  .orElse(""),
+        userCouncilFee -> Optional.ofNullable(userCouncilFee.getPaidAt())
+                                  .map(String::valueOf)
+                                  .orElse(""),
+        userCouncilFee -> Optional.ofNullable(userCouncilFee.getNumOfPaidSemester())
+                                  .map(String::valueOf)
+                                  .orElse(""),
+        userCouncilFee -> Optional.ofNullable(userCouncilFee.getIsRefunded())
+                                  .map(isRefunded -> isRefunded ? "O" : "X")
+                                  .orElse(""),
+        userCouncilFee -> Optional.ofNullable(userCouncilFee.getIsRefunded())
+                                  .filter(isRefunded -> isRefunded)
+                                  .map(isRefunded -> Optional.ofNullable(userCouncilFee.getRefundedAt())
+                                      .map(String::valueOf)
+                                      .orElse(""))
+                                  .orElse(""),
+        userCouncilFee -> Optional.ofNullable(userCouncilFee.getRestOfSemester())
+                                  .map(String::valueOf)
+                                  .orElse(""),
+        userCouncilFee -> Optional.ofNullable(userCouncilFee.getIsAppliedThisSemester())
+                                  .map(isRefunded -> isRefunded ? "O" : "X")
+                                  .orElse("")
+    );
+
     @Override
     public void createDataRows(Sheet sheet, List<UserCouncilFeeResponseDto> dataList) {
         int rowNum = 1;
-        for (UserCouncilFeeResponseDto userCouncilFeeResponseDto : dataList) {
+        for (UserCouncilFeeResponseDto userCouncilFee : dataList) {
             Row row = sheet.createRow(rowNum++);
-            row.createCell(0).setCellValue(
-                    (userCouncilFeeResponseDto.getIsJoinedService() != null) ?
-                            (userCouncilFeeResponseDto.getIsJoinedService() ?
-                                    "O" :
-                                    "X") :
-                            ""
-            );
-            row.createCell(1).setCellValue(
-                    userCouncilFeeResponseDto.getEmail() != null ? userCouncilFeeResponseDto.getEmail() : ""
-            );
-            row.createCell(2).setCellValue(
-                    userCouncilFeeResponseDto.getUserName() != null ? userCouncilFeeResponseDto.getUserName() : ""
-            );
-            row.createCell(3).setCellValue(
-                    userCouncilFeeResponseDto.getStudentId() != null ? userCouncilFeeResponseDto.getStudentId() : ""
-            );
-            row.createCell(4).setCellValue(
-                    userCouncilFeeResponseDto.getAdmissionYear() != null ? userCouncilFeeResponseDto.getAdmissionYear().toString() : ""
-            );
-            row.createCell(5).setCellValue(
-                    userCouncilFeeResponseDto.getNickname() != null ? userCouncilFeeResponseDto.getNickname() : ""
-            );
-            row.createCell(6).setCellValue(
-                    userCouncilFeeResponseDto.getMajor() != null ? userCouncilFeeResponseDto.getMajor() : ""
-            );
-            row.createCell(7).setCellValue(
-                    userCouncilFeeResponseDto.getAcademicStatus() != null ? userCouncilFeeResponseDto.getAcademicStatus().getValue() : ""
-            );
-            row.createCell(8).setCellValue(
-                    userCouncilFeeResponseDto.getCurrentCompletedSemester() != null ? userCouncilFeeResponseDto.getCurrentCompletedSemester().toString() : ""
-            );
-            row.createCell(9).setCellValue(
-                    userCouncilFeeResponseDto.getGraduationYear() != null ? userCouncilFeeResponseDto.getGraduationYear().toString() : ""
-            );
-            row.createCell(10).setCellValue(
-                    userCouncilFeeResponseDto.getGraduationType() != null ? userCouncilFeeResponseDto.getGraduationType().getValue() : ""
-            );
-            row.createCell(11).setCellValue(
-                    userCouncilFeeResponseDto.getPhoneNumber() != null ? userCouncilFeeResponseDto.getPhoneNumber() : ""
-            );
-            row.createCell(12).setCellValue(
-                    userCouncilFeeResponseDto.getJoinedAt() != null ? userCouncilFeeResponseDto.getJoinedAt().toString() : ""
-            );
-            row.createCell(13).setCellValue(
-                    userCouncilFeeResponseDto.getPaidAt() != null ? userCouncilFeeResponseDto.getPaidAt().toString() : ""
-            );
-            row.createCell(14).setCellValue(
-                    userCouncilFeeResponseDto.getNumOfPaidSemester() != null ? userCouncilFeeResponseDto.getNumOfPaidSemester().toString() : ""
-            );
-            row.createCell(15).setCellValue(
-                    (userCouncilFeeResponseDto.getIsRefunded() != null) ?
-                            (userCouncilFeeResponseDto.getIsRefunded() ?
-                                    "O" :
-                                    "X") :
-                            ""
-            );
-            row.createCell(16).setCellValue(
-                    (userCouncilFeeResponseDto.getRefundedAt() != null) ?
-                        (userCouncilFeeResponseDto.getIsRefunded() ?
-                                    userCouncilFeeResponseDto.getRefundedAt().toString() :
-                                    "") :
-                            ""
-            );
-            row.createCell(17).setCellValue(
-                    userCouncilFeeResponseDto.getRestOfSemester() != null ? userCouncilFeeResponseDto.getRestOfSemester().toString() : ""
-            );
-            row.createCell(18).setCellValue(
-                    (userCouncilFeeResponseDto.getIsAppliedThisSemester() != null) ?
-                            (userCouncilFeeResponseDto.getIsAppliedThisSemester() ?
-                                    "O" :
-                                    "X") :
-                            ""
-            );
+
+            int colNum = 0;
+            for (Function<UserCouncilFeeResponseDto, String> func : cellMappingFunctions) {
+                Cell cell = row.createCell(colNum++);
+                cell.setCellValue(func.apply(userCouncilFee));
+            }
         }
     }
 

--- a/src/main/java/net/causw/application/excel/UserExcelService.java
+++ b/src/main/java/net/causw/application/excel/UserExcelService.java
@@ -20,46 +20,47 @@ import java.util.List;
 @Service
 public class UserExcelService extends ExcelAbstractService<UserResponseDto> {
 
-    private static final List<Function<UserResponseDto, String>> cellMappingFunctions = List.of(
-        user -> Optional.ofNullable(user.getEmail()).orElse(""),
-        user -> Optional.ofNullable(user.getName()).orElse(""),
-        user -> Optional.ofNullable(user.getStudentId()).orElse(""),
-        user -> Optional.ofNullable(user.getAdmissionYear())
-                        .map(String::valueOf)
-                        .orElse(""),
-        user -> Optional.ofNullable(user.getRoles())
-                        .map(roles -> roles.stream()
+    private static final Function<UserResponseDto, List<String>> cellMappingFunction =
+        user -> List.of(
+            Optional.ofNullable(user.getEmail()).orElse(""),
+            Optional.ofNullable(user.getName()).orElse(""),
+            Optional.ofNullable(user.getStudentId()).orElse(""),
+            Optional.ofNullable(user.getAdmissionYear())
+                    .map(String::valueOf)
+                    .orElse(""),
+            Optional.ofNullable(user.getRoles())
+                    .map(roles -> roles.stream()
                             .map(Role::getDescription)
                             .collect(Collectors.joining(",")))
-                        .orElse(""),
-        user -> Optional.ofNullable(user.getState())
-                        .map(UserState::getDescription)
-                        .orElse(""),
-        user -> Optional.ofNullable(user.getNickname()).orElse(""),
-        user -> Optional.ofNullable(user.getMajor()).orElse(""),
-        user -> Optional.ofNullable(user.getAcademicStatus())
-                        .map(AcademicStatus::getValue)
-                        .orElse(""),
-        user -> Optional.ofNullable(user.getCurrentCompletedSemester())
-                        .map(String::valueOf)
-                        .orElse(""),
-        user -> Optional.ofNullable(user.getGraduationYear())
-                        .map(String::valueOf)
-                        .orElse(""),
-        user -> Optional.ofNullable(user.getGraduationType())
-                        .map(GraduationType::getValue)
-                        .orElse(""),
-        user -> Optional.ofNullable(user.getPhoneNumber()).orElse(""),
-        user -> Optional.ofNullable(user.getCircleNameIfLeader())
-                        .map(circles -> String.join(",", circles))
-                        .orElse(""),
-        user -> Optional.ofNullable(user.getRejectionOrDropReason()).orElse(""),
-        user -> Optional.ofNullable(user.getCreatedAt())
-                        .map(String::valueOf)
-                        .orElse(""),
-        user -> Optional.ofNullable(user.getUpdatedAt())
-                        .map(String::valueOf)
-                        .orElse("")
+                    .orElse(""),
+            Optional.ofNullable(user.getState())
+                    .map(UserState::getDescription)
+                    .orElse(""),
+            Optional.ofNullable(user.getNickname()).orElse(""),
+            Optional.ofNullable(user.getMajor()).orElse(""),
+            Optional.ofNullable(user.getAcademicStatus())
+                    .map(AcademicStatus::getValue)
+                    .orElse(""),
+            Optional.ofNullable(user.getCurrentCompletedSemester())
+                    .map(String::valueOf)
+                    .orElse(""),
+            Optional.ofNullable(user.getGraduationYear())
+                    .map(String::valueOf)
+                    .orElse(""),
+            Optional.ofNullable(user.getGraduationType())
+                    .map(GraduationType::getValue)
+                    .orElse(""),
+            Optional.ofNullable(user.getPhoneNumber()).orElse(""),
+            Optional.ofNullable(user.getCircleNameIfLeader())
+                    .map(circles -> String.join(",", circles))
+                    .orElse(""),
+            Optional.ofNullable(user.getRejectionOrDropReason()).orElse(""),
+            Optional.ofNullable(user.getCreatedAt())
+                    .map(String::valueOf)
+                    .orElse(""),
+            Optional.ofNullable(user.getUpdatedAt())
+                    .map(String::valueOf)
+                    .orElse("")
     );
 
     @Override
@@ -69,9 +70,10 @@ public class UserExcelService extends ExcelAbstractService<UserResponseDto> {
             Row row = sheet.createRow(rowNum++);
 
             int colNum = 0;
-            for (Function<UserResponseDto, String> func : cellMappingFunctions) {
+            List<String> cellValues = cellMappingFunction.apply(user);
+            for (String value : cellValues) {
                 Cell cell = row.createCell(colNum++);
-                cell.setCellValue(func.apply(user));
+                cell.setCellValue(value);
             }
         }
     }

--- a/src/main/java/net/causw/application/userCouncilFee/UserCouncilFeeService.java
+++ b/src/main/java/net/causw/application/userCouncilFee/UserCouncilFeeService.java
@@ -70,20 +70,7 @@ public class UserCouncilFeeService {
         );
 
         List<UserCouncilFeeResponseDto> userCouncilFeeResponseDtoList = userCouncilFeeRepository.findAll()
-                        .stream().map(userCouncilFee -> (userCouncilFee.getIsJoinedService()) ?
-                                toUserCouncilFeeResponseDto(
-                                        userCouncilFee,
-                                        userCouncilFee.getUser(),
-                                        StatusUtil.getRestOfSemester(userCouncilFee),
-                                        StatusUtil.getIsAppliedCurrentSemester(userCouncilFee)
-                                ) :
-                                toUserCouncilFeeResponseDtoReduced(
-                                        userCouncilFee,
-                                        userCouncilFee.getCouncilFeeFakeUser(),
-                                        StatusUtil.getRestOfSemester(userCouncilFee),
-                                        StatusUtil.getIsAppliedCurrentSemester(userCouncilFee)
-                                )
-                        ).toList();
+                        .stream().map(this::toUserCouncilFeeResponseDto).toList();
 
         LinkedHashMap<String, List<UserCouncilFeeResponseDto>> sheetNameDataMap = new LinkedHashMap<>();
         sheetNameDataMap.put("학생회비 납부자 현황", userCouncilFeeResponseDtoList);
@@ -105,24 +92,10 @@ public class UserCouncilFeeService {
     }
 
     public UserCouncilFeeResponseDto getUserCouncilFeeInfo(String userCouncilFeeId) {
-        UserCouncilFee userCouncilFee = userCouncilFeeRepository.findById(userCouncilFeeId)
-                .orElseThrow(() -> new BadRequestException(ErrorCode.ROW_DOES_NOT_EXIST, MessageUtil.USER_COUNCIL_FEE_NOT_FOUND));
-
-        if (userCouncilFee.getIsJoinedService()) {
-            return toUserCouncilFeeResponseDto(
-                    userCouncilFee,
-                    userCouncilFee.getUser(),
-                    StatusUtil.getRestOfSemester(userCouncilFee),
-                    StatusUtil.getIsAppliedCurrentSemester(userCouncilFee)
-            );
-        } else {
-            return toUserCouncilFeeResponseDtoReduced(
-                    userCouncilFee,
-                    userCouncilFee.getCouncilFeeFakeUser(),
-                    StatusUtil.getRestOfSemester(userCouncilFee),
-                    StatusUtil.getIsAppliedCurrentSemester(userCouncilFee)
-            );
-        }
+        return userCouncilFeeRepository.findById(userCouncilFeeId)
+                .map(this::toUserCouncilFeeResponseDto)
+                .orElseThrow(() -> new BadRequestException(
+                    ErrorCode.ROW_DOES_NOT_EXIST, MessageUtil.USER_COUNCIL_FEE_NOT_FOUND));
     }
 
     @Transactional
@@ -395,12 +368,22 @@ public class UserCouncilFeeService {
         return UserCouncilFeeDtoMapper.INSTANCE.toUserCouncilFeeListResponseDtoReduced(userCouncilFee, councilFeeFakeUser);
     }
 
-    private UserCouncilFeeResponseDto toUserCouncilFeeResponseDto(UserCouncilFee userCouncilFee, User user, Integer restOfSemester, Boolean isAppliedThisSemester) {
-        return UserCouncilFeeDtoMapper.INSTANCE.toUserCouncilFeeResponseDto(userCouncilFee, user, restOfSemester, isAppliedThisSemester);
-    }
-
-    private UserCouncilFeeResponseDto toUserCouncilFeeResponseDtoReduced(UserCouncilFee userCouncilFee, CouncilFeeFakeUser councilFeeFakeUser, Integer restOfSemester, Boolean isAppliedThisSemester) {
-        return UserCouncilFeeDtoMapper.INSTANCE.toUserCouncilFeeResponseDtoReduced(userCouncilFee, councilFeeFakeUser, restOfSemester, isAppliedThisSemester);
+    private UserCouncilFeeResponseDto toUserCouncilFeeResponseDto(UserCouncilFee userCouncilFee) {
+        if (userCouncilFee.getIsJoinedService()) {
+            return UserCouncilFeeDtoMapper.INSTANCE.toUserCouncilFeeResponseDto(
+                userCouncilFee,
+                userCouncilFee.getUser(),
+                StatusUtil.getRestOfSemester(userCouncilFee),
+                StatusUtil.getIsAppliedCurrentSemester(userCouncilFee)
+            );
+        } else {
+            return UserCouncilFeeDtoMapper.INSTANCE.toUserCouncilFeeResponseDtoReduced(
+                userCouncilFee,
+                userCouncilFee.getCouncilFeeFakeUser(),
+                StatusUtil.getRestOfSemester(userCouncilFee),
+                StatusUtil.getIsAppliedCurrentSemester(userCouncilFee)
+            );
+        }
     }
 
     private CurrentUserCouncilFeeResponseDto toCurrentUserCouncilFeeResponseDto(UserCouncilFee userCouncilFee, Integer restOfSemester, Boolean isAppliedThisSemester) {

--- a/src/test/java/net/causw/application/excel/ExcelAbstractServiceTest.java
+++ b/src/test/java/net/causw/application/excel/ExcelAbstractServiceTest.java
@@ -37,19 +37,10 @@ public class ExcelAbstractServiceTest {
   static final String fileName = "fileName";
   static final String sheetName = "sheetName";
 
-  static final List<UserResponseDto> userList = List.of(
-      UserDtoMapper.INSTANCE.toUserResponseDto(mock(User.class)));
-  static final List<UserCouncilFeeResponseDto> userCouncilFeeList = List.of(
-      UserCouncilFeeDtoMapper.INSTANCE.toUserCouncilFeeResponseDto(
-          mock(UserCouncilFee.class),
-          mock(User.class),
-          4,
-          true));
-
   static Stream<Arguments> provideExcelServices(){
     return Stream.of(
-        Arguments.arguments(new UserExcelService(), userList),
-        Arguments.arguments(new CouncilFeeExcelService(), userCouncilFeeList));
+        Arguments.arguments(new UserExcelService(), List.of(mock(UserResponseDto.class))),
+        Arguments.arguments(new CouncilFeeExcelService(), List.of(mock(UserCouncilFeeResponseDto.class))));
   }
 
   @ParameterizedTest

--- a/src/test/java/net/causw/application/excel/ExcelAbstractServiceTest.java
+++ b/src/test/java/net/causw/application/excel/ExcelAbstractServiceTest.java
@@ -33,13 +33,13 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 public class ExcelAbstractServiceTest {
 
-  static final List<String> HEADER_STRING_LIST = List.of("아이디(이메일)", "이름", "학번");
-  static final String FILE_NAME = "fileName";
-  static final String SHEET_NAME = "sheetName";
+  static final List<String> headerStringList = List.of("아이디(이메일)", "이름", "학번");
+  static final String fileName = "fileName";
+  static final String sheetName = "sheetName";
 
-  static final List<UserResponseDto> USER_LIST = List.of(
+  static final List<UserResponseDto> userList = List.of(
       UserDtoMapper.INSTANCE.toUserResponseDto(mock(User.class)));
-  static final List<UserCouncilFeeResponseDto> USER_COUNCIL_FEE_LIST = List.of(
+  static final List<UserCouncilFeeResponseDto> userCouncilFeeList = List.of(
       UserCouncilFeeDtoMapper.INSTANCE.toUserCouncilFeeResponseDto(
           mock(UserCouncilFee.class),
           mock(User.class),
@@ -48,8 +48,8 @@ public class ExcelAbstractServiceTest {
 
   static Stream<Arguments> provideExcelServices(){
     return Stream.of(
-        Arguments.arguments(new UserExcelService(), USER_LIST),
-        Arguments.arguments(new CouncilFeeExcelService(), USER_COUNCIL_FEE_LIST));
+        Arguments.arguments(new UserExcelService(), userList),
+        Arguments.arguments(new CouncilFeeExcelService(), userCouncilFeeList));
   }
 
   @ParameterizedTest
@@ -60,10 +60,10 @@ public class ExcelAbstractServiceTest {
     // given
     MockHttpServletResponse response = new MockHttpServletResponse();
     LinkedHashMap<String, List<T>> sheetDataMap = new LinkedHashMap<>();
-    sheetDataMap.put(SHEET_NAME, dataList);
+    sheetDataMap.put(sheetName, dataList);
 
     // when
-    service.generateExcel(response, FILE_NAME, HEADER_STRING_LIST, sheetDataMap);
+    service.generateExcel(response, fileName, headerStringList, sheetDataMap);
 
     // then
     byte[] content = response.getContentAsByteArray();
@@ -93,11 +93,11 @@ public class ExcelAbstractServiceTest {
     List<String> headerStringList = List.of();
     MockHttpServletResponse response = new MockHttpServletResponse();
     LinkedHashMap<String, List<T>> sheetDataMap = new LinkedHashMap<>();
-    sheetDataMap.put(SHEET_NAME, dataList);
+    sheetDataMap.put(sheetName, dataList);
 
     // when & then
     assertThatThrownBy(() ->
-        service.generateExcel(response, FILE_NAME, headerStringList, sheetDataMap))
+        service.generateExcel(response, fileName, headerStringList, sheetDataMap))
         .as("헤더가 비어 있으면 예외가 발생해야 합니다.")
         .isInstanceOf(InternalServerException.class);
   }
@@ -110,11 +110,11 @@ public class ExcelAbstractServiceTest {
     List<String> headerStringList = null;
     MockHttpServletResponse response = new MockHttpServletResponse();
     LinkedHashMap<String, List<T>> sheetDataMap = new LinkedHashMap<>();
-    sheetDataMap.put(SHEET_NAME, dataList);
+    sheetDataMap.put(sheetName, dataList);
 
     // when & then
     assertThatThrownBy(() ->
-        service.generateExcel(response, FILE_NAME, headerStringList, sheetDataMap))
+        service.generateExcel(response, fileName, headerStringList, sheetDataMap))
         .as("헤더가 null이면 예외가 발생해야 합니다.")
         .isInstanceOf(InternalServerException.class);
   }
@@ -124,11 +124,11 @@ public class ExcelAbstractServiceTest {
   @DisplayName("Excel 시트 데이터 생성 성공 - 정상적인 데이터")
   void testCreateSheetSuccess(ExcelAbstractService<T> service, List<T> dataList) {
     // given
-    int expectedRowNum = dataList.size() + 1, expectedColNum = HEADER_STRING_LIST.size();
+    int expectedRowNum = dataList.size() + 1, expectedColNum = headerStringList.size();
     Workbook workbook = new XSSFWorkbook();
 
     // when
-    service.createSheet(workbook, SHEET_NAME, HEADER_STRING_LIST, dataList);
+    service.createSheet(workbook, sheetName, headerStringList, dataList);
 
     // then
     Sheet createdSheet = workbook.getSheetAt(0);
@@ -143,11 +143,11 @@ public class ExcelAbstractServiceTest {
   void testGenerateExcelWithEmptyUserListSuccess(ExcelAbstractService<T> service) {
     // given
     List<T> dataList = List.of();
-    int expectedRowNum = 1, expectedColNum = HEADER_STRING_LIST.size();
+    int expectedRowNum = 1, expectedColNum = headerStringList.size();
     Workbook workbook = new XSSFWorkbook();
 
     // when
-    service.createSheet(workbook, SHEET_NAME, HEADER_STRING_LIST, dataList);
+    service.createSheet(workbook, sheetName, headerStringList, dataList);
 
     // then
     Sheet createdSheet = workbook.getSheetAt(0);

--- a/src/test/java/net/causw/application/excel/ExcelAbstractServiceTest.java
+++ b/src/test/java/net/causw/application/excel/ExcelAbstractServiceTest.java
@@ -2,33 +2,28 @@ package net.causw.application.excel;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Stream;
-import net.causw.adapter.persistence.user.User;
-import net.causw.adapter.persistence.userCouncilFee.UserCouncilFee;
 import net.causw.application.dto.user.UserResponseDto;
 import net.causw.application.dto.userCouncilFee.UserCouncilFeeResponseDto;
-import net.causw.application.dto.util.dtoMapper.UserCouncilFeeDtoMapper;
-import net.causw.application.dto.util.dtoMapper.UserDtoMapper;
 import net.causw.domain.exceptions.InternalServerException;
 import org.apache.poi.ss.formula.functions.T;
+import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.InjectMocks;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 public class ExcelAbstractServiceTest {
@@ -49,6 +44,7 @@ public class ExcelAbstractServiceTest {
   void testGenerateExcelSuccess(
       ExcelAbstractService<T> service, List<T> dataList) throws IOException {
     // given
+    int expectedRowNum = dataList.size() + 1, expectedColNum = headerStringList.size();
     MockHttpServletResponse response = new MockHttpServletResponse();
     LinkedHashMap<String, List<T>> sheetDataMap = new LinkedHashMap<>();
     sheetDataMap.put(sheetName, dataList);
@@ -74,6 +70,10 @@ public class ExcelAbstractServiceTest {
     assertThat(createdSheet.getSheetName())
         .as("시트 이름이 sheetDataMap에 포함되어야 합니다.")
         .isIn(sheetDataMap.keySet());
+
+    verifySheet(createdSheet, expectedRowNum);
+    verifyHeaderRow(createdSheet.getRow(0), expectedColNum);
+    verifyDataRow(createdSheet.getRow(1));
   }
 
   @ParameterizedTest
@@ -124,8 +124,9 @@ public class ExcelAbstractServiceTest {
     // then
     Sheet createdSheet = workbook.getSheetAt(0);
 
-    verifyRow(createdSheet,expectedRowNum);
-    verifyCell(createdSheet, expectedColNum);
+    verifySheet(createdSheet, expectedRowNum);
+    verifyHeaderRow(createdSheet.getRow(0), expectedColNum);
+    verifyDataRow(createdSheet.getRow(1));
   }
 
   @ParameterizedTest
@@ -143,24 +144,56 @@ public class ExcelAbstractServiceTest {
     // then
     Sheet createdSheet = workbook.getSheetAt(0);
 
-    verifyRow(createdSheet,expectedRowNum);
-    verifyCell(createdSheet, expectedColNum);
+    verifySheet(createdSheet, expectedRowNum);
+    verifyHeaderRow(createdSheet.getRow(0), expectedColNum);
   }
 
-  private void verifyRow(Sheet sheet, int expectedRowNum) {
+  private void verifySheet(Sheet sheet, int expectedRowNum) {
+    assertThat(sheet).isNotNull();
     assertThat(sheet.getPhysicalNumberOfRows())
-        .as("헤더를 포함한 행의 개수는 %s이어야 합니다.", expectedRowNum)
+        .as("헤더를 포함한 행의 개수가 예측값과 같아야 합니다.")
         .isEqualTo(expectedRowNum);
+
+    sheet.iterator().forEachRemaining(
+        row -> assertThat(row)
+              .as("모든 행은 null이 아니어야 합니다.")
+              .isNotNull()
+    );
   }
 
-  private void verifyCell(Sheet sheet, int expectedColNum) {
-    Row header = sheet.getRow(0);
-
-    assertThat(header.getPhysicalNumberOfCells())
-        .as("열의 개수는 headerStringList의 크기와 같아야 합니다.")
+  private void verifyHeaderRow(Row row, int expectedColNum) {
+    assertThat(row).isNotNull();
+    assertThat(row.getPhysicalNumberOfCells())
+        .as("셀의 개수가 예측값과 같아야 합니다.")
         .isEqualTo(expectedColNum);
-    assertThat(sheet)
-        .as("모든 셀은 null이 아니어야 합니다.")
-        .usingRecursiveAssertion().isNotNull();
+
+    row.iterator().forEachRemaining(
+        cell -> {
+          assertThat(cell)
+              .as("모든 셀은 null이 아니어야 합니다.")
+              .isNotNull();
+          assertThat(cell.getCellType())
+              .as("모든 셀은 STRING 타입이어야 합니다.")
+              .isNotNull().isEqualTo(CellType.STRING);
+          assertThat(cell.getStringCellValue())
+              .as("실제 엑셀의 헤더와 headerStringList의 내용이 일치해야 합니다.")
+              .isNotNull().isEqualTo(headerStringList.get(cell.getColumnIndex()));
+        }
+    );
+  }
+
+  private void verifyDataRow(Row row) {
+    assertThat(row).isNotNull();
+
+    row.iterator().forEachRemaining(
+        cell -> {
+          assertThat(cell)
+              .as("모든 셀은 null이 아니어야 합니다.")
+              .isNotNull();
+          assertThat(cell.getCellType())
+              .as("모든 셀은 STRING 타입이어야 합니다.")
+              .isNotNull().isEqualTo(CellType.STRING);
+        }
+    );
   }
 }

--- a/src/test/java/net/causw/application/user/UserServiceTest.java
+++ b/src/test/java/net/causw/application/user/UserServiceTest.java
@@ -11,6 +11,7 @@ import net.causw.application.dto.user.UserResponseDto;
 import net.causw.application.excel.UserExcelService;
 import net.causw.domain.model.enums.user.UserState;
 
+import net.causw.domain.model.util.ObjectFixtures;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -45,14 +46,9 @@ class UserServiceTest {
   @Mock
   UserAdmissionRepository userAdmissionRepository;
 
+  @Mock
   HttpServletResponse response;
-  User user;
 
-  @BeforeEach
-  void setUp() {
-    response = mock(HttpServletResponse.class);
-    user = mock(User.class);
-  }
 
   @Nested
   class ExportUserListToExcelTest {
@@ -63,12 +59,10 @@ class UserServiceTest {
       //given
       UserState state = UserState.AWAIT;
       String sheetName = state.getDescription() + " 유저";
-      UserAdmission userAdmission = mock(UserAdmission.class);
-      List<UserAdmission> userAdmissionList = List.of(userAdmission);
+      UserAdmission userAdmission = ObjectFixtures.getUserAdmission();
+      userAdmission.getUser().setState(state);
 
-      given(user.getState()).willReturn(state);
-      given(userAdmission.getUser()).willReturn(user);
-      given(userAdmissionRepository.findAll()).willReturn(userAdmissionList);
+      given(userAdmissionRepository.findAll()).willReturn(List.of(userAdmission));
 
       //when
       userService.exportUserListToExcel(response);
@@ -86,10 +80,10 @@ class UserServiceTest {
       //given
       UserState state = UserState.ACTIVE;
       String sheetName = state.getDescription() + " 유저";
-      List<User> userList = List.of(user);
+      User user = ObjectFixtures.getUser();
+      user.setState(state);
 
-      given(user.getState()).willReturn(state);
-      given(userRepository.findAllByState(state)).willReturn(userList);
+      given(userRepository.findAllByState(state)).willReturn(List.of(user));
 
       //when
       userService.exportUserListToExcel(response);

--- a/src/test/java/net/causw/application/userCouncilFee/UserCouncilFeeServiceTest.java
+++ b/src/test/java/net/causw/application/userCouncilFee/UserCouncilFeeServiceTest.java
@@ -1,0 +1,125 @@
+package net.causw.application.userCouncilFee;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.LinkedHashMap;
+import java.util.List;
+import net.causw.adapter.persistence.repository.userCouncilFee.UserCouncilFeeRepository;
+import net.causw.adapter.persistence.semester.Semester;
+import net.causw.adapter.persistence.userCouncilFee.UserCouncilFee;
+import net.causw.application.dto.userCouncilFee.UserCouncilFeeResponseDto;
+import net.causw.application.excel.CouncilFeeExcelService;
+import net.causw.application.semester.SemesterService;
+import net.causw.domain.model.util.ObjectFixtures;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class UserCouncilFeeServiceTest {
+
+  @InjectMocks
+  UserCouncilFeeService userCouncilFeeService;
+
+  @Mock
+  UserCouncilFeeRepository userCouncilFeeRepository;
+
+  @Mock
+  CouncilFeeExcelService councilFeeExcelService;
+
+  @Mock
+  SemesterService semesterService;
+
+  @Mock
+  HttpServletResponse response;
+
+  static final String sheetName = "학생회비 납부자 현황";
+  static final Semester semester = ObjectFixtures.getSemester();
+
+  @BeforeEach
+  public void setUp() {
+    given(semesterService.getCurrentSemesterEntity()).willReturn(semester);
+  }
+
+  @Nested
+  class ExportUserCouncilFeeToExcelTest{
+
+    @DisplayName("Excel로 데이터 내보내기 성공 - 가입 학생회비 납부자 목록")
+    @Test
+    void testExportJoinedUserCouncilFeeToExcelTest(){
+      //given
+      UserCouncilFee userCouncilFee = ObjectFixtures.getUserCouncilFee(true);
+      given(userCouncilFeeRepository.findAll()).willReturn(List.of(userCouncilFee));
+
+      //when
+      userCouncilFeeService.exportUserCouncilFeeToExcel(response);
+
+      //then
+      LinkedHashMap<String, List<UserCouncilFeeResponseDto>> exportedUserCouncilFeeDataMap
+          = captureGeneratedExcelData();
+      List<UserCouncilFeeResponseDto> exportedUserCouncilFeeList
+          = exportedUserCouncilFeeDataMap.get(sheetName);
+
+      verifyUserCouncilFeeResponseDto(
+          exportedUserCouncilFeeList, userCouncilFee.getUser().getStudentId());
+    }
+
+    @DisplayName("Excel로 데이터 내보내기 성공 - 미가입 학생회비 납부자 목록")
+    @Test
+    void testExportNotJoinedUserCouncilFeeToExcelTest(){
+      //given
+      UserCouncilFee userCouncilFee = ObjectFixtures.getUserCouncilFee(false);
+      given(userCouncilFeeRepository.findAll()).willReturn(List.of(userCouncilFee));
+
+      //when
+      userCouncilFeeService.exportUserCouncilFeeToExcel(response);
+
+      //then
+      LinkedHashMap<String, List<UserCouncilFeeResponseDto>> exportedUserCouncilFeeDataMap
+          = captureGeneratedExcelData();
+      List<UserCouncilFeeResponseDto> exportedUserCouncilFeeList
+          = exportedUserCouncilFeeDataMap.get(sheetName);
+
+      verifyUserCouncilFeeResponseDto(
+          exportedUserCouncilFeeList, userCouncilFee.getCouncilFeeFakeUser().getStudentId());
+    }
+
+    private LinkedHashMap<String, List<UserCouncilFeeResponseDto>> captureGeneratedExcelData() {
+      ArgumentCaptor<LinkedHashMap<String, List<UserCouncilFeeResponseDto>>> captor =
+          ArgumentCaptor.forClass(LinkedHashMap.class);
+      verify(councilFeeExcelService, times(1))
+          .generateExcel(eq(response), anyString(), anyList(), captor.capture());
+
+      return captor.getValue();
+    }
+
+    private void verifyUserCouncilFeeResponseDto(
+        List<UserCouncilFeeResponseDto> exportedUserCouncilFeeList,
+        String studentId
+    ) {
+      for (UserCouncilFeeResponseDto actual : exportedUserCouncilFeeList) {
+        assertThat(actual).isNotNull();
+        assertThat(actual.getStudentId())
+            .as("실제 UserCouncilFeeResponseDto의 studentId가 존재해야 합니다.")
+            .isNotNull();
+        assertThat(actual.getStudentId())
+            .as("실제 studentId와 입력한 studentId가 일치해야 합니다.")
+            .isEqualTo(studentId);
+      }
+    }
+  }
+}

--- a/src/test/java/net/causw/domain/model/util/ObjectFixtures.java
+++ b/src/test/java/net/causw/domain/model/util/ObjectFixtures.java
@@ -1,0 +1,86 @@
+package net.causw.domain.model.util;
+
+import java.util.List;
+import net.causw.adapter.persistence.semester.Semester;
+import net.causw.adapter.persistence.user.User;
+import net.causw.adapter.persistence.user.UserAdmission;
+import net.causw.adapter.persistence.userCouncilFee.CouncilFeeFakeUser;
+import net.causw.adapter.persistence.userCouncilFee.UserCouncilFee;
+import net.causw.application.dto.user.UserCreateRequestDto;
+import net.causw.domain.model.enums.semester.SemesterType;
+import net.causw.domain.model.enums.user.GraduationType;
+import net.causw.domain.model.enums.userAcademicRecord.AcademicStatus;
+
+public class ObjectFixtures {
+
+  public static User getUser() {
+    UserCreateRequestDto userCreateRequestDto = new UserCreateRequestDto(
+        "email@cau.ac.kr",
+        "name",
+        "password",
+        "20002000",
+        2000,
+        "nickName",
+        "major",
+        "010-2000-2000"
+    );
+
+    User user = User.from(userCreateRequestDto, "password");
+    user.setCurrentCompletedSemester(4);
+    return user;
+  }
+
+  public static CouncilFeeFakeUser getCouncilFeeFakeUser() {
+    return CouncilFeeFakeUser.of(
+        "name",
+        "20012001",
+        "010-2001-2001",
+        2001,
+        "major",
+        AcademicStatus.UNDETERMINED,
+        4,
+        2004,
+        GraduationType.FEBRUARY
+    );
+  }
+
+  public static UserCouncilFee getUserCouncilFee(boolean isJoinedService) {
+    if (isJoinedService) {
+      return UserCouncilFee.of(
+          true,
+          getUser(),
+          null,
+          1,
+          8,
+          false,
+          0
+      );
+    } else {
+      return UserCouncilFee.of(
+          false,
+          null,
+          getCouncilFeeFakeUser(),
+          1,
+          8,
+          false,
+          0
+      );
+    }
+  }
+
+  public static UserAdmission getUserAdmission() {
+    return UserAdmission.of(
+        getUser(),
+        List.of(),
+        "description"
+    );
+  }
+
+  public static Semester getSemester() {
+    return Semester.of(
+        2000,
+        SemesterType.FIRST,
+        getUser()
+    );
+  }
+}


### PR DESCRIPTION
### 🚩 관련사항


### 📢 전달사항
주요 변경 사항은 다음과 같습니다.

1. 학생회비 납부자 엑셀 내용 수정
- 학적 상태 영어에서 한글로 변경
- 졸업 유형 영어에서 한글로 변경
- 학생회비 환불되지 않은 경우 환불 시점 0에서 ""으로 수정


2. 엑셀 서비스 구현 클래스의 테스트를 파라미터화 테스트로 변경
- 엑셀 서비스 구현 클래스들(UserExcelService, CouncilFeeExcelService)의 테스트 케이스가 동일함
- 유지보수 용이성을 위해 기존의 UserExcelServiceTest를 삭제하고 ExcelAbstractServiceTest에서 모든 엑셀 서비스 구현 클래스들을 파라미터화 테스트로 한 번에 테스트 할 수 있도록 변경


3. 테스트에 ObjectFixtures 적용 및 일부 변수 불변으로 변경
- ObjectFixtures 클래스를 추가하여 객체의 필드 값이 테스트 내에서 중요한 경우 실제 객체를 사용하여 테스트 (객체의 필드 값이 테스트 내에서 중요하지 않은 경우 모킹)
- 테스트 내에서 변경되지 않는 전역 변수들 static final로 변경 (BeforeEach에서 제거)


### 📸 스크린샷
유닛 테스트
- ExcelAbstractServiceTest
![Screenshot from 2025-04-05 17-37-31](https://github.com/user-attachments/assets/f3c58279-a386-46fd-b6d0-599d9c910592)

- UserCouncilFeeServiceTest
![Screenshot from 2025-04-05 17-38-03](https://github.com/user-attachments/assets/57b35349-d334-4dfb-b111-5e52b8ae2938)


API 테스트
![Screenshot from 2025-04-05 17-45-11](https://github.com/user-attachments/assets/89a6fc8a-c1ec-4765-bd55-25794307a5c9)


API 테스트 결과 파일
![Screenshot from 2025-04-05 17-49-55](https://github.com/user-attachments/assets/463698bc-1237-447f-b40a-b60bf2861815)


### 📃 진행사항


### ⚙️ 기타사항


개발기간: 