### PR TITLE
feat : 크자회 전용 게시판 목록, 홈화면 api 제공

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/controller/CommonController.java
+++ b/app-main/src/main/java/net/causw/app/main/controller/CommonController.java
@@ -30,12 +30,26 @@ public class CommonController {
 
     @GetMapping("/api/v1/home")
     @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("!@security.isGraduatedUser()")
     @Operation(summary = "홈페이지 불러오기 API(완료)",
             description = "동아리에 속하지 않고 삭제되지 않은 게시판과 해당 게시판의 최신 글 3개의 정보를 반환합니다.\n" +
-                    "개발 db상에는 동아리에 속하지 않은 많은 더미 데이터가 있지만 실제 운영될 때는 동아리에 속하지 않는 게시판은 학생회 공지게시판 뿐입니다.")
+                    "개발 db상에는 동아리에 속하지 않은 많은 더미 데이터가 있지만 실제 운영될 때는 동아리에 속하지 않는 게시판은 학생회 공지게시판 뿐입니다.\n" +
+                    "졸업생은 해당 api에 접근이 불가합니다."
+    )
     public List<HomePageResponseDto> getHomePage(@AuthenticationPrincipal CustomUserDetails userDetails) {
 
         return this.homePageService.getHomePage(userDetails.getUser());
+    }
+
+    @GetMapping("/api/v1/home/almumi")
+    @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("@security.isGraduatedUser()")
+    @Operation(summary = "크자회 전용 홈페이지 불러오기 API(완료)",
+            description = "크자회 전용 홈페이지에 보여질 크자회 공지 게시판, 소통 게시판을 반환하기 위한 api 입니다.\n" +
+                    "db상에 isAlumni, isHome 값이 모두 true 인 경우를 반환합니다.")
+    public List<HomePageResponseDto> getAlumniHomePage(@AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        return this.homePageService.getAlumniHomePage(userDetails.getUser());
     }
 
     /*

--- a/app-main/src/main/java/net/causw/app/main/domain/model/entity/board/Board.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/entity/board/Board.java
@@ -39,6 +39,11 @@ public class Board extends BaseEntity {
     @ColumnDefault("false")
     private Boolean isDefault;
 
+    @Column(name = "is_alumni", nullable = false)
+    @ColumnDefault("false")
+    private Boolean isAlumni;
+
+
     @Column(name = "is_anonymous_allowed", nullable = false)
     @ColumnDefault("false")
     private Boolean is_anonymous_allowed;

--- a/app-main/src/main/java/net/causw/app/main/domain/model/entity/board/Board.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/entity/board/Board.java
@@ -43,6 +43,10 @@ public class Board extends BaseEntity {
     @ColumnDefault("false")
     private Boolean isAlumni;
 
+    @Column(name = "is_home", nullable = false)
+    @ColumnDefault("false")
+    private Boolean isHome;
+
 
     @Column(name = "is_anonymous_allowed", nullable = false)
     @ColumnDefault("false")

--- a/app-main/src/main/java/net/causw/app/main/infrastructure/security/SecurityHelper.java
+++ b/app-main/src/main/java/net/causw/app/main/infrastructure/security/SecurityHelper.java
@@ -33,6 +33,16 @@ public class SecurityHelper {
                         .anyMatch(authority -> authority.getAuthority().equals(role)));
     }
 
+    public static boolean isGraduated(CustomUserDetails userDetails){
+        AcademicStatus academicStatus = userDetails.getUser().getAcademicStatus();
+
+        if(academicStatus.equals(AcademicStatus.GRADUATED)){
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     public static boolean isAcademicRecordCertified(CustomUserDetails userDetails) {
         AcademicStatus academicStatus = userDetails.getUser().getAcademicStatus();
 

--- a/app-main/src/main/java/net/causw/app/main/infrastructure/security/SecurityService.java
+++ b/app-main/src/main/java/net/causw/app/main/infrastructure/security/SecurityService.java
@@ -78,6 +78,19 @@ public class SecurityService {
         return isActiveUser() && SecurityHelper.isAcademicRecordCertified(getUserDetails());
     }
 
+
+    /**
+     * 현재 인증된 사용자의 학적이 졸업상태인지 확인하기 위함(GRADUATED)
+     * 크자회 전용 API 에서 사용
+     *
+     * 사용자 상태(UserState)가 ACTIVE고
+     * NONE 역할만을 가지고 있지 않고
+     * 학적 상태(AcademicStatus)가 GRADUATED 인 경우 졸업생으로 판단
+     * */
+    public boolean isGraduatedUser() {
+        return SecurityHelper.isGraduated(getUserDetails());
+    }
+
     private Authentication getAuthentication() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 

--- a/app-main/src/main/java/net/causw/app/main/repository/board/BoardRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/board/BoardRepository.java
@@ -27,4 +27,6 @@ public interface BoardRepository extends JpaRepository<Board, String> {
 
     List<Board> findByIsAlumniTrueAndIsDeletedFalseOrderByCreatedAtAsc();
 
+    List<Board> findByIsHomeTrueAndIsAlumniTrueAndIsDeletedFalse();
+
 }

--- a/app-main/src/main/java/net/causw/app/main/repository/board/BoardRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/board/BoardRepository.java
@@ -24,4 +24,7 @@ public interface BoardRepository extends JpaRepository<Board, String> {
     Boolean existsByName(String name);
 
     Optional<Board> findByName(String name);
+
+    List<Board> findByIsAlumniTrueAndIsDeletedFalseOrderByCreatedAtAsc();
+
 }

--- a/app-main/src/main/java/net/causw/app/main/service/board/BoardService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/board/BoardService.java
@@ -6,6 +6,7 @@ import net.causw.app.main.domain.model.entity.board.BoardApply;
 import net.causw.app.main.domain.model.entity.circle.Circle;
 import net.causw.app.main.domain.model.entity.circle.CircleMember;
 import net.causw.app.main.domain.model.entity.notification.UserBoardSubscribe;
+import net.causw.app.main.domain.model.enums.userAcademicRecord.AcademicStatus;
 import net.causw.app.main.repository.board.BoardApplyRepository;
 import net.causw.app.main.repository.board.BoardRepository;
 import net.causw.app.main.repository.circle.CircleMemberRepository;
@@ -102,6 +103,7 @@ public class BoardService {
             User user
     ) {
         Set<Role> roles = user.getRoles();
+        AcademicStatus academicStatus = user.getAcademicStatus();
 
         ValidatorBucket.of()
                 .consistOf(UserStateValidator.of(user.getState()))
@@ -112,7 +114,11 @@ public class BoardService {
 
         if (roles.contains(Role.ADMIN) || roles.contains(Role.PRESIDENT)) {
             boards = boardRepository.findByOrderByCreatedAtAsc();
-        }else{
+        }
+        else if (academicStatus.equals(AcademicStatus.GRADUATED)){
+            boards = boardRepository.findByIsAlumniTrueAndIsDeletedFalseOrderByCreatedAtAsc();
+        }
+        else{
             List<Circle> joinCircles = circleMemberRepository.findByUser_Id(user.getId()).stream()
                 .filter(circleMember -> circleMember.getStatus() == CircleMemberStatus.MEMBER)
                 .map(CircleMember::getCircle)

--- a/app-main/src/main/resources/db/migration/V20250721174123__AddIsHomeColumnInBoard.sql
+++ b/app-main/src/main/resources/db/migration/V20250721174123__AddIsHomeColumnInBoard.sql
@@ -1,0 +1,4 @@
+-- Migration: AddIsHomeColumnInBoard
+
+ALTER TABLE tb_board
+ADD COLUMN is_home BIT DEFAULT b'0' NOT NULL;

--- a/global/src/main/java/net/causw/global/constant/StaticValue.java
+++ b/global/src/main/java/net/causw/global/constant/StaticValue.java
@@ -16,6 +16,7 @@ public class StaticValue {
     public static final Integer DEFAULT_POST_PAGE_SIZE = 20;
     public static final Integer DEFAULT_COMMENT_PAGE_SIZE = 20;
     public static final Integer HOME_POST_PAGE_SIZE = 3;
+    public static final Integer ALUMNI_HOME_POST_PAGE_SIZE = 4;
     public final static Integer USER_LIST_PAGE_SIZE = 30;
     public final static Integer DEFAULT_NOTIFICATION_PAGE_SIZE = 10;
     public final static Integer SIDE_NOTIFICATION_PAGE_SIZE = 4;


### PR DESCRIPTION
### 🚩 관련사항
#865 


### 📢 전달사항
https://www.notion.so/api-2333d138d33c8020abfdc55bd8fb01cd?source=copy_link

크자회 전용 게시판 목록, 홈화면 제공을 위한 작업입니다.

**변경사항**
- tb_board 테이블에 is_alumni, is_home 컬럼 추가
- is_alumni : 크자회에게 제공될 게시판인지 판단 여부 설정
- is_home : 홈화면에 표출될 게시판인지 판단 여부 설정

위 변경사항에 따라서 크자회 전용 게시판 목록 제어는 추후 운영계에서도 is_alumni 값을 T/F 값으로 제어합니다. 
(크자회 공지게시판, 소통게시판, 서비스 공지게시판, 건의/오류 게시판 예정)
- 크자회 전용 게시판 목록은 별도 api가 아닌 AcademicStatus를 확인하는 분기로 설정하여 기존과 동일한 /boards/main API를 사용합니다.



크자회 전용 홈화면도 마찬가지로 is_alumni 가 true 이고 is_home이 true 인 경우의 게시판을 홈화면으로 불러옵니다. 
(크자회 공지게시판, 소통게시판 예정)
- 전용 홈페이지는 common-controller에 /home/alumni API를 별도로 생성하여 분리하였습니다.
- 기존 /home 과의 접근 구분을 위해 securityservice의 isGraduated를 기준으로 졸업 학적 기준으로 홈화면을 구분하였습니다.
- 공수를 고려하여 기존의 HomePageResponseDto를 그대로 적용하였으나, 추후 디자인 변경과 함께 기존의 /home API 로직을 모두 변경하고 DTO의 정보 과잉 공급문제를 해결할 예정입니다.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항


개발기간: 