### PR TITLE
fix: 소프트웨어학부 공지 크롤링 오류 수정

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/repository/board/BoardRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/board/BoardRepository.java
@@ -22,4 +22,6 @@ public interface BoardRepository extends JpaRepository<Board, String> {
     Optional<Board> findAppNotice();
 
     Boolean existsByName(String name);
+
+    Optional<Board> findByName(String name);
 }

--- a/src/main/java/net/causw/adapter/persistence/repository/crawled/CrawledNoticeRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/crawled/CrawledNoticeRepository.java
@@ -4,5 +4,8 @@ package net.causw.adapter.persistence.repository.crawled;
 import net.causw.adapter.persistence.crawled.CrawledNotice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CrawledNoticeRepository extends JpaRepository<CrawledNotice, String> {
+    List<CrawledNotice> findTop20ByOrderByAnnounceDateDesc();
 }

--- a/src/main/java/net/causw/adapter/persistence/repository/post/PostRepository.java
+++ b/src/main/java/net/causw/adapter/persistence/repository/post/PostRepository.java
@@ -1,5 +1,6 @@
 package net.causw.adapter.persistence.repository.post;
 
+import net.causw.adapter.persistence.board.Board;
 import net.causw.adapter.persistence.form.Form;
 import net.causw.adapter.persistence.post.Post;
 import org.springframework.data.domain.Page;
@@ -62,4 +63,6 @@ public interface PostRepository extends JpaRepository<Post, String> {
     }
 
     Optional<Post> findByForm(Form form);
+
+    boolean existsByBoardAndContentContains(Board board, String contentSubstring);
 }

--- a/src/main/java/net/causw/application/crawler/CrawledToPostTransferService.java
+++ b/src/main/java/net/causw/application/crawler/CrawledToPostTransferService.java
@@ -1,0 +1,98 @@
+package net.causw.application.crawler;
+
+import lombok.RequiredArgsConstructor;
+import net.causw.adapter.persistence.board.Board;
+import net.causw.adapter.persistence.crawled.CrawledFileLink;
+import net.causw.adapter.persistence.crawled.CrawledNotice;
+import net.causw.adapter.persistence.post.Post;
+import net.causw.adapter.persistence.repository.board.BoardRepository;
+import net.causw.adapter.persistence.repository.crawled.CrawledNoticeRepository;
+import net.causw.adapter.persistence.repository.post.PostRepository;
+import net.causw.adapter.persistence.repository.user.UserRepository;
+import net.causw.adapter.persistence.repository.uuidFile.UuidFileRepository;
+import net.causw.adapter.persistence.user.User;
+import net.causw.adapter.persistence.uuidFile.UuidFile;
+import net.causw.domain.exceptions.BadRequestException;
+import net.causw.domain.exceptions.ErrorCode;
+import net.causw.domain.model.util.MessageUtil;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class CrawledToPostTransferService {
+
+    private final CrawledNoticeRepository crawledNoticeRepository;
+    private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final UuidFileRepository uuidFileRepository;
+
+    @Scheduled(fixedRate = 5000) // 테스트용, 5초마다 실행
+//    @Scheduled(cron = "0 0 1 * * *") // 매일 새벽 1시
+    @Transactional
+    public void transferCrawledNoticesToPosts() {
+        Board board = boardRepository.findByName("소프트웨어학부 학부 공지")
+                .orElseThrow(() -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        MessageUtil.BOARD_NOT_FOUND
+                ));
+
+        User user = userRepository.findByStudentId("20220881")
+                .orElseThrow(() -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        MessageUtil.USER_NOT_FOUND
+                ));
+
+        List<CrawledNotice> notices = crawledNoticeRepository.findTop20ByOrderByAnnounceDateDesc();
+
+        for (CrawledNotice notice : notices) {
+            String title = (notice.getTitle() == null || notice.getTitle().isBlank()) ? "제목 없음" : notice.getTitle();
+            String content = (notice.getContent() == null || notice.getContent().isBlank()) ? "내용 없음" : notice.getContent();
+
+            // 본문 끝에 링크 추가하여 중복 체크
+            StringBuilder contentBuilder = new StringBuilder(content);
+
+            List<UuidFile> uuidFileList = new ArrayList<>();
+
+            // 이미지 처리
+            if (notice.getImageLink() != null && !notice.getImageLink().isBlank()) {
+                contentBuilder.append("\n\n![공지 이미지](").append(notice.getImageLink()).append(")");
+            }
+
+            // 파일 처리
+            if (notice.getCrawledFileLinks() != null) {
+                for (CrawledFileLink fileLink : notice.getCrawledFileLinks()) {
+                    contentBuilder.append("\n\n[첨부파일: ")
+                            .append(fileLink.getFileName())
+                            .append("](")
+                            .append(fileLink.getFileLink())
+                            .append(")");
+                }
+            }
+
+            // 원본 링크 삽입
+            contentBuilder.append("\n\n[공지 링크](").append(notice.getLink()).append(")");
+
+            // 게시판에 같은 링크 포함한 글이 이미 있으면 넘김
+            if (postRepository.existsByBoardAndContentContains(board, notice.getLink())) continue;
+
+            Post post = Post.of(
+                    title,
+                    contentBuilder.toString(),
+                    user,
+                    false,
+                    false,
+                    board,
+                    null,
+                    uuidFileList
+            );
+
+            postRepository.save(post);
+        }
+    }
+}

--- a/src/main/java/net/causw/application/crawler/CrawledToPostTransferService.java
+++ b/src/main/java/net/causw/application/crawler/CrawledToPostTransferService.java
@@ -32,8 +32,8 @@ public class CrawledToPostTransferService {
     private final PostRepository postRepository;
     private final UuidFileRepository uuidFileRepository;
 
-    @Scheduled(fixedRate = 5000) // 테스트용, 5초마다 실행
-//    @Scheduled(cron = "0 0 1 * * *") // 매일 새벽 1시
+//    @Scheduled(fixedRate = 5000) // 테스트용, 5초마다 실행
+    @Scheduled(cron = "0 0 1 * * *") // 매일 새벽 1시
     @Transactional
     public void transferCrawledNoticesToPosts() {
         Board board = boardRepository.findByName("소프트웨어학부 학부 공지")

--- a/src/main/java/net/causw/application/crawler/WebCrawlerService.java
+++ b/src/main/java/net/causw/application/crawler/WebCrawlerService.java
@@ -96,7 +96,7 @@ public class WebCrawlerService {
     }
 
     //HTML페이지를 가져옴
-    private Document fetchUrl(String url) {
+    protected Document fetchUrl(String url) {
         try {
             return Jsoup.connect(url).get();
         } catch (IOException e) {
@@ -105,7 +105,7 @@ public class WebCrawlerService {
     }
 
     // 상세 페이지로 이동하여 내용 크롤링
-    private CrawledNotice parseNotice(Element row, String noticeUrl) {
+    protected CrawledNotice parseNotice(Element row, String noticeUrl) {
         String noticeType = row.select("td span.tag").text();
         Document detailDoc = fetchUrl(noticeUrl);
 

--- a/src/main/java/net/causw/application/crawler/WebCrawlerService.java
+++ b/src/main/java/net/causw/application/crawler/WebCrawlerService.java
@@ -37,32 +37,25 @@ public class WebCrawlerService {
     @Scheduled(cron = "0 0 * * * *") // 매 시각 0분 0초에 실행 (배포용)
     @Transactional
     public void crawlAndSaveCAUSWNoticeSite()  {
-        int pageNum = 1;
-
         // 최신 URL 가져오기
         String recentNoticeLink = latestCrawlRepository.findByCrawlCategory(CrawlCategory.CAU_SW_NOTICE)
                 .map(LatestCrawl::getLatestUrl)
                 .orElse(null);
 
+        int pageNum = 1;
         boolean isNew = true;
         while (isNew) {
             String url = StaticValue.CAU_CSE_BASE_URL + pageNum;
-            Document doc;
-            try {
-                doc = Jsoup.connect(url).get();
-            } catch (IOException e) {
-                throw new InternalServerException(ErrorCode.INTERNAL_SERVER, MessageUtil.FAIL_TO_CRAWL_CAU_SW_NOTICE_SITE);
-            }
+            Document doc = fetchUrl(url);
 
             Elements rows = doc.select("table.table-basic tbody tr");
-
             if (rows.isEmpty()) {
                 break; // 더 이상 페이지가 없으면 종료
             }
 
             List<CrawledNotice> notices = new ArrayList<>();
+
             for (Element row : rows) {
-                String noticeType = row.select("td span.tag").text();
                 Element titleElement = row.select("td.aleft a").first();
                 if (titleElement == null) {
                     continue;
@@ -74,60 +67,10 @@ public class WebCrawlerService {
                     isNew = false;
                     break;
                 }
-                // 상세 페이지로 이동하여 내용 크롤링
-                Document detailDoc;
-                try {
-                    detailDoc = Jsoup.connect(absoluteLink).get();
-                } catch (IOException e) {
-                    throw new InternalServerException(ErrorCode.INTERNAL_SERVER, MessageUtil.FAIL_TO_CRAWL_CAU_SW_NOTICE_SITE);
-                }
-                String title = detailDoc.select("div.header > h3").text();  // 제목 추출
-                String announceDate = detailDoc.select("div.header > div > span").get(1).text();    // 작성일 추출
-                String author = detailDoc.select("div.header > div > span").get(3).text();  // 작성자 추출
-                String content = detailDoc.select("div.fr-view").outerHtml();   // 본문 내용 추출
-                String imageLink = detailDoc.select("div.fr-view > p > img").attr("abs:src");  // 절대경로로 이미지 추출 => 없는 경우 빈 문자열 삽입\
-
-
-                // 첨부파일 다운로드 경로 추출
-                Elements downloadLinks = detailDoc.select("div.files span");
-                List<CrawledFileLink> crawledFileLinks = new ArrayList<>();
-
-                for (Element link : downloadLinks) {
-                    // 정규식 사용
-                    String onclickAttr = link.attr("onclick");
-                    Pattern pattern = Pattern.compile("goLocation\\('/_module/bbs/download.php','(\\d+)','(\\w+)'\\).*?>(.*?)<");
-                    Matcher matcher = pattern.matcher(link.outerHtml());
-
-                    while (matcher.find()) {
-                        String uid = matcher.group(1); // uid 추출
-                        String code = matcher.group(2); // code 추출
-                        String fileName = matcher.group(3).trim(); // 파일명 추출
-                        // 파일 다운로드 경로 생성
-                        String fileUrl = String.format("https://cse.cau.ac.kr/_module/bbs/download.php?uid=%s&code=%s", uid, code);
-                        // CrawledFileLink 객체 생성
-                        crawledFileLinks.add(CrawledFileLink.of(fileName, fileUrl));
-                    }
-                }
-
-                if (downloadLinks.isEmpty()) {
-                    // 첨부파일이 없는 경우
-                    crawledFileLinks = null;
-                }
-
-                // CrawledNotice 객체 생성
-                CrawledNotice notice = CrawledNotice.of(
-                        noticeType,
-                        title,
-                        content,
-                        absoluteLink,
-                        author,
-                        announceDate,
-                        imageLink,
-                        crawledFileLinks
-                );
+                CrawledNotice notice = parseNotice(row, absoluteLink);
                 notices.add(notice);
-
             }
+
             // DB save
             if (!notices.isEmpty()) {
                 // 새로운 공지사항이 하나라도 있으면 저장
@@ -151,5 +94,82 @@ public class WebCrawlerService {
             pageNum++;
         }
     }
-}
 
+    //HTML페이지를 가져옴
+    private Document fetchUrl(String url) {
+        try {
+            return Jsoup.connect(url).get();
+        } catch (IOException e) {
+            throw new InternalServerException(ErrorCode.INTERNAL_SERVER, MessageUtil.FAIL_TO_CRAWL_CAU_SW_NOTICE_SITE);
+        }
+    }
+
+    // 상세 페이지로 이동하여 내용 크롤링
+    private CrawledNotice parseNotice(Element row, String noticeUrl) {
+        String noticeType = row.select("td span.tag").text();
+        Document detailDoc = fetchUrl(noticeUrl);
+
+        String title = detailDoc.select("div.header > h3").text();  // 제목 추출
+        String announceDate = detailDoc.select("div.header > div > span").get(1).text();    // 작성일 추출
+        String author = detailDoc.select("div.header > div > span").get(3).text();  // 작성자 추출
+
+        String imageLink = detailDoc.select("div.fr-view > p > img").attr("abs:src");  // 절대경로로 이미지 추출 => 없는 경우 빈 문자열 삽입
+
+        // 본문 내용 추출
+        Element contentElement = detailDoc.select("div.fr-view").first();
+        StringBuilder textWithLineBreaks = new StringBuilder();
+
+        // 태그 기준으로 줄바꿈
+        for (Element elem : contentElement.getAllElements()) {
+            switch (elem.tagName()) {
+                case "p":
+                case "li":
+                    textWithLineBreaks.append(elem.text()).append("\n");
+                    break;
+                case "br":
+                    textWithLineBreaks.append("\n");
+                    break;
+            }
+        }
+        String content = textWithLineBreaks.toString().trim();
+
+        List<CrawledFileLink> fileLinks = extractDownloadLink(detailDoc);
+        return CrawledNotice.of(
+                noticeType,
+                title,
+                content,
+                noticeUrl,
+                author,
+                announceDate,
+                imageLink,
+                fileLinks.isEmpty() ? null : fileLinks
+        );
+    }
+
+    //첨부파일 다운로드 정보를 찾고 다운로드 가능한 파일링크 생성
+    private List<CrawledFileLink> extractDownloadLink(Document detailDoc) {
+        List<CrawledFileLink> crawledFileLinks = new ArrayList<>();
+        Elements downloadElements = detailDoc.select("div.files span");
+
+        // 첨부파일 다운로드 경로 추출
+        Elements downloadLinks = detailDoc.select("div.files span");
+        Pattern pattern = Pattern.compile("goLocation\\('/_module/bbs/download.php','(\\d+)','(\\w+)'\\).*?>(.*?)<");
+
+        for (Element link : downloadLinks) {
+            // 정규식 사용
+            String onclickAttr = link.attr("onclick");
+            Matcher matcher = pattern.matcher(link.outerHtml());
+
+            while (matcher.find()) {
+                String uid = matcher.group(1); // uid 추출
+                String code = matcher.group(2); // code 추출
+                String fileName = matcher.group(3).trim(); // 파일명 추출
+                // 파일 다운로드 경로 생성
+                String fileUrl = String.format("https://cse.cau.ac.kr/_module/bbs/download.php?uid=%s&code=%s", uid, code);
+                // CrawledFileLink 객체 생성
+                crawledFileLinks.add(CrawledFileLink.of(fileName, fileUrl));
+            }
+        }
+        return crawledFileLinks;
+    }
+}

--- a/src/test/java/net/causw/application/crawler/CrawledToPostTransferServiceTest.java
+++ b/src/test/java/net/causw/application/crawler/CrawledToPostTransferServiceTest.java
@@ -1,0 +1,137 @@
+package net.causw.application.crawler;
+
+import net.causw.adapter.persistence.board.Board;
+import net.causw.adapter.persistence.crawled.CrawledFileLink;
+import net.causw.adapter.persistence.crawled.CrawledNotice;
+import net.causw.adapter.persistence.post.Post;
+import net.causw.adapter.persistence.repository.board.BoardRepository;
+import net.causw.adapter.persistence.repository.crawled.CrawledNoticeRepository;
+import net.causw.adapter.persistence.repository.post.PostRepository;
+import net.causw.adapter.persistence.repository.user.UserRepository;
+import net.causw.adapter.persistence.user.User;
+import net.causw.domain.exceptions.BadRequestException;
+import net.causw.domain.model.util.MessageUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CrawledToPostTransferServiceTest {
+
+    @InjectMocks
+    private CrawledToPostTransferService service;
+
+    @Mock
+    private BoardRepository boardRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CrawledNoticeRepository crawledNoticeRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private Board mockBoard;
+
+    @Mock
+    private User mockUser;
+
+    @Mock
+    private CrawledNotice mockNotice;
+
+    @Mock
+    private CrawledFileLink mockFileLink;
+
+    @Captor
+    private ArgumentCaptor<Post> postCaptor;
+
+    @Nested
+    @DisplayName("정상 동작 테스트")
+    class SuccessTests {
+        @BeforeEach
+        void setUp() {
+            given(boardRepository.findByName("소프트웨어학부 학부 공지"))
+                    .willReturn(Optional.of(mockBoard));
+            given(userRepository.findByStudentId("20220881"))
+                    .willReturn(Optional.of(mockUser));
+        }
+
+        @Test
+        @DisplayName("신규 공지 변환 및 저장")
+        void transfer_NewNotices_SavesPosts() {
+            // given
+            given(mockNotice.getTitle()).willReturn("공지제목");
+            given(mockNotice.getContent()).willReturn("공지내용");
+            given(mockNotice.getImageLink()).willReturn("http://img");
+            given(mockNotice.getLink()).willReturn("http://link");
+            given(mockNotice.getCrawledFileLinks()).willReturn(List.of(mockFileLink));
+            given(mockFileLink.getFileName()).willReturn("file.pdf");
+            given(mockFileLink.getFileLink()).willReturn("http://file");
+            given(postRepository.existsByBoardAndContentContains(mockBoard, "http://link"))
+                    .willReturn(false);
+            given(crawledNoticeRepository.findTop20ByOrderByAnnounceDateDesc())
+                    .willReturn(List.of(mockNotice));
+
+            // when
+            service.transferCrawledNoticesToPosts();
+
+            // then
+            verify(postRepository, times(1)).save(postCaptor.capture());
+            Post saved = postCaptor.getValue();
+
+            assertThat(saved.getBoard()).isEqualTo(mockBoard);
+            assertThat(saved.getWriter()).isEqualTo(mockUser);
+            assertThat(saved.getTitle()).isEqualTo("공지제목");
+            String content = saved.getContent();
+            assertThat(content).contains("공지내용");
+            assertThat(content).contains("![공지 이미지](http://img)");
+            assertThat(content).contains("[첨부파일: file.pdf](http://file)");
+            assertThat(content).contains("[공지 링크](http://link)");
+        }
+
+        @Test
+        @DisplayName("이미 존재하는 공지는 저장하지 않음")
+        void transfer_ExistingNotice_SkipsSave() {
+            given(crawledNoticeRepository.findTop20ByOrderByAnnounceDateDesc())
+                    .willReturn(List.of(mockNotice));
+            given(postRepository.existsByBoardAndContentContains(mockBoard, "http://link"))
+                    .willReturn(true);
+            given(mockNotice.getLink()).willReturn("http://link");
+
+            service.transferCrawledNoticesToPosts();
+
+            verify(postRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("예외 상황 테스트")
+    class ExceptionTests {
+
+        @Test
+        @DisplayName("게시판이 없으면 BadRequestException")
+        void transfer_NoBoard_Throws() {
+            given(boardRepository.findByName(anyString())).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.transferCrawledNoticesToPosts())
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessageContaining(MessageUtil.BOARD_NOT_FOUND);
+
+            verify(userRepository, never()).findByStudentId(anyString());
+            verify(crawledNoticeRepository, never()).findTop20ByOrderByAnnounceDateDesc();
+        }
+    }
+}

--- a/src/test/java/net/causw/application/crawler/WebCrawlerServiceTest.java
+++ b/src/test/java/net/causw/application/crawler/WebCrawlerServiceTest.java
@@ -1,0 +1,149 @@
+package net.causw.application.crawler;
+
+import net.causw.adapter.persistence.crawled.CrawledNotice;
+import net.causw.adapter.persistence.crawled.LatestCrawl;
+import net.causw.adapter.persistence.repository.crawled.CrawledNoticeRepository;
+import net.causw.adapter.persistence.repository.crawled.LatestCrawlRepository;
+import net.causw.domain.model.enums.crawl.CrawlCategory;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class WebCrawlerServiceTest {
+
+    @Spy
+    @InjectMocks
+    private WebCrawlerService webCrawlerService;
+
+    @Mock
+    private CrawledNoticeRepository crawledNoticeRepository;
+
+    @Mock
+    private LatestCrawlRepository latestCrawlRepository;
+
+    @Mock private Document mockDocPage1, mockDocPage2;
+    @Mock private Elements rowsNonEmpty, rowsEmpty;
+    @Mock private Element mockRow, titleElement;
+    @Mock private CrawledNotice mockNotice;
+
+    @Test
+    @DisplayName("최초 크롤링 시작: 신규 공지 저장 및 LatestCrawl 최초 저장")
+    void crawl_FirstTime_SaveAndStoreLatest() throws Exception {
+        // given
+        given(latestCrawlRepository.findByCrawlCategory(CrawlCategory.CAU_SW_NOTICE))
+                .willReturn(Optional.empty());
+        doReturn(mockDocPage1, mockDocPage2)
+                .when(webCrawlerService).fetchUrl(anyString());
+
+        given(mockDocPage1.select("table.table-basic tbody tr"))
+                .willReturn(rowsNonEmpty);
+        given(rowsNonEmpty.isEmpty()).willReturn(false);
+        given(rowsNonEmpty.iterator()).willReturn(List.of(mockRow).iterator());
+
+        given(mockRow.select("td.aleft a"))
+                .willReturn(new Elements(titleElement));
+        given(titleElement.absUrl("href"))
+                .willReturn("http://new-link");
+
+        doReturn(mockNotice)
+                .when(webCrawlerService).parseNotice(mockRow, "http://new-link");
+        given(mockNotice.getLink()).willReturn("http://new-link");
+
+        given(mockDocPage2.select("table.table-basic tbody tr"))
+                .willReturn(rowsEmpty);
+        given(rowsEmpty.isEmpty()).willReturn(true);
+
+        // when
+        webCrawlerService.crawlAndSaveCAUSWNoticeSite();
+
+        // then
+        verify(crawledNoticeRepository, times(1))
+                .saveAll(List.of(mockNotice));
+        verify(latestCrawlRepository, times(1)).save(
+                argThat(latestCrawl ->
+                        "http://new-link".equals(latestCrawl.getLatestUrl()) &&
+                                latestCrawl.getCrawlCategory() == CrawlCategory.CAU_SW_NOTICE
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("새로운 공지가 없는 경우: 저장 및 업데이트 안 함")
+    void crawl_NoNewNotices_NoSaveOrUpdate() throws Exception {
+        // given
+        given(latestCrawlRepository.findByCrawlCategory(CrawlCategory.CAU_SW_NOTICE))
+                .willReturn(Optional.of(
+                        LatestCrawl.of("http://old-link", CrawlCategory.CAU_SW_NOTICE)
+                ));
+        doReturn(mockDocPage1).when(webCrawlerService).fetchUrl(anyString());
+
+        given(mockDocPage1.select("table.table-basic tbody tr"))
+                .willReturn(rowsNonEmpty);
+        given(rowsNonEmpty.isEmpty()).willReturn(false);
+        given(rowsNonEmpty.iterator()).willReturn(List.of(mockRow).iterator());
+        given(mockRow.select("td.aleft a"))
+                .willReturn(new Elements(titleElement));
+        given(titleElement.absUrl("href"))
+                .willReturn("http://old-link");
+
+        // when
+        webCrawlerService.crawlAndSaveCAUSWNoticeSite();
+
+        // then
+        verify(crawledNoticeRepository, never()).saveAll(any());
+        verify(latestCrawlRepository, never()).save(any());
+        verify(latestCrawlRepository, never()).updateLatestUrlByCategory(anyString(), any());
+    }
+
+    @Test
+    @DisplayName("새 공지 발견 시: LatestCrawl 업데이트")
+    void crawl_ExistingLatest_NewNotice_UpdatesLatestUrl() throws Exception {
+        // given: LatestCrawl에 old-link 저장
+        given(latestCrawlRepository.findByCrawlCategory(CrawlCategory.CAU_SW_NOTICE))
+                .willReturn(Optional.of(
+                        LatestCrawl.of("http://old-link", CrawlCategory.CAU_SW_NOTICE)
+                ));
+        doReturn(mockDocPage1, mockDocPage2)
+                .when(webCrawlerService).fetchUrl(anyString());
+
+        given(mockDocPage1.select("table.table-basic tbody tr"))
+                .willReturn(rowsNonEmpty);
+        given(rowsNonEmpty.isEmpty()).willReturn(false);
+        given(rowsNonEmpty.iterator()).willReturn(List.of(mockRow).iterator());
+        given(mockRow.select("td.aleft a"))
+                .willReturn(new Elements(titleElement));
+        given(titleElement.absUrl("href"))
+                .willReturn("http://new-link");
+
+        doReturn(mockNotice)
+                .when(webCrawlerService).parseNotice(mockRow, "http://new-link");
+        given(mockNotice.getLink()).willReturn("http://new-link");
+
+        given(mockDocPage2.select("table.table-basic tbody tr"))
+                .willReturn(rowsEmpty);
+        given(rowsEmpty.isEmpty()).willReturn(true);
+
+        // when
+        webCrawlerService.crawlAndSaveCAUSWNoticeSite();
+
+        // then
+        verify(crawledNoticeRepository, times(1)).saveAll(List.of(mockNotice));
+        verify(latestCrawlRepository, times(1))
+                .updateLatestUrlByCategory("http://new-link", CrawlCategory.CAU_SW_NOTICE);
+        verify(latestCrawlRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
### 🚩 관련사항
#807 

### 📢 전달사항

1. 문제점 
    - 소프트웨어학부의 공지를 크롤링하는 로직만 있고, 소프트웨어학부 공지사항에서 게시글 보여주는 로직은 없었음
    - 크롤링을 하지만, Content가 HTML그대로 저장되는 로직이었음.

2.  해결
    - `CrawledToPostTransferService` 파일을 만들어, 크롤링한 것을 저장하는 엔티티인 CrawledNotice에서 일반 게시판의 게시글을 저장하는 Post엔티티로 옮기는 로직 작성
    -`WebCrawlerService`에서 메서드를 분리했고, HTML파싱하는 로직도 작성완료


3.  크롤링 프로세스
    - 소프트웨어학부 공지사항 페이지에서 크롤링을 하고, 가장 최근에 저장된 공지를 latestCrawl 저장함
    - `WebCrawlerService`에서 매일 자정에 자동으로 크롤링 메서드를 실행하는데, 저장된 최신공지와 동일한 공지가 올라올 경우에는 중복 없이 종료함
    - `CrawledToPostTransferService`에서  매일 새벽 1시(01:00) 에 새로 크롤링된 공지사항들을 동문 네트워크 내 소프트웨어학부 공지 게시판(Post) 으로 옮깁니다.


### 📸 스크린샷

<img width="1440" alt="스크린샷 2025-04-29 오후 7 12 58" src="https://github.com/user-attachments/assets/5b6f1865-269f-4914-8ea0-316c2ff4562e" />

<img width="1440" alt="스크린샷 2025-04-29 오후 7 13 05" src="https://github.com/user-attachments/assets/20876024-e041-4086-8c35-292877502e7a" />

<img width="1440" alt="스크린샷 2025-04-29 오후 7 13 12" src="https://github.com/user-attachments/assets/6ffda225-69f1-4e85-9019-3675077bbb57" />


<img width="703" alt="스크린샷 2025-04-29 오후 7 02 26" src="https://github.com/user-attachments/assets/0b040290-2715-4e99-a546-2f789640d1be" />

<img width="699" alt="스크린샷 2025-04-29 오후 7 01 39" src="https://github.com/user-attachments/assets/58cb8b0d-5440-4e59-bdb6-a2c5340f8977" />


### 📃 진행사항
- [x] CrawledNotice에서 Post로 옮기는 로직 구현 완료
- [x] Local환경에서 테스트 완료
- [x] Test코드 작성 완료


### ⚙️ 기타사항
기타 참고사항을 적어주세요.
1. 이미지, 엑셀 파일링크 등을 UUID_FIle에 저장하면 에러가 나서 본문에 링크를 붙였는데, 추후 수정해야 할 듯함. 프론트에서 Markdown 문법을 해석할 수 있도록 변경해서 클릭 가능한 링크로 변경해도 좋을 듯함.
2. 작성자를 20220881 학번(저입니다)으로 고정시켜놨는데, 나중에는 작성자도 빼야함

개발기간: 4d