### PR TITLE
Feat/post/815

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/repository/post/LikePostRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/post/LikePostRepository.java
@@ -4,7 +4,10 @@ import net.causw.adapter.persistence.post.LikePost;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikePostRepository extends JpaRepository<LikePost, String> {
+
     Boolean existsByPostIdAndUserId(String postId, String userId);
+
+    void deleteLikeByPostIdAndUserId(String postId, String userId);
 
     Long countByPostId(String postId);
 }

--- a/src/main/java/net/causw/adapter/persistence/repository/post/LikePostRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/post/LikePostRepository.java
@@ -1,7 +1,11 @@
 package net.causw.adapter.persistence.repository.post;
 
 import net.causw.adapter.persistence.post.LikePost;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LikePostRepository extends JpaRepository<LikePost, String> {
 
@@ -10,4 +14,11 @@ public interface LikePostRepository extends JpaRepository<LikePost, String> {
     void deleteLikeByPostIdAndUserId(String postId, String userId);
 
     Long countByPostId(String postId);
+
+    @Query("SELECT lp " +
+        "FROM LikePost lp " +
+        "JOIN lp.post p " +
+        "WHERE lp.user.id = :userId " +
+        "ORDER BY p.createdAt DESC")
+    Page<LikePost> findByUserId(@Param("userId") String userId, Pageable pageable);
 }

--- a/src/main/java/net/causw/adapter/web/PostController.java
+++ b/src/main/java/net/causw/adapter/web/PostController.java
@@ -362,6 +362,29 @@ public class PostController {
         this.postService.likePost(userDetails.getUser(), id);
     }
 
+    @DeleteMapping(value ="/{id}/like" )
+    @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified()")
+    @Operation(summary = "게시글 좋아요 취소 API(완료)",
+        description = "특정 유저가 특정 게시글에 좋아요를 누른 걸 취소하는 Api 입니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "Created", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
+        @ApiResponse(responseCode = "4000", description = "로그인된 사용자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+        @ApiResponse(responseCode = "4000", description = "게시글을 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+        @ApiResponse(responseCode = "4000", description = "좋아요를 누르지 않은 게시글입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+        @ApiResponse(responseCode = "4102", description = "추방된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+        @ApiResponse(responseCode = "4103", description = "비활성화된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+        @ApiResponse(responseCode = "4104", description = "대기 중인 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+        @ApiResponse(responseCode = "4109", description = "가입이 거절된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+        @ApiResponse(responseCode = "4012", description = "접근 권한이 없습니다. 다시 로그인 해주세요. 문제 반복시 관리자에게 문의해주세요.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+    })
+    public void cancelLikePost(
+        @PathVariable("id") String id,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ){
+        this.postService.cancelLikePost(userDetails.getUser(), id);
+    }
+
     @PostMapping(value ="/{id}/favorite" )
     @ResponseStatus(value = HttpStatus.CREATED)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified()")

--- a/src/main/java/net/causw/adapter/web/UserController.java
+++ b/src/main/java/net/causw/adapter/web/UserController.java
@@ -135,6 +135,27 @@ public class UserController {
         return this.userService.findFavoritePosts(userDetails.getUser(), pageNum);
     }
 
+    @GetMapping(value = "/posts/like")
+    @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified()")
+    @Operation(summary = "로그인한 사용자가 좋아요 누른 게시글 기록 조회 API(완료)",
+        description = "로그인한 사용자가 좋아요 누른 게시글의 목록을 조회하는 Api 입니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserPostsResponseDto.class))),
+        @ApiResponse(responseCode = "4000", description = "로그인된 사용자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+        @ApiResponse(responseCode = "4102", description = "추방된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+        @ApiResponse(responseCode = "4103", description = "비활성화된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+        @ApiResponse(responseCode = "4104", description = "대기 중인 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+        @ApiResponse(responseCode = "4109", description = "가입이 거절된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+        @ApiResponse(responseCode = "4012", description = "접근 권한이 없습니다. 다시 로그인 해주세요. 문제 반복시 관리자에게 문의해주세요.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+    })
+    public UserPostsResponseDto findMyLikePosts(
+        @RequestParam(name = "pageNum", defaultValue = "0") Integer pageNum,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return this.userService.findLikePosts(userDetails.getUser(), pageNum);
+    }
+
     @GetMapping(value = "/comments/written")
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("@securityService.isActiveAndNotNoneUserAndAcademicRecordCertified()")

--- a/src/main/java/net/causw/application/user/UserService.java
+++ b/src/main/java/net/causw/application/user/UserService.java
@@ -120,6 +120,9 @@ public class UserService {
     private final UserAcademicRecordApplicationRepository userAcademicRecordApplicationRepository;
     private final UserAcademicRecordApplicationAttachImageRepository userAcademicRecordApplicationAttachImageRepository;
 
+    private final UserDtoMapper userDtoMapper;
+    private final PostDtoMapper postDtoMapper;
+
     @Transactional
     public void findPassword(
             UserFindPasswordRequestDto userFindPasswordRequestDto
@@ -274,10 +277,10 @@ public class UserService {
             .consistOf(UserStateValidator.of(requestUser.getState()))
             .validate();
 
-        return UserDtoMapper.INSTANCE.toUserPostsResponseDto(
+        return userDtoMapper.toUserPostsResponseDto(
             requestUser,
             this.likePostRepository.findByUserId(requestUser.getId(), this.pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE))
-                .map(likePost -> PostDtoMapper.INSTANCE.toPostsResponseDto(
+                .map(likePost -> postDtoMapper.toPostsResponseDto(
                     likePost.getPost(),
                     getNumOfComment(likePost.getPost()),
                     getNumOfPostLikes(likePost.getPost()),

--- a/src/main/java/net/causw/domain/model/util/MessageUtil.java
+++ b/src/main/java/net/causw/domain/model/util/MessageUtil.java
@@ -61,6 +61,7 @@ public class MessageUtil {
 
     // Like & favorite
     public static final String POST_ALREADY_LIKED = "좋아요를 이미 누른 게시글 입니다.";
+    public static final String POST_NOT_LIKED = "좋아요을 누르지 않은 게시글입니다.";
     public static final String POST_ALREADY_FAVORITED = "즐겨찾기를 이미 누른 게시글 입니다.";
     public static final String COMMENT_ALREADY_LIKED = "좋아요를 이미 누른 댓글입니다.";
     public static final String CHILD_COMMENT_ALREADY_LIKED = "좋아요를 이미 누른 대댓글입니다.";

--- a/src/test/java/net/causw/application/post/PostServiceTest.java
+++ b/src/test/java/net/causw/application/post/PostServiceTest.java
@@ -58,15 +58,15 @@ public class PostServiceTest {
 
     @DisplayName("좋아요 성공 테스트")
     @Test
-    void likePostSuccess() {
+    void likePost_shouldSucceed_whenPostIsNotLiked() {
       // given
       String postId = "dummy123";
 
       UserState userStateNotDeleted = UserState.ACTIVE;
-      given(post.getWriter()).willReturn(user);
-      given(user.getState()).willReturn(userStateNotDeleted);
+      given(post.getWriter()).willReturn(writer);
+      given(writer.getState()).willReturn(userStateNotDeleted);
 
-      when(postRepository.findById(postId)).thenReturn(Optional.ofNullable(post));
+      when(postRepository.findById(postId)).thenReturn(Optional.of(post));
       when(likePostRepository.existsByPostIdAndUserId(postId, user.getId())).thenReturn(false);
 
       // When
@@ -76,17 +76,17 @@ public class PostServiceTest {
       verify(likePostRepository, times(1)).save(any(LikePost.class));
     }
 
-    @DisplayName("유저 삭제 상태일시 좋아요 실패")
+    @DisplayName("게시물 작성 유저 삭제 상태일시 좋아요 실패")
     @Test
-    void likePostFailure_WhenUserDeleted() {
+    void likePost_shouldFail_whenWriterIsDeleted() {
       // given
       String postId = "dummy123";
 
       UserState userStateDeleted = UserState.DELETED;
-      given(post.getWriter()).willReturn(user);
-      given(user.getState()).willReturn(userStateDeleted);
+      given(post.getWriter()).willReturn(writer);
+      given(writer.getState()).willReturn(userStateDeleted);
 
-      when(postRepository.findById(postId)).thenReturn(Optional.ofNullable(post));
+      when(postRepository.findById(postId)).thenReturn(Optional.of(post));
 
       // When & Then
       assertThatThrownBy(() -> postService.likePost(user, postId))
@@ -99,15 +99,15 @@ public class PostServiceTest {
 
     @DisplayName("좋아요 이미 한 게시물에 대해서 좋아요 실패")
     @Test
-    void likePostFailure_WhenPostAlreadyLiked() {
+    void likePost_shouldFail_whenAlreadyLiked() {
       // given
       String postId = "dummy123";
 
       UserState userStateNotDeleted = UserState.ACTIVE;
-      given(post.getWriter()).willReturn(user);
-      given(user.getState()).willReturn(userStateNotDeleted);
+      given(post.getWriter()).willReturn(writer);
+      given(writer.getState()).willReturn(userStateNotDeleted);
 
-      when(postRepository.findById(postId)).thenReturn(Optional.ofNullable(post));
+      when(postRepository.findById(postId)).thenReturn(Optional.of(post));
       when(likePostRepository.existsByPostIdAndUserId(postId, user.getId())).thenReturn(true);
 
       // When & Then
@@ -138,17 +138,17 @@ public class PostServiceTest {
 
     @DisplayName("좋아요 취소 성공 테스트")
     @Test
-    void likePostSuccess() {
+    void cancelLikePost_shouldSucceed_whenPostIsLiked() {
       // given
       String postId = "dummy123";
       String userId = "dummy1234";
 
       UserState userStateNotDeleted = UserState.ACTIVE;
-      given(post.getWriter()).willReturn(user);
-      given(user.getState()).willReturn(userStateNotDeleted);
+      given(post.getWriter()).willReturn(writer);
+      given(writer.getState()).willReturn(userStateNotDeleted);
       given(user.getId()).willReturn(userId);
 
-      when(postRepository.findById(postId)).thenReturn(Optional.ofNullable(post));
+      when(postRepository.findById(postId)).thenReturn(Optional.of(post));
       when(likePostRepository.existsByPostIdAndUserId(postId, user.getId())).thenReturn(true);
 
       // When
@@ -158,17 +158,17 @@ public class PostServiceTest {
       verify(likePostRepository, times(1)).deleteLikeByPostIdAndUserId(postId, user.getId());
     }
 
-    @DisplayName("유저 삭제 상태일시 좋아요 취소 실패")
+    @DisplayName("게시물 작성 유저 삭제 상태일시 좋아요 취소 실패")
     @Test
-    void likePostFailure_WhenUserDeleted() {
+    void cancelLikePost_shouldFail_whenWriterIsDeleted() {
       // given
       String postId = "dummy123";
 
       UserState userStateDeleted = UserState.DELETED;
-      given(post.getWriter()).willReturn(user);
-      given(user.getState()).willReturn(userStateDeleted);
+      given(post.getWriter()).willReturn(writer);
+      given(writer.getState()).willReturn(userStateDeleted);
 
-      when(postRepository.findById(postId)).thenReturn(Optional.ofNullable(post));
+      when(postRepository.findById(postId)).thenReturn(Optional.of(post));
 
       // When & Then
       assertThatThrownBy(() -> postService.cancelLikePost(user, postId))
@@ -176,20 +176,20 @@ public class PostServiceTest {
           .extracting("errorCode")
           .isEqualTo(ErrorCode.DELETED_USER);
 
-      verify(likePostRepository, times(0)).save(any(LikePost.class));
+      verify(likePostRepository, times(0)).deleteLikeByPostIdAndUserId(postId, user.getId());
     }
 
     @DisplayName("좋아요 하지 않은 게시물에 대해서 좋아요 취소 실패")
     @Test
-    void likePostFailure_WhenPostWasNotLiked() {
+    void cancelLikePost_shouldFail_whenPostIsNotLiked() {
       // given
       String postId = "dummy123";
 
       UserState userStateNotDeleted = UserState.ACTIVE;
-      given(post.getWriter()).willReturn(user);
-      given(user.getState()).willReturn(userStateNotDeleted);
+      given(post.getWriter()).willReturn(writer);
+      given(writer.getState()).willReturn(userStateNotDeleted);
 
-      when(postRepository.findById(postId)).thenReturn(Optional.ofNullable(post));
+      when(postRepository.findById(postId)).thenReturn(Optional.of(post));
       when(likePostRepository.existsByPostIdAndUserId(postId, user.getId())).thenReturn(false);
 
       // When & Then
@@ -199,7 +199,7 @@ public class PostServiceTest {
           .extracting("errorCode")
           .isEqualTo(ErrorCode.ROW_DOES_NOT_EXIST);
 
-      verify(likePostRepository, times(0)).save(any(LikePost.class));
+      verify(likePostRepository, times(0)).deleteLikeByPostIdAndUserId(postId, user.getId());
     }
   }
 

--- a/src/test/java/net/causw/application/user/UserServiceTest.java
+++ b/src/test/java/net/causw/application/user/UserServiceTest.java
@@ -3,14 +3,27 @@ package net.causw.application.user;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Set;
+import net.causw.adapter.persistence.post.LikePost;
+import net.causw.adapter.persistence.post.Post;
+import net.causw.adapter.persistence.repository.post.FavoritePostRepository;
+import net.causw.adapter.persistence.repository.post.LikePostRepository;
+import net.causw.adapter.persistence.repository.post.PostRepository;
 import net.causw.adapter.persistence.repository.user.UserAdmissionRepository;
 import net.causw.adapter.persistence.repository.user.UserRepository;
 import net.causw.adapter.persistence.user.User;
 import net.causw.adapter.persistence.user.UserAdmission;
+import net.causw.application.dto.post.PostsResponseDto;
+import net.causw.application.dto.user.UserPostsResponseDto;
 import net.causw.application.dto.user.UserResponseDto;
+import net.causw.application.dto.util.dtoMapper.PostDtoMapper;
+import net.causw.application.dto.util.dtoMapper.UserDtoMapper;
 import net.causw.application.excel.UserExcelService;
+import net.causw.application.pageable.PageableFactory;
+import net.causw.domain.model.enums.user.Role;
 import net.causw.domain.model.enums.user.UserState;
 
+import net.causw.domain.model.util.StaticValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -20,15 +33,23 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -38,12 +59,22 @@ class UserServiceTest {
 
   @Mock
   UserExcelService userExcelService;
-
   @Mock
   UserRepository userRepository;
-
   @Mock
   UserAdmissionRepository userAdmissionRepository;
+  @Mock
+  LikePostRepository likePostRepository;
+  @Mock
+  PageableFactory pageableFactory;
+  @Mock
+  PostDtoMapper postDtoMapper;
+  @Mock
+  UserDtoMapper userDtoMapper;
+  @Mock
+  PostRepository postRepository;
+  @Mock
+  FavoritePostRepository favoritePostRepository;
 
   HttpServletResponse response;
   User user;
@@ -121,5 +152,73 @@ class UserServiceTest {
             .isEqualTo(userState);
       }
     }
+  }
+
+  @Nested
+  @DisplayName("유저 게시글 모아보기 테스트")
+  class UserFindPostsTest {
+
+    @DisplayName("유저 좋아요 게시글 모아보기 성공")
+    @Test
+    void findLikePosts_ShouldSuccess() {
+      // given
+      Integer pageNum = 0;
+      PageRequest pageable = PageRequest.of(0, 10);
+      String userId = "dummyId";
+
+      when(user.getRoles()).thenReturn(Set.of(Role.COMMON));
+      when(user.getState()).thenReturn(UserState.ACTIVE);
+      when(user.getId()).thenReturn(userId);
+
+      String mockPostId = "dummyPostId";
+      Post mockPost = mock(Post.class);
+      given(mockPost.getId()).willReturn(mockPostId);
+
+      LikePost mockLikePost = mock(LikePost.class);
+      List<LikePost> mockLikePosts = List.of(mockLikePost);
+      Page<LikePost> mockLikePostPages = new PageImpl<>(mockLikePosts);
+
+      when(mockLikePost.getPost()).thenReturn(mockPost);
+
+      when(pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE)).thenReturn(
+          pageable);
+      when(likePostRepository.findByUserId(user.getId(),
+          pageableFactory.create(pageNum, StaticValue.DEFAULT_POST_PAGE_SIZE)))
+          .thenReturn(mockLikePostPages);
+
+      PostsResponseDto mockPostDto = mock(PostsResponseDto.class);
+      UserPostsResponseDto expectedResponseDto = mock(UserPostsResponseDto.class);
+
+      given(postDtoMapper.toPostsResponseDto(
+          eq(mockLikePost.getPost()),
+          anyLong(),
+          anyLong(),
+          anyLong(),
+          any(),
+          anyBoolean(),
+          anyBoolean()
+      )).willReturn(mockPostDto);
+
+      given(userDtoMapper.toUserPostsResponseDto(eq(user), any()))
+          .willReturn(expectedResponseDto);
+
+      given(postRepository.countAllCommentByPost_Id(mockPost.getId())).willReturn(1L);
+      given(likePostRepository.countByPostId(mockPost.getId())).willReturn(1L);
+      given(favoritePostRepository.countByPostIdAndIsDeletedFalse(mockPost.getId())).willReturn(1L);
+      given(mockLikePost.getPost().getPostAttachImageList()).willReturn(List.of());
+      given(mockPost.getVote()).willReturn(null);
+      given(mockPost.getVote()).willReturn(null);
+      // when
+      UserPostsResponseDto result = userService.findLikePosts(user, pageNum);
+
+      // then
+      assertThat(result).isEqualTo(expectedResponseDto);
+
+      verify(likePostRepository, times(1)).findByUserId(userId, pageable);
+      verify(postDtoMapper, times(1)).toPostsResponseDto(any(), anyLong(), anyLong(), anyLong(), any(), anyBoolean(), anyBoolean());
+      verify(userDtoMapper, times(1)).toUserPostsResponseDto(eq(user), any());
+
+    }
+
   }
 }


### PR DESCRIPTION
### 🚩 관련사항
#815


### 📢 전달사항
- 테스트코드 작성의 용이성을 위해서 dtoMapper를 서비스레이어에서 주입받는 방식으로 변경한 코드가 일부 있습니다.
해당 내용에 대한 피드백을 받고 나머지 서비스 레이어의 dtoMapper 사용방식도 변경하려고 합니다. 피드백 주시면 감사하겠습니다.

- `userService#findLikePosts` 테스트의 경우, 엣지 케이스 테스트까지 아직 작성하지 못한 상태입니다.
- 테스트 코드의 경우 제가 구현한 메서드들에 대해서만 작성한 상태입니다.
다음 스프린트에서 제가 관여한 도메인들에 대한 테스트코드까지 추가작성하도록 하겠습니다.(ex. 캘린더, #816 게시글 즐겨찾기, #812  게시글 작성(투표 생성)


### 📸 스크린샷
<img width="492" alt="image" src="https://github.com/user-attachments/assets/291820ad-3a51-4fb2-8273-7e33f8d6a6f8" />

<img width="496" alt="image" src="https://github.com/user-attachments/assets/3dc19c24-b577-4dae-80d1-00807bed27fa" />



### 📃 진행사항
- [x] 게시글 좋아요 취소 API 구현
- [x] 좋아요한 게시글 모아보기 API 구현
- [x] 게시글 좋아요 관련 테스트코드 작성
- [x] 좋아요 게시글 모아보기 성공케이스 테스트코드 작성
- [ ] 좋아요 게시글 모아보기 엣지케이스 테스트코드 작성


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 2d