### PR TITLE
hotfix : notificationLog에 targetParentId 파라미터 추가, 경조사 정보에 신청자 학번/이름 추가

### DIFF
--- a/src/main/java/net/causw/adapter/persistence/notification/Notification.java
+++ b/src/main/java/net/causw/adapter/persistence/notification/Notification.java
@@ -31,12 +31,16 @@ public class Notification extends BaseEntity {
     @Column(name = "target_id")
     private String targetId;
 
+    @Column(name = "target_parent_id")
+    private String targetParentId;
+
     public static Notification of(
             User user,
             String title,
             String body,
             NoticeType noticeType,
-            String targetId
+            String targetId,
+            String targetParentId
     ) {
         return Notification.builder()
                 .user(user)
@@ -44,6 +48,7 @@ public class Notification extends BaseEntity {
                 .body(body)
                 .noticeType(noticeType)
                 .targetId(targetId)
+                .targetParentId(targetParentId)
                 .build();
     }
 

--- a/src/main/java/net/causw/application/dto/ceremony/CeremonyResponseDto.java
+++ b/src/main/java/net/causw/application/dto/ceremony/CeremonyResponseDto.java
@@ -39,5 +39,10 @@ public class CeremonyResponseDto {
     @Schema(description = "경조사 거부 사유")
     private String note;
 
+    @Schema(description = "경조사 신청자 학번")
+    private String applicantStudentId;
+
+    @Schema(description = "경조사 신청자 이름")
+    private String applicantName;
 
 }

--- a/src/main/java/net/causw/application/dto/notification/NotificationResponseDto.java
+++ b/src/main/java/net/causw/application/dto/notification/NotificationResponseDto.java
@@ -28,6 +28,9 @@ public class NotificationResponseDto {
     @Schema(description = "조회할 게시글 id(경조사 or 게시글)", example = "uuid 형식의 String 값입니다")
     private String targetId;
 
+    @Schema(description = "조회할 타겟의 부모 id(게시글의 경우 게시판)", example = "uuid 형식의 String 값입니다")
+    private String targetParentId;
+
     @Schema(description = "알람 확인 여부", example = "true/false")
     private Boolean isRead;
 

--- a/src/main/java/net/causw/application/dto/util/dtoMapper/CeremonyDtoMapper.java
+++ b/src/main/java/net/causw/application/dto/util/dtoMapper/CeremonyDtoMapper.java
@@ -27,6 +27,8 @@ public interface CeremonyDtoMapper {
     @Mapping(target = "ceremonyState", source = "ceremonyState")
     @Mapping(target = "attachedImageUrlList", source = "ceremonyAttachImageList", qualifiedByName = "mapAttachedImages")
     @Mapping(target = "note", source = "note")
+    @Mapping(target = "applicantStudentId", source = "user.studentId")
+    @Mapping(target = "applicantName", source = "user.name")
     CeremonyResponseDto toCeremonyResponseDto(Ceremony ceremony);
 
 

--- a/src/main/java/net/causw/application/dto/util/dtoMapper/NotificationDtoMapper.java
+++ b/src/main/java/net/causw/application/dto/util/dtoMapper/NotificationDtoMapper.java
@@ -16,6 +16,7 @@ public interface NotificationDtoMapper {
     @Mapping(target = "body", source = "notification.body")
     @Mapping(target = "noticeType", source = "notification.noticeType")
     @Mapping(target = "targetId", source = "notification.targetId")
+    @Mapping(target = "targetParentId", source = "notification.targetParentId")
     @Mapping(target = "isRead", source = "isRead")
     NotificationResponseDto toNotificationResponseDto(String notificationLogId, Notification notification, Boolean isRead);
 

--- a/src/main/java/net/causw/application/notification/BoardNotificationService.java
+++ b/src/main/java/net/causw/application/notification/BoardNotificationService.java
@@ -60,8 +60,8 @@ public class BoardNotificationService implements NotificationService {
         List<UserBoardSubscribe> userBoardSubscribeList = userBoardSubscribeRepository.findByBoardAndIsSubscribedTrue(board);
         BoardNotificationDto boardNotificationDto = BoardNotificationDto.of(board, post);
 
-        Notification notification = Notification.of(post.getWriter(), boardNotificationDto.getTitle(), boardNotificationDto.getBody(), NoticeType.BOARD, post.getId());
-
+        Notification notification = Notification.of(post.getWriter(), boardNotificationDto.getTitle(), boardNotificationDto.getBody(), NoticeType.BOARD, post.getId(), board.getId());
+        
         saveNotification(notification);
 
         userBoardSubscribeList.stream()

--- a/src/main/java/net/causw/application/notification/CeremonyNotificationService.java
+++ b/src/main/java/net/causw/application/notification/CeremonyNotificationService.java
@@ -59,7 +59,7 @@ public class CeremonyNotificationService implements NotificationService {
         List<CeremonyNotificationSetting> ceremonyNotificationSettings = ceremonyNotificationSettingRepository.findByAdmissionYearOrSetAll(admissionYear);
         CeremonyNotificationDto ceremonyNotificationDto = CeremonyNotificationDto.of(ceremony);
 
-        Notification notification = Notification.of(ceremony.getUser(), ceremonyNotificationDto.getTitle(), ceremonyNotificationDto.getBody(), NoticeType.CEREMONY, ceremony.getId());
+        Notification notification = Notification.of(ceremony.getUser(), ceremonyNotificationDto.getTitle(), ceremonyNotificationDto.getBody(), NoticeType.CEREMONY, ceremony.getId(), null);
 
         saveNotification(notification);
 

--- a/src/main/java/net/causw/application/notification/CommentNotificationService.java
+++ b/src/main/java/net/causw/application/notification/CommentNotificationService.java
@@ -59,7 +59,7 @@ public class CommentNotificationService implements NotificationService{
         List<UserCommentSubscribe> userCommentSubscribeList = userCommentSubscribeRepository.findByCommentAndIsSubscribedTrue(comment);
         CommentNotificationDto commentNotificationDto = CommentNotificationDto.of(comment, childComment);
 
-        Notification notification = Notification.of(childComment.getWriter(), commentNotificationDto.getTitle(), commentNotificationDto.getBody(), NoticeType.COMMENT, comment.getPost().getId());
+        Notification notification = Notification.of(childComment.getWriter(), commentNotificationDto.getTitle(), commentNotificationDto.getBody(), NoticeType.COMMENT, comment.getPost().getId(), comment.getPost().getBoard().getId());
 
         saveNotification(notification);
 

--- a/src/main/java/net/causw/application/notification/PostNotificationService.java
+++ b/src/main/java/net/causw/application/notification/PostNotificationService.java
@@ -59,7 +59,7 @@ public class PostNotificationService implements NotificationService{
         List<UserPostSubscribe> userPostSubscribeList = userPostSubscribeRepository.findByPostAndIsSubscribedTrue(post);
         PostNotificationDto postNotificationDto = PostNotificationDto.of(post, comment);
 
-        Notification notification = Notification.of(comment.getWriter(), postNotificationDto.getTitle(), postNotificationDto.getBody(), NoticeType.POST, post.getId());
+        Notification notification = Notification.of(comment.getWriter(), postNotificationDto.getTitle(), postNotificationDto.getBody(), NoticeType.POST, post.getId(), post.getBoard().getId());
 
         saveNotification(notification);
 

--- a/src/test/java/net/causw/application/notification/CommentNotificationServiceTest.java
+++ b/src/test/java/net/causw/application/notification/CommentNotificationServiceTest.java
@@ -1,6 +1,7 @@
 package net.causw.application.notification;
 
 import com.google.firebase.messaging.FirebaseMessagingException;
+import net.causw.adapter.persistence.board.Board;
 import net.causw.adapter.persistence.comment.ChildComment;
 import net.causw.adapter.persistence.comment.Comment;
 import net.causw.adapter.persistence.notification.Notification;
@@ -50,6 +51,7 @@ class CommentNotificationServiceTest {
     private Comment mockComment;
     private ChildComment mockChildComment;
     private Post mockPost;
+    private Board mockBoard;
 
     @BeforeEach
     void setUp() {
@@ -68,6 +70,7 @@ class CommentNotificationServiceTest {
         mockUser.setFcmTokens(new HashSet<>());
         mockUser.getFcmTokens().add("dummy-token");
 
+        mockBoard = mock(Board.class);
         mockPost = mock(Post.class);
         mockComment = mock(Comment.class);
         mockChildComment = mock(ChildComment.class);
@@ -80,6 +83,9 @@ class CommentNotificationServiceTest {
     void sendByCommentIsSubscribed_성공() {
         given(mockPost.getId()).willReturn("post-id");
         given(mockChildComment.getWriter()).willReturn(mockUser);
+        given(mockPost.getBoard()).willReturn(mockBoard);
+        given(mockBoard.getId()).willReturn("board-id");
+
 
         given(userCommentSubscribeRepository.findByCommentAndIsSubscribedTrue(mockComment))
                 .willReturn(List.of(UserCommentSubscribe.of(mockUser, mockComment, true)));
@@ -94,6 +100,8 @@ class CommentNotificationServiceTest {
     @DisplayName("댓글 구독 안된 경우 알림 저장, 로그 저장 안됨")
     void sendByCommentIsSubscribed_구독없음() {
         given(mockPost.getId()).willReturn("post-id");
+        given(mockPost.getBoard()).willReturn(mockBoard);
+        given(mockBoard.getId()).willReturn("board-id");
         given(userCommentSubscribeRepository.findByCommentAndIsSubscribedTrue(mockComment))
                 .willReturn(List.of());
 
@@ -110,6 +118,8 @@ class CommentNotificationServiceTest {
         mockUser.getFcmTokens().add(validToken);
 
         given(mockPost.getId()).willReturn("post-id");
+        given(mockPost.getBoard()).willReturn(mockBoard);
+        given(mockBoard.getId()).willReturn("board-id");
         given(mockChildComment.getWriter()).willReturn(mockUser);
         given(mockComment.getContent()).willReturn("부모 댓글");
         given(mockChildComment.getContent()).willReturn("대댓글 내용");
@@ -130,6 +140,8 @@ class CommentNotificationServiceTest {
         mockUser.getFcmTokens().add(invalidToken);
 
         given(mockPost.getId()).willReturn("post-id");
+        given(mockPost.getBoard()).willReturn(mockBoard);
+        given(mockBoard.getId()).willReturn("board-id");
         given(mockChildComment.getWriter()).willReturn(mockUser);
 
         given(userCommentSubscribeRepository.findByCommentAndIsSubscribedTrue(mockComment))

--- a/src/test/java/net/causw/application/notification/NotificationLogServiceTest.java
+++ b/src/test/java/net/causw/application/notification/NotificationLogServiceTest.java
@@ -76,7 +76,7 @@ public class NotificationLogServiceTest {
 
         @BeforeEach
         void setUpCeremonyNotification() {
-            Notification ceremonyNotification = Notification.of(mockUser, "경조사 제목", "내용", NoticeType.CEREMONY, "경조사-id");
+            Notification ceremonyNotification = Notification.of(mockUser, "경조사 제목", "내용", NoticeType.CEREMONY, "경조사-id", null);
             NotificationLog ceremonyLog = NotificationLog.of(mockUser, ceremonyNotification);
             List<NotificationLog> logs = List.of(ceremonyLog);
 
@@ -123,9 +123,9 @@ public class NotificationLogServiceTest {
 
         @BeforeEach
         void setUpGeneralNotification() {
-            Notification boardNotification = Notification.of(mockUser, "게시판 제목", "게시글 내용", NoticeType.BOARD, "게시글-id");
-            Notification postNotification = Notification.of(mockUser, "게시글 제목", "댓글 내용", NoticeType.POST, "게시글-id");
-            Notification commentNotification = Notification.of(mockUser, "댓글 내용", "대댓글 내용", NoticeType.COMMENT, "게시글-id");
+            Notification boardNotification = Notification.of(mockUser, "게시판 제목", "게시글 내용", NoticeType.BOARD, "게시글-id", "게시판-id");
+            Notification postNotification = Notification.of(mockUser, "게시글 제목", "댓글 내용", NoticeType.POST, "게시글-id", "게시판-id");
+            Notification commentNotification = Notification.of(mockUser, "댓글 내용", "대댓글 내용", NoticeType.COMMENT, "게시글-id", "게시판-id");
 
             NotificationLog boardLog = NotificationLog.of(mockUser, boardNotification);
             NotificationLog postLog = NotificationLog.of(mockUser, postNotification);
@@ -180,7 +180,7 @@ public class NotificationLogServiceTest {
 
         @BeforeEach
         void setUpReadNotification() throws Exception {
-            Notification notification = Notification.of(mockUser, "제목", "본문", NoticeType.CEREMONY, "targetId");
+            Notification notification = Notification.of(mockUser, "제목", "본문", NoticeType.CEREMONY, "targetId", "targetParentId");
             unreadLog = NotificationLog.of(mockUser, notification); // isRead = false 초기값
 
             Field idField = unreadLog.getClass().getSuperclass().getDeclaredField("id");

--- a/src/test/java/net/causw/application/notification/PostNotificationServiceTest.java
+++ b/src/test/java/net/causw/application/notification/PostNotificationServiceTest.java
@@ -1,6 +1,7 @@
 package net.causw.application.notification;
 
 import com.google.firebase.messaging.FirebaseMessagingException;
+import net.causw.adapter.persistence.board.Board;
 import net.causw.adapter.persistence.comment.Comment;
 import net.causw.adapter.persistence.notification.Notification;
 import net.causw.adapter.persistence.notification.NotificationLog;
@@ -47,6 +48,7 @@ class PostNotificationServiceTest {
 
     private User mockUser;
     private Post mockPost;
+    private Board mockBoard;
     private Comment mockComment;
 
     @BeforeEach
@@ -66,6 +68,7 @@ class PostNotificationServiceTest {
         mockUser.setFcmTokens(new HashSet<>());
         mockUser.getFcmTokens().add("dummy-token");
 
+        mockBoard = mock(Board.class);
         mockPost = mock(Post.class);
         mockComment = mock(Comment.class);
     }
@@ -74,6 +77,8 @@ class PostNotificationServiceTest {
     @DisplayName("게시글 구독 시 알림 및 로그 저장")
     void sendByPostIsSubscribed_성공() {
         given(mockPost.getId()).willReturn("post-id");
+        given(mockPost.getBoard()).willReturn(mockBoard);
+        given(mockBoard.getId()).willReturn("board-id");
         lenient().when(mockComment.getPost()).thenReturn(mockPost);
 
         given(userPostSubscribeRepository.findByPostAndIsSubscribedTrue(mockPost))
@@ -89,6 +94,8 @@ class PostNotificationServiceTest {
     @DisplayName("게시글 구독 안된 경우 알림 저장, 로그 저장 안됨")
     void sendByPostIsSubscribed_구독없음() {
         given(mockPost.getId()).willReturn("post-id");
+        given(mockPost.getBoard()).willReturn(mockBoard);
+        given(mockBoard.getId()).willReturn("board-id");
         lenient().when(mockComment.getPost()).thenReturn(mockPost);
 
         given(userPostSubscribeRepository.findByPostAndIsSubscribedTrue(mockPost))
@@ -106,6 +113,8 @@ class PostNotificationServiceTest {
         mockUser.getFcmTokens().add("valid-token");
 
         given(mockPost.getId()).willReturn("post-id");
+        given(mockPost.getBoard()).willReturn(mockBoard);
+        given(mockBoard.getId()).willReturn("board-id");
         lenient().when(mockComment.getPost()).thenReturn(mockPost);
         given(mockPost.getTitle()).willReturn("게시글 제목");
         given(mockComment.getContent()).willReturn("댓글 내용");
@@ -127,6 +136,8 @@ class PostNotificationServiceTest {
         mockUser.getFcmTokens().add(invalidToken);
 
         given(mockPost.getId()).willReturn("post-id");
+        given(mockPost.getBoard()).willReturn(mockBoard);
+        given(mockBoard.getId()).willReturn("board-id");
         given(mockComment.getPost()).willReturn(mockPost);
 
         given(userPostSubscribeRepository.findByPostAndIsSubscribedTrue(mockPost))


### PR DESCRIPTION
### 🚩 관련사항
관련된 이슈번호 혹은 PR 번호를 기록합니다.


### 📢 전달사항
경조사, 알람 개발중 프론트 측의 요청사항 해결을 위한 작업입니다.

###경조사 수정사항
경조사 정보 중 신청자의 학번, 이름이 누락되어 applicantStudentId, applicantName으로 dto에 반환값을 추가하였습니다.


###일반알람 수정사항
알람 기능중 일반 알람에서 페이지 라우팅을 위해 기존 targetId에 추가로 게시판 ID를 요청받았습니다. 
현재 구조상 경조사 알람과 함께 NotificationResponseDto로 공통으로 관리하고, 게시판 id 추가로 위해서 별도의 dto로 분리하는 것보단 targetParentId라는 파라미터를 추가해 공통적으로 관리하면서 추후 확장성을 증대시키는 방향으로 수정을 진행하였습니다.

참고할점은 위와같은 방식으로 수정을 진행하면서 경조사 알람에도 targetParentId가 null값으로 반환되는 상황입니다. 


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] 경조사 신청자 학번/이름 추가
- [ ] 일반 알람 게시판 ID 반환


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 