### PR TITLE
chore: 배포 상태 알림 디스코드 봇 관련 cd 스크립트 수정

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -125,7 +125,7 @@ jobs:
         if: always()
         uses: sarisia/actions-status-discord@v1
         with:
-          webhook: ${{ secrets.DISCORD_WEBHOOK_URL_DEV }}
+          webhook: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL_DEV }}
 
           # ✅ status 자동 감지
           status: ${{ job.status }}
@@ -134,7 +134,7 @@ jobs:
           content: >-
             ${{ job.status == 'success' &&
                 format('`[{0}]` 🎉 배포가 성공적으로 완료됐어요!', github.ref_name)
-            || format('`[{0}]` 🚨 배포 실패! <@&123456789012345678> 확인해주세요.', github.ref_name) }}
+            || format('`[{0}]` 🚨 배포 실패! <@&{1}> 확인해주세요.', github.ref_name, secrets.DISCORD_BACKEND_ROLE_ID) }}
 
           # ✅ title: 브랜치 prefix + 이모지 포함
           title: >-

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -121,3 +121,36 @@ jobs:
             sleep 15
             sudo nohup java -jar /home/ubuntu/app/*.jar > ./nohup.out 2>&1 &
 
+      - name: Discord Notify (Always)
+        if: always()
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_URL_DEV }}
+
+          # ✅ status 자동 감지
+          status: ${{ job.status }}
+
+          # ✅ content: 실패 시 역할 멘션 포함
+          content: >-
+            ${{ job.status == 'success' &&
+                format('`[{0}]` 🎉 배포가 성공적으로 완료됐어요!', github.ref_name)
+            || format('`[{0}]` 🚨 배포 실패! <@&123456789012345678> 확인해주세요.', github.ref_name) }}
+
+          # ✅ title: 브랜치 prefix + 이모지 포함
+          title: >-
+            ${{ job.status == 'success' &&
+                format('✅ [{0}] 배포 성공', github.ref_name)
+            || format('❌ [{0}] 배포 실패', github.ref_name) }}
+
+          # ✅ Embed description
+          description: |
+            🛠 브랜치: `${{ github.ref_name }}`
+            🔖 커밋: `${{ github.sha }}`
+            🙋 작성자: `${{ github.actor }}`
+            🔗 [깃허브 액션 로그 보기](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+          # ✅ 상태별 색상
+          color: ${{ job.status == 'success' && '0x00ff00' || '0xff0000' }}
+
+          # ✅ 봇 이름 커스터마이징
+          username: "🚀 배포 봇"

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -125,7 +125,7 @@ jobs:
         if: always()
         uses: sarisia/actions-status-discord@v1
         with:
-          webhook: ${{ secrets.DISCORD_WEBHOOK_URL_MAIN }}
+          webhook: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL_MAIN }}
 
           # ✅ status 자동 감지
           status: ${{ job.status }}
@@ -134,7 +134,7 @@ jobs:
           content: >-
             ${{ job.status == 'success' &&
                 format('`[{0}]` 🎉 배포가 성공적으로 완료됐어요!', github.ref_name)
-            || format('`[{0}]` 🚨 배포 실패! <@&123456789012345678> 확인해주세요.', github.ref_name) }}
+            || format('`[{0}]` 🚨 배포 실패! <@&{1}> 확인해주세요.', github.ref_name, secrets.DISCORD_BACKEND_ROLE_ID) }}
 
           # ✅ title: 브랜치 prefix + 이모지 포함
           title: >-

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -120,3 +120,37 @@ jobs:
             sudo fuser -k -n tcp 8080
             sleep 15
             sudo nohup java -jar /home/ubuntu/app/*.jar > ./nohup.out 2>&1 &
+
+      - name: Discord Notify (Always)
+        if: always()
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_URL_MAIN }}
+
+          # ✅ status 자동 감지
+          status: ${{ job.status }}
+
+          # ✅ content: 실패 시 역할 멘션 포함
+          content: >-
+            ${{ job.status == 'success' &&
+                format('`[{0}]` 🎉 배포가 성공적으로 완료됐어요!', github.ref_name)
+            || format('`[{0}]` 🚨 배포 실패! <@&123456789012345678> 확인해주세요.', github.ref_name) }}
+
+          # ✅ title: 브랜치 prefix + 이모지 포함
+          title: >-
+            ${{ job.status == 'success' &&
+                format('✅ [{0}] 배포 성공', github.ref_name)
+            || format('❌ [{0}] 배포 실패', github.ref_name) }}
+
+          # ✅ Embed description
+          description: |
+            🛠 브랜치: `${{ github.ref_name }}`
+            🔖 커밋: `${{ github.sha }}`
+            🙋 작성자: `${{ github.actor }}`
+            🔗 [깃허브 액션 로그 보기](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+          # ✅ 상태별 색상
+          color: ${{ job.status == 'success' && '0x00ff00' || '0xff0000' }}
+
+          # ✅ 봇 이름 커스터마이징
+          username: "🚀 배포 봇"


### PR DESCRIPTION
### 🚩 관련사항

#842 
main dev 브랜치에서 깃허브 액션 cd 스크립트를 통한 배포 완료 시 배포 상태를 전달하는 단계를 추가했습니다.

### 📢 전달사항

아래 secret들을 추가했습니다.
- `DISCORD_BACKEND_ROLE_ID` : 디스코드 내 `Backend` 역할 id
- `DISCORD_DEPLOY_WEBHOOK_URL_DEV` : `backend-dev-deploy` 채팅 채널 웹훅 url
- `DISCORD_DEPLOY_WEBHOOK_URL_MAIN` : `backend-main-deploy` 채팅 채널 웹훅 url

추후, 역할 변경이나, 웹훅 url에 변경이 일어날 경우 해당 secrets를 수정해주시기 바랍니다.

### 📸 스크린샷

- 성공 시 예시
<img width="490" alt="image" src="https://github.com/user-attachments/assets/928a708d-ca64-4846-81c3-6e0690b5634c" />


- 실패 시 예시
<img width="496" alt="image" src="https://github.com/user-attachments/assets/8ec0dee1-cb98-42a0-8b3a-904fa3dea6e8" />



### 📃 진행사항
- [x] 깃허브 액션 스크립트 수정
- [x] 개인 레포지토리에서 테스트
- [ ] 개발서버 배포 이후 테스트
- [ ] 실서버 배포 이후 테스트


### ⚙️ 기타사항


개발기간: 3h