### PR TITLE
chore: 로그 분석을 위한 로그 파일 형식 수정 및 HTTP 요청당 로그 필터 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,11 @@ dependencies {
 
     //FCM
     implementation 'com.google.firebase:firebase-admin:9.2.0'
+
+    // logback json 형식 관련
+    implementation 'ch.qos.logback.contrib:logback-json-classic:0.1.5'
+    implementation 'ch.qos.logback.contrib:logback-jackson:0.1.5'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
 }
 
 test {

--- a/src/main/java/net/causw/global/filter/RequestLoggingFilter.java
+++ b/src/main/java/net/causw/global/filter/RequestLoggingFilter.java
@@ -1,0 +1,58 @@
+package net.causw.global.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class RequestLoggingFilter extends OncePerRequestFilter {
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request,
+      HttpServletResponse response,
+      FilterChain filterChain)
+      throws ServletException, IOException {
+
+    try {
+      String traceId = UUID.randomUUID().toString().replace("-", "").substring(0, 16);
+      MDC.put("traceId", traceId);
+      MDC.put("path", request.getRequestURI());
+      MDC.put("httpMethod", request.getMethod());
+      MDC.put("remoteIP", request.getRemoteAddr());
+
+      String userId = getUserId();
+      if (userId != null) MDC.put("userId", userId);
+
+      long start = System.currentTimeMillis();
+
+      StatusCaptureWrapper wrappedResponse = new StatusCaptureWrapper(response);
+      filterChain.doFilter(request, wrappedResponse);
+
+      long duration = System.currentTimeMillis() - start;
+      MDC.put("status", String.valueOf(wrappedResponse.getStatus()));
+      MDC.put("duration", String.valueOf(duration));
+
+    } finally {
+      MDC.clear(); // 누락되면 memory leak
+    }
+  }
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    String uri = request.getRequestURI();
+    return uri.startsWith("/static/") || uri.equals("/favicon.ico");
+  }
+
+  private String getUserId() {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    return (auth != null && auth.isAuthenticated()) ? auth.getName() : null;
+  }
+}

--- a/src/main/java/net/causw/global/filter/StatusCaptureWrapper.java
+++ b/src/main/java/net/causw/global/filter/StatusCaptureWrapper.java
@@ -1,0 +1,35 @@
+package net.causw.global.filter;
+
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
+import java.io.IOException;
+
+public class StatusCaptureWrapper extends HttpServletResponseWrapper {
+  private int httpStatus = SC_OK;
+
+  public StatusCaptureWrapper(HttpServletResponse response) {
+    super(response);
+  }
+
+  @Override
+  public void setStatus(int sc) {
+    super.setStatus(sc);
+    this.httpStatus = sc;
+  }
+
+  @Override
+  public void sendError(int sc) throws IOException {
+    super.sendError(sc);
+    this.httpStatus = sc;
+  }
+
+  @Override
+  public void sendError(int sc, String msg) throws IOException {
+    super.sendError(sc, msg);
+    this.httpStatus = sc;
+  }
+
+  public int getStatus() {
+    return this.httpStatus;
+  }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -8,17 +8,65 @@
         </encoder>
     </appender>
 
-    <!-- 일반 파일 출력 설정 -->
+    <appender name="CONSOLE_JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+                <appendLineSeparator>true</appendLineSeparator>
+                <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter" />
+                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSZ</timestampFormat>
+                <timestampFormatTimezoneId>Asia/Seoul</timestampFormatTimezoneId>
+                <includeContextName>true</includeContextName>
+                <includeLoggerName>true</includeLoggerName>
+                <includeThreadName>true</includeThreadName>
+                <includeMdc>true</includeMdc> <!-- traceId, spanId 등 사용 가능 -->
+                <includeFormattedMessage>true</includeFormattedMessage>
+            </layout>
+        </encoder>
+    </appender>
+
+    <!-- 운영용 파일 출력 설정 -->
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_DIR}/general.log</file>
-        <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+                <appendLineSeparator>true</appendLineSeparator>
+                <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter" />
+                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSZ</timestampFormat>
+                <timestampFormatTimezoneId>Asia/Seoul</timestampFormatTimezoneId>
+                <includeContextName>true</includeContextName>
+                <includeLoggerName>true</includeLoggerName>
+                <includeThreadName>true</includeThreadName>
+                <includeMdc>true</includeMdc> <!-- traceId, spanId 등 사용 가능 -->
+                <includeFormattedMessage>true</includeFormattedMessage>
+            </layout>
         </encoder>
         <!-- 지난 로그는 loghistory로 저장 -->
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- 로그 파일 이름 설정: 날짜별 -->
             <fileNamePattern>${LOG_DIR}/general-%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>7</maxHistory> <!-- 로그 파일을 최대 7일 동안 유지 -->
+        </rollingPolicy>
+    </appender>
+
+    <!-- 개발 환경용 로그 파일 설정 -->
+    <appender name="DEV_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/dev.log</file>
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+                <appendLineSeparator>true</appendLineSeparator>
+                <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter" />
+                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSZ</timestampFormat>
+                <timestampFormatTimezoneId>Asia/Seoul</timestampFormatTimezoneId>
+                <includeContextName>true</includeContextName>
+                <includeLoggerName>true</includeLoggerName>
+                <includeThreadName>true</includeThreadName>
+                <includeMdc>true</includeMdc>
+                <includeFormattedMessage>true</includeFormattedMessage>
+            </layout>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/dev-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>3</maxHistory>
         </rollingPolicy>
     </appender>
 
@@ -32,29 +80,9 @@
 
     <!-- 개발 환경 -->
     <springProfile name="dev">
-        <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
-
-        <!-- Discord 알림 관련 -->
-        <springProperty name="DISCORD_WEBHOOK_URL" source="logging.discord.webhook-uri"/>
-        <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
-            <webhookUri>${DISCORD_WEBHOOK_URL}</webhookUri>
-            <layout class="ch.qos.logback.classic.PatternLayout">
-                <pattern>%d{HH:mm:ss} [%thread] [%-5level] %logger{36} - %msg%n```%ex{10}```</pattern>
-            </layout>
-            <username>BACKEND-ERROR!</username>
-            <tts>false</tts>
-        </appender>
-
-        <appender name="ASYNC_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
-            <appender-ref ref="DISCORD" />
-            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                <level>ERROR</level>
-            </filter>
-        </appender>
-
         <root level="INFO">
-            <appender-ref ref="ASYNC_DISCORD"/>
             <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="DEV_FILE"/>
         </root>
     </springProfile>
 


### PR DESCRIPTION
### 🚩 관련사항
#845

### 📢 전달사항

**이번 풀리퀘스트는 그라파나 로키에서 데이터를 분석하기 위해서 로그의 형식을 수정하고, 사용자의 모든 api 요청에 대해서 분석하기 위한 발판을 마련하는 풀리퀘스트입니다.**

관련해서 이슈와 레퍼런스들을 잘 읽어주시면 감사하겠습니다.

- 그라파나 > 로키에서 로그 데이터를 분석하기 위해서, 파일로 저장되는 로그의 포맷을 json 형식으로 수정했습니다.
- 사용자 요청에 대한 데이터를 축적하고 오류에 대해 빠르게 접근하기 위해 HTTP 요청 당 메타데이터를 저장하는 로그 필터를 추가하였습니다.
- 개발환경에서의 로그 또한 파일로 저장하기 위해 `DEV_FILE` 이라는 appender를 추가하였습니다.

### 📸 스크린샷
<img width="1577" alt="image" src="https://github.com/user-attachments/assets/151b40b4-e5c3-442e-a874-75e896eadda7" />


### 📃 진행사항
- [x] 로그백 설정에 json 관련 설정 추가
- [x] 개발 로그백 설정에서 discord 전송 제외하고 로그 파일로 저장하도록 수정
- [x] HTTP 요청별 필터 구성
- [x] measureTime 어노테이션 aspect 작동시 로그 debug 레벨에서 진행하도록 수정
- [x] 로컬에서 요청별 필터 제대로 작동하는 지 확인
- [ ] 개발환경에서 로그 파일 제대로 저장되는 지 확인
- [ ] 실서버 적용 및 그라파나 대시보드 적용된 로그 형식으로 그라파나 대시보드 구성


### ⚙️ 기타사항
json 형식으로 로그가 잘 노출되는지 확인하고 싶으시다면, `logback-spring.xml` 파일에서

```
<!-- 로컬 환경 -->
    <springProfile name="local">
        <root level="INFO">
            <appender-ref ref="CONSOLE"/>
        </root>
    </springProfile>
```
부분을

```
<!-- 로컬 환경 -->
    <springProfile name="local">
        <root level="INFO">
            <appender-ref ref="CONSOLE_JSON"/>
        </root>
    </springProfile>
```

부분으로 변경하시고 테스트 해보시면 됩니다.

개발기간:  5h