### PR TITLE
fix: Flyway 버전 순서 무시 설정 및 충돌 해결 중 삭제된 코드 복원

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -56,7 +56,7 @@ jobs:
 
       # Flyway 마이그레이션
       - name: Run Flyway migration
-        run: ./gradlew flywayMigrate -Penv=dev
+        run: ./gradlew :app-main:flywayMigrate -Dflyway.outOfOrder=true -Penv=dev
 
       # Build -> jar 파일 생성
       - name: Build app-main module

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -40,11 +40,18 @@ jobs:
         run: |
           echo "$FIREBASE_KEY" > $DIR/$FIREBASE_KEY_FILENAME
 
+      # .env.prod 파일 추가
       - name: Copy .env.prod from secret
         env:
           ENV_PROD: ${{ secrets.ENV_PROD }}
         run: |
-          echo "$ENV_PROD" > .env.prod
+          cat <<EOF > .env.prod
+          $ENV_PROD
+          EOF
+
+      # Flyway 마이그레이션
+      - name: Run Flyway migration
+        run: ./gradlew :app-main:flywayMigrate -Dflyway.outOfOrder=true -Penv=prod
 
       # Build -> jar 파일 생성
       - name: Build app-main


### PR DESCRIPTION
### 🚩 관련사항
#882 의 마이그레이션 파일 버전이 먼저 머지된 #883 의 마이그레이션 파일 버전보다 낮아 머지에 실패하였습니다.


### 📢 전달사항
1. main, dev 브랜치로 머지시 파일 버전 순서를 무시하고 마이그레이션하는 설정을 추가했습니다. 
2. 충돌 해결 과정에서 실수로 삭제된 main-cd의 마이그레이션 스텝을 복원했습니다.


### 📸 스크린샷
버전 순서 무시 설정으로 마이그레이션한 뒤 머지에 성공했습니다.
<img width="901" height="143" alt="image" src="https://github.com/user-attachments/assets/f8006bee-ce53-49b7-a894-a0c29df67e8f" />