### PR TITLE
fix : ceremonyresponsedto에 title 추가

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/dto/ceremony/CeremonyResponseDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/ceremony/CeremonyResponseDto.java
@@ -45,4 +45,7 @@ public class CeremonyResponseDto {
     @Schema(description = "경조사 신청자 이름")
     private String applicantName;
 
+    @Schema(description = "경조사 제목")
+    private String title;
+
 }

--- a/app-main/src/main/java/net/causw/app/main/dto/util/dtoMapper/CeremonyDtoMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/util/dtoMapper/CeremonyDtoMapper.java
@@ -29,7 +29,16 @@ public interface CeremonyDtoMapper {
     @Mapping(target = "note", source = "note")
     @Mapping(target = "applicantStudentId", source = "user.studentId")
     @Mapping(target = "applicantName", source = "user.name")
+    @Mapping(target = "title", source = ".", qualifiedByName = "mapTitle")
     CeremonyResponseDto toCeremonyResponseDto(Ceremony ceremony);
+
+    @Named("mapTitle")
+    static String mapTitle(Ceremony ceremony) {
+        return String.format("%s(%s) - %s",
+                ceremony.getUser().getName(),
+                ceremony.getUser().getAdmissionYear().toString(),
+                ceremony.getCeremonyCategory().getLabel());
+    }
 
 
 


### PR DESCRIPTION
### 🚩 관련사항
경조사 상세조회 토스트 알림 에러 해결


### 📢 전달사항
프론트 측에서 경조사 상세에 title을 전달 받지 않는 이유로 관리자 api와의 충돌이 일어난다고 하여 title반환을 추가하였습니다.

title은 별도로 db에 저장되는 것이 아니기 때문에 기존의 데이터와 동일하게 문자열 조합으로 반환할 수 있도록 하였고, 해당내용은 dtomapper에 작성되어 ceremonyresponsedto를 사용하는 모든 api에 공통적용됩니다.

### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 