### PR TITLE
hotfix : 댓글 생성 에러 해결

### DIFF
--- a/src/main/java/net/causw/application/comment/CommentService.java
+++ b/src/main/java/net/causw/application/comment/CommentService.java
@@ -75,9 +75,9 @@ public class CommentService {
                 consistOf(ConstraintValidator.of(comment, this.validator));
         validatorBucket.validate();
         //1. comment의 구독 여부 저장
-        createCommentSubscribe(creator, comment.getId());
-
         CommentResponseDto commentResponseDto = toCommentResponseDto(commentRepository.save(comment), creator, post.getBoard());
+
+        createCommentSubscribe(creator, comment.getId());
 
         //2. comment가 달린 게시글의 구독자에게 전송
         postNotificationService.sendByPostIsSubscribed(post, comment);


### PR DESCRIPTION
### 🚩 관련사항
#811 


### 📢 전달사항
댓글 생성 시 구독여부 설정 생성할 때 엔티티 저장 이전에 호출하여 에러가 발생했습니다. post와 board에 대한 구독여부와 동일하게 통일하였습니다


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 