### PR TITLE
test: 투표 도메인 테스트 작성

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/vote/VoteOption.java
+++ b/src/main/java/net/causw/adapter/persistence/vote/VoteOption.java
@@ -1,8 +1,10 @@
 package net.causw.adapter.persistence.vote;
 
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.*;
 import net.causw.adapter.persistence.base.BaseEntity;
+import org.jetbrains.annotations.TestOnly;
 
 @Entity
 @Builder(access = AccessLevel.PROTECTED)

--- a/src/main/java/net/causw/application/vote/VoteService.java
+++ b/src/main/java/net/causw/application/vote/VoteService.java
@@ -34,130 +34,143 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class VoteService {
-    private final VoteOptionRepository voteOptionRepository;
-    private final VoteRepository voteRepository;
-    private final PostRepository postRepository;
-    private final VoteRecordRepository voteRecordRepository;
 
-    @Transactional
-    public VoteResponseDto createVote(CreateVoteRequestDto createVoteRequestDTO, User user) {
-        Post post = postRepository.findById(createVoteRequestDTO.getPostId())
-                .orElseThrow(() -> new BadRequestException(ErrorCode.ROW_DOES_NOT_EXIST, MessageUtil.POST_NOT_FOUND));
-        if (!(user.equals(post.getWriter()))){
-            throw new BadRequestException(ErrorCode.API_NOT_ALLOWED, MessageUtil.VOTE_START_NOT_ACCESSIBLE);
-        }
-        List<VoteOption> voteOptions = createVoteRequestDTO.getOptions().stream()
-                .map(VoteOption::of)
-                .collect(Collectors.toList());
-        Vote vote = Vote.of(
-                createVoteRequestDTO.getTitle(),
-                createVoteRequestDTO.getAllowAnonymous(),
-                createVoteRequestDTO.getAllowMultiple(),
-                voteOptions,
-                post
-        );
-        Vote savedVote = voteRepository.save(vote);
-        post.updateVote(vote);
-        voteOptions.forEach(voteOption -> voteOption.updateVote(savedVote));
-        voteOptionRepository.saveAll(voteOptions);
-        return toVoteResponseDto(savedVote,user);
+  private final VoteOptionRepository voteOptionRepository;
+  private final VoteRepository voteRepository;
+  private final PostRepository postRepository;
+  private final VoteRecordRepository voteRecordRepository;
+
+  @Transactional
+  public VoteResponseDto createVote(CreateVoteRequestDto createVoteRequestDTO, User user) {
+    Post post = postRepository.findById(createVoteRequestDTO.getPostId())
+        .orElseThrow(() -> new BadRequestException(ErrorCode.ROW_DOES_NOT_EXIST,
+            MessageUtil.POST_NOT_FOUND));
+    if (!(user.equals(post.getWriter()))) {
+      throw new BadRequestException(ErrorCode.API_NOT_ALLOWED,
+          MessageUtil.VOTE_START_NOT_ACCESSIBLE);
     }
+    List<VoteOption> voteOptions = createVoteRequestDTO.getOptions().stream()
+        .map(VoteOption::of)
+        .collect(Collectors.toList());
+    Vote vote = Vote.of(
+        createVoteRequestDTO.getTitle(),
+        createVoteRequestDTO.getAllowAnonymous(),
+        createVoteRequestDTO.getAllowMultiple(),
+        voteOptions,
+        post
+    );
+    Vote savedVote = voteRepository.save(vote);
+    post.updateVote(vote);
+    voteOptions.forEach(voteOption -> voteOption.updateVote(savedVote));
+    voteOptionRepository.saveAll(voteOptions);
+    return toVoteResponseDto(savedVote, user);
+  }
 
-    @Transactional
-    public String castVote(CastVoteRequestDto castVoteRequestDto, User user) {
-        List<String> voteOptionIds = castVoteRequestDto.getVoteOptionIdList();
-        if (voteOptionIds == null || voteOptionIds.isEmpty()) {
-            throw new BadRequestException(ErrorCode.INVALID_PARAMETER, MessageUtil.VOTE_OPTION_NOT_PROVIDED);
-        }
-        // 첫 번째 VoteOption을 이용해 Vote를 가져옴 (모든 옵션은 동일한 Vote에 속해야 함)
-        VoteOption firstVoteOption = voteOptionRepository.findById(castVoteRequestDto.getVoteOptionIdList().get(0))
-                .orElseThrow(() -> new BadRequestException(ErrorCode.ROW_DOES_NOT_EXIST, MessageUtil.VOTE_OPTION_NOT_FOUND));
-        Vote vote = firstVoteOption.getVote();
-
-        // 중복 투표가 허용되지 않는 경우
-        if (!vote.isAllowMultiple()) {
-            if (voteOptionIds.size() > 1) {
-                throw new BadRequestException(ErrorCode.INVALID_PARAMETER, MessageUtil.VOTE_NOT_MULTIPLE);
-            }
-            List<VoteRecord> existingVoteRecords = voteRecordRepository.findByVoteOption_VoteAndUser(vote, user);
-            if (!existingVoteRecords.isEmpty()) {
-                throw new BadRequestException(ErrorCode.INVALID_PARAMETER, MessageUtil.VOTE_ALREADY_DONE);
-            }
-        }
-        List<VoteOption> voteOptions = voteOptionRepository.findAllById(voteOptionIds);
-        List<VoteRecord> newVoteRecords = voteOptions.stream()
-                .map(voteOption -> VoteRecord.of(user, voteOption))
-                .collect(Collectors.toList());
-        voteRecordRepository.saveAll(newVoteRecords);
-        return "투표 성공";
+  @Transactional
+  public String castVote(CastVoteRequestDto castVoteRequestDto, User user) {
+    List<String> voteOptionIds = castVoteRequestDto.getVoteOptionIdList();
+    if (voteOptionIds == null || voteOptionIds.isEmpty()) {
+      throw new BadRequestException(ErrorCode.INVALID_PARAMETER,
+          MessageUtil.VOTE_OPTION_NOT_PROVIDED);
     }
+    // 첫 번째 VoteOption을 이용해 Vote를 가져옴 (모든 옵션은 동일한 Vote에 속해야 함)
+    VoteOption firstVoteOption = voteOptionRepository.findById(
+            castVoteRequestDto.getVoteOptionIdList().get(0))
+        .orElseThrow(() -> new BadRequestException(ErrorCode.ROW_DOES_NOT_EXIST,
+            MessageUtil.VOTE_OPTION_NOT_FOUND));
+    Vote vote = firstVoteOption.getVote();
 
-    @Transactional
-    public VoteResponseDto endVote(String voteId, User user) {
-        Vote vote = voteRepository.findById(voteId)
-                .orElseThrow(() -> new BadRequestException(ErrorCode.ROW_DOES_NOT_EXIST,MessageUtil.VOTE_NOT_FOUND));
-        if (!(user.equals(vote.getPost().getWriter()))){
-            throw new BadRequestException(ErrorCode.API_NOT_ALLOWED, MessageUtil.VOTE_END_NOT_ACCESSIBLE);
-        }
-        if (vote.isEnd()) {
-            throw new BadRequestException(ErrorCode.INVALID_PARAMETER, MessageUtil.VOTE_ALREADY_END);
-        }
-        vote.endVote();
-        voteRepository.save(vote);
-        return toVoteResponseDto(vote,user);
+    // 중복 투표가 허용되지 않는 경우
+    if (!vote.isAllowMultiple()) {
+      if (voteOptionIds.size() > 1) {
+        throw new BadRequestException(ErrorCode.INVALID_PARAMETER, MessageUtil.VOTE_NOT_MULTIPLE);
+      }
+      List<VoteRecord> existingVoteRecords = voteRecordRepository.findByVoteOption_VoteAndUser(vote,
+          user);
+      if (!existingVoteRecords.isEmpty()) {
+        throw new BadRequestException(ErrorCode.INVALID_PARAMETER, MessageUtil.VOTE_ALREADY_DONE);
+      }
     }
+    List<VoteOption> voteOptions = voteOptionRepository.findAllById(voteOptionIds);
+    List<VoteRecord> newVoteRecords = voteOptions.stream()
+        .map(voteOption -> VoteRecord.of(user, voteOption))
+        .collect(Collectors.toList());
+    voteRecordRepository.saveAll(newVoteRecords);
+    return "투표 성공";
+  }
 
-    @Transactional
-    public VoteResponseDto restartVote(String voteId, User user) {
-        Vote vote = voteRepository.findById(voteId)
-                .orElseThrow(() -> new BadRequestException(ErrorCode.ROW_DOES_NOT_EXIST,MessageUtil.VOTE_NOT_FOUND));
-        if (!(user.equals(vote.getPost().getWriter()))){
-            throw new BadRequestException(ErrorCode.API_NOT_ALLOWED, MessageUtil.VOTE_RESTART_NOT_ACCESSIBLE);
-        }
-        if (!vote.isEnd()) {
-            throw new BadRequestException(ErrorCode.INVALID_PARAMETER, MessageUtil.VOTE_NOT_END);
-        }
-        vote.restartVote();
-        voteRepository.save(vote);
-        return toVoteResponseDto(vote,user);
+  @Transactional
+  public VoteResponseDto endVote(String voteId, User user) {
+    Vote vote = voteRepository.findById(voteId)
+        .orElseThrow(() -> new BadRequestException(ErrorCode.ROW_DOES_NOT_EXIST,
+            MessageUtil.VOTE_NOT_FOUND));
+    if (!(user.equals(vote.getPost().getWriter()))) {
+      throw new BadRequestException(ErrorCode.API_NOT_ALLOWED, MessageUtil.VOTE_END_NOT_ACCESSIBLE);
     }
-
-    @Transactional(readOnly = true)
-    public VoteResponseDto getVoteById(String voteId, User user) {
-        Vote vote = voteRepository.findById(voteId)
-                .orElseThrow(() -> new BadRequestException(ErrorCode.ROW_DOES_NOT_EXIST, MessageUtil.VOTE_NOT_FOUND));
-        return toVoteResponseDto(vote,user);
+    if (vote.isEnd()) {
+      throw new BadRequestException(ErrorCode.INVALID_PARAMETER, MessageUtil.VOTE_ALREADY_END);
     }
+    vote.endVote();
+    voteRepository.save(vote);
+    return toVoteResponseDto(vote, user);
+  }
 
-    private VoteResponseDto toVoteResponseDto(Vote vote, User user) {
-        List<VoteOptionResponseDto> voteOptionResponseDtoList = vote.getVoteOptions().stream()
-                .sorted(Comparator.comparing(VoteOption::getCreatedAt))
-                .map(this::tovoteOptionResponseDto)
-                .collect(Collectors.toList());
-
-        Set<String> uniqueUserIds = voteOptionResponseDtoList.stream()
-                .flatMap(voteOptionResponseDto -> voteOptionResponseDto.getVoteUsers().stream())
-                .map(UserResponseDto::getId)
-                .collect(Collectors.toSet());
-        Integer totalUserCount = uniqueUserIds.size();
-        return VoteDtoMapper.INSTANCE.toVoteResponseDto(
-                vote,
-                voteOptionResponseDtoList
-                , StatusUtil.isVoteOwner(vote, user)
-                , vote.isEnd()
-                , voteRecordRepository.existsByVoteOption_VoteAndUser(vote, user)
-                , voteOptionResponseDtoList.stream()
-                        .mapToInt(VoteOptionResponseDto::getVoteCount)
-                        .sum()
-                , totalUserCount);
+  @Transactional
+  public VoteResponseDto restartVote(String voteId, User user) {
+    Vote vote = voteRepository.findById(voteId)
+        .orElseThrow(() -> new BadRequestException(ErrorCode.ROW_DOES_NOT_EXIST,
+            MessageUtil.VOTE_NOT_FOUND));
+    if (!(user.equals(vote.getPost().getWriter()))) {
+      throw new BadRequestException(ErrorCode.API_NOT_ALLOWED,
+          MessageUtil.VOTE_RESTART_NOT_ACCESSIBLE);
     }
-
-    private VoteOptionResponseDto tovoteOptionResponseDto(VoteOption voteOption) {
-        List<VoteRecord> voteRecords = voteRecordRepository.findAllByVoteOption(voteOption);
-        List<UserResponseDto> userResponseDtos = voteRecords.stream()
-                .map(voteRecord -> UserDtoMapper.INSTANCE.toUserResponseDto(voteRecord.getUser(), null, null))
-                .collect(Collectors.toList());
-        return VoteDtoMapper.INSTANCE.toVoteOptionResponseDto(voteOption, voteRecords.size(), userResponseDtos);
+    if (!vote.isEnd()) {
+      throw new BadRequestException(ErrorCode.INVALID_PARAMETER, MessageUtil.VOTE_NOT_END);
     }
+    vote.restartVote();
+    voteRepository.save(vote);
+    return toVoteResponseDto(vote, user);
+  }
+
+  @Transactional(readOnly = true)
+  public VoteResponseDto getVoteById(String voteId, User user) {
+    Vote vote = voteRepository.findById(voteId)
+        .orElseThrow(() -> new BadRequestException(ErrorCode.ROW_DOES_NOT_EXIST,
+            MessageUtil.VOTE_NOT_FOUND));
+    return toVoteResponseDto(vote, user);
+  }
+
+  private VoteResponseDto toVoteResponseDto(Vote vote, User user) {
+    List<VoteOptionResponseDto> voteOptionResponseDtoList = vote.getVoteOptions().stream()
+        .sorted(Comparator.comparing(VoteOption::getCreatedAt))
+        .map(this::tovoteOptionResponseDto)
+        .collect(Collectors.toList());
+
+    Set<String> uniqueUserIds = voteOptionResponseDtoList.stream()
+        .flatMap(voteOptionResponseDto -> voteOptionResponseDto.getVoteUsers().stream())
+        .map(UserResponseDto::getId)
+        .collect(Collectors.toSet());
+    Integer totalUserCount = uniqueUserIds.size();
+    return VoteDtoMapper.INSTANCE.toVoteResponseDto(
+        vote,
+        voteOptionResponseDtoList
+        , StatusUtil.isVoteOwner(vote, user)
+        , vote.isEnd()
+        , voteRecordRepository.existsByVoteOption_VoteAndUser(vote, user)
+        , voteOptionResponseDtoList.stream()
+            .mapToInt(VoteOptionResponseDto::getVoteCount)
+            .sum()
+        , totalUserCount);
+  }
+
+  private VoteOptionResponseDto tovoteOptionResponseDto(VoteOption voteOption) {
+    List<VoteRecord> voteRecords = voteRecordRepository.findAllByVoteOption(voteOption);
+    List<UserResponseDto> userResponseDtos = voteRecords.stream()
+        .map(voteRecord -> UserDtoMapper.INSTANCE.toUserResponseDto(voteRecord.getUser(), null,
+            null))
+        .collect(Collectors.toList());
+    return VoteDtoMapper.INSTANCE.toVoteOptionResponseDto(voteOption, voteRecords.size(),
+        userResponseDtos);
+  }
 
 }

--- a/src/main/java/net/causw/application/vote/VoteService.java
+++ b/src/main/java/net/causw/application/vote/VoteService.java
@@ -105,7 +105,6 @@ public class VoteService {
         vote.endVote();
         voteRepository.save(vote);
         return toVoteResponseDto(vote,user);
-
     }
 
     @Transactional
@@ -113,10 +112,10 @@ public class VoteService {
         Vote vote = voteRepository.findById(voteId)
                 .orElseThrow(() -> new BadRequestException(ErrorCode.ROW_DOES_NOT_EXIST,MessageUtil.VOTE_NOT_FOUND));
         if (!(user.equals(vote.getPost().getWriter()))){
-            throw new BadRequestException(ErrorCode.API_NOT_ALLOWED, MessageUtil.VOTE_END_NOT_ACCESSIBLE);
+            throw new BadRequestException(ErrorCode.API_NOT_ALLOWED, MessageUtil.VOTE_RESTART_NOT_ACCESSIBLE);
         }
         if (!vote.isEnd()) {
-            throw new BadRequestException(ErrorCode.INVALID_PARAMETER, MessageUtil.VOTE_ALREADY_END);
+            throw new BadRequestException(ErrorCode.INVALID_PARAMETER, MessageUtil.VOTE_NOT_END);
         }
         vote.restartVote();
         voteRepository.save(vote);

--- a/src/main/java/net/causw/domain/model/util/MessageUtil.java
+++ b/src/main/java/net/causw/domain/model/util/MessageUtil.java
@@ -167,9 +167,11 @@ public class MessageUtil {
     public static final String VOTE_NOT_MULTIPLE = "이 투표는 여러 항목을 선택할 수 없습니다.";
     public static final String VOTE_ALREADY_DONE = "해당 투표에 이미 참여한 이력이 있습니다.";
     public static final String VOTE_ALREADY_END = "이미 종료된 투표입니다.";
+    public static final String VOTE_NOT_END = "종료되지 않은 투표입니다.";
 
     public static final String VOTE_NOT_FOUND = "투표가 존재하지 않습니다.";
     public static final String VOTE_END_NOT_ACCESSIBLE = "투표 종료 권한이 존재하지 않습니다.";
+    public static final String VOTE_RESTART_NOT_ACCESSIBLE = "투표 재시작 권한이 존재하지 않습니다.";
     public static final String VOTE_START_NOT_ACCESSIBLE = "투표 시작 권한이 존재하지 않습니다.";
     // 500
     public static final String INTERNAL_SERVER_ERROR = "Internal Server Error";

--- a/src/test/java/net/causw/application/vote/VoteServiceTest.java
+++ b/src/test/java/net/causw/application/vote/VoteServiceTest.java
@@ -1,0 +1,131 @@
+package net.causw.application.vote;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
+import net.causw.adapter.persistence.board.Board;
+import net.causw.adapter.persistence.post.Post;
+import net.causw.adapter.persistence.repository.post.PostRepository;
+import net.causw.adapter.persistence.repository.vote.VoteOptionRepository;
+import net.causw.adapter.persistence.repository.vote.VoteRecordRepository;
+import net.causw.adapter.persistence.repository.vote.VoteRepository;
+import net.causw.adapter.persistence.user.User;
+import net.causw.adapter.persistence.vote.Vote;
+import net.causw.adapter.persistence.vote.VoteOption;
+import net.causw.adapter.persistence.vote.VoteRecord;
+import net.causw.application.dto.user.UserResponseDto;
+import net.causw.application.dto.util.StatusUtil;
+import net.causw.application.dto.util.dtoMapper.UserDtoMapper;
+import net.causw.application.dto.util.dtoMapper.VoteDtoMapper;
+import net.causw.application.dto.vote.CreateVoteRequestDto;
+import net.causw.application.dto.vote.VoteOptionResponseDto;
+import net.causw.application.dto.vote.VoteResponseDto;
+import net.causw.domain.model.enums.user.Role;
+import net.causw.domain.model.util.ObjectFixtures;
+import net.causw.domain.model.util.StaticValue;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class VoteServiceTest {
+
+  @InjectMocks
+  VoteService voteService;
+
+  @Mock
+  VoteOptionRepository voteOptionRepository;
+  @Mock
+  VoteRepository voteRepository;
+  @Mock
+  PostRepository postRepository;
+  @Mock
+  VoteRecordRepository voteRecordRepository;
+
+  User user;
+  Post post;
+  Board board;
+  List<VoteOption> voteOptions;
+  Vote vote;
+
+  @BeforeEach
+  public void setUp() {
+    user = ObjectFixtures.getUser();
+    board = ObjectFixtures.getBoard();
+    post = ObjectFixtures.getPost(user, board);
+    voteOptions = ObjectFixtures.getVoteOptions();
+    voteOptions.forEach(
+        voteOption -> ReflectionTestUtils.setField(voteOption, "createdAt", LocalDateTime.now()));
+    vote = ObjectFixtures.getVote(voteOptions, post);
+  }
+
+
+  @Nested
+  @DisplayName("투표 생성 테스트")
+  class voteCreateTest {
+
+    CreateVoteRequestDto createVoteRequestDto;
+
+    @BeforeEach
+    public void setUp() {
+      createVoteRequestDto = new CreateVoteRequestDto("title", false, false,
+          List.of("option1", "option2"), post.getId());
+    }
+
+    @Test
+    @DisplayName("투표 생성 성공 테스트")
+    public void createVote_ShouldSuccess() {
+      // given
+      given(postRepository.findById(createVoteRequestDto.getPostId())).willReturn(
+          Optional.of(post));
+
+      given(postRepository.findById(post.getId())).willReturn(Optional.of(post));
+      given(voteRepository.save(any(Vote.class))).willReturn(vote);
+      given(voteOptionRepository.saveAll(anyList())).willAnswer(
+            invocation -> invocation.getArgument(0));
+
+      // when
+      VoteResponseDto result = voteService.createVote(createVoteRequestDto, user);
+
+      // then
+      SoftAssertions.assertSoftly(softAssertions -> {
+        assertThat(result.getTitle()).isEqualTo("title");
+        assertThat(result.getAllowAnonymous()).isEqualTo(false);
+        assertThat(result.getAllowMultiple()).isEqualTo(false);
+
+        assertThat(result.getOptions()).hasSize(2);
+        assertThat(result.getOptions()).extracting(VoteOptionResponseDto::getVoteCount)
+            .containsExactlyElementsOf(List.of(0,0));
+        assertThat(result.getOptions()).extracting(VoteOptionResponseDto::getOptionName)
+            .containsExactlyElementsOf(List.of("option1", "option2"));
+
+        assertThat(result.getIsOwner()).isEqualTo(true);
+        assertThat(result.getHasVoted()).isEqualTo(false);
+        assertThat(result.getIsEnd()).isEqualTo(false);
+
+        assertThat(result.getTotalVoteCount()).isEqualTo(0);
+        assertThat(result.getTotalUserCount()).isEqualTo(0);
+      });
+    }
+  }
+}

--- a/src/test/java/net/causw/domain/model/util/ObjectFixtures.java
+++ b/src/test/java/net/causw/domain/model/util/ObjectFixtures.java
@@ -8,6 +8,8 @@ import net.causw.adapter.persistence.user.User;
 import net.causw.adapter.persistence.user.UserAdmission;
 import net.causw.adapter.persistence.userCouncilFee.CouncilFeeFakeUser;
 import net.causw.adapter.persistence.userCouncilFee.UserCouncilFee;
+import net.causw.adapter.persistence.vote.Vote;
+import net.causw.adapter.persistence.vote.VoteOption;
 import net.causw.application.dto.user.UserCreateRequestDto;
 import net.causw.domain.model.enums.semester.SemesterType;
 import net.causw.domain.model.enums.user.GraduationType;
@@ -91,9 +93,9 @@ public class ObjectFixtures {
         "boardName",
         "boardDescription",
         List.of(
-            "ADMIN","PRESIDENT","VICE_PRESIDENT",
-            "COUNCIL","LEADER_1","LEADER_2","LEADER_3","LEADER_4",
-            "LEADER_CIRCLE","LEADER_ALUMNI","COMMON","PROFESSOR"),
+            "ADMIN", "PRESIDENT", "VICE_PRESIDENT",
+            "COUNCIL", "LEADER_1", "LEADER_2", "LEADER_3", "LEADER_4",
+            "LEADER_CIRCLE", "LEADER_ALUMNI", "COMMON", "PROFESSOR"),
         "category",
         true,
         null
@@ -110,6 +112,20 @@ public class ObjectFixtures {
         board,
         null,
         List.of()
+    );
+  }
+
+  public static List<VoteOption> getVoteOptions() {
+    return List.of(VoteOption.of("option1"), VoteOption.of("option2"));
+  }
+
+  public static Vote getVote(List<VoteOption> voteOptions, Post post) {
+    return Vote.of(
+        "title",
+        false,
+        false,
+        voteOptions,
+        post
     );
   }
 }


### PR DESCRIPTION
### 🚩 관련사항
#820 


### 📢 전달사항
- 820번 풀리퀘스트와 관련하여, 미비사항으로 작성했던 투표 도메인 서비스 단위 테스트를 추가했습니다.
- 테스트 중 투표 재시작 로직과 관련하여 예외처리 메시지가 로직과 부합하지 않는 부분을 확인하여 수정하였습니다. c38fec5e4c3e4c31759114bd42ec5e8a38171a6a

### 📸 스크린샷
<img width="484" alt="image" src="https://github.com/user-attachments/assets/59cc762a-747c-4638-8b66-8a75f5d53486" />



### 📃 진행사항
- [x] 투표 도메인 서비스 단위 테스트 작성
- [x] 투표 재시작 관련 예외 메시지 수정


### ⚙️ 기타사항

- `ObjectFixture` 부분을 좀더 리팩토링해보면 어떨까 합니다. 확실히 재사용성 측면에서 좋은 방법인 것 같은데, 
엣지 케이스 테스트 측면에서 필드 수정을 하거나 하기가 쉽지 않다는 부분이 있었습니다.
저의 경우에는 그럴때 모킹(mocking)을 사용하긴 했습니다. 하지만 이런 부분들도 `ObjectFixture` 클래스를 리팩토링하여 해결할 수 있지 않을까 합니다.

개발기간: 1d