### PR TITLE
hotfix: 카테고리 enum 누락 해결

### DIFF
--- a/app-main/src/main/resources/db/migration/V20250803171739__add_graduation_to_ceremony_category_enum.sql
+++ b/app-main/src/main/resources/db/migration/V20250803171739__add_graduation_to_ceremony_category_enum.sql
@@ -1,0 +1,4 @@
+-- Migration: add_graduation_to_ceremony_category_enum
+
+ALTER TABLE tb_ceremony
+MODIFY COLUMN ceremony_category ENUM('MARRIAGE','FUNERAL','GRADUATION','ETC') NOT NULL;


### PR DESCRIPTION
### 🚩 관련사항
#894 

### 📢 전달사항
경조사 테이블 (tb_ceremony)의 ceremony_category 필드는 현재 enum값으로 처리되어있음 (MARRIGE, FUNERAL, GRADUATION, ETC)
그러나 현재 dev DB에서는 이 중 GRADUATION이 누락되어있음.
따라서 이를 해결하기 위해 flyway 마이그레이션 스크립트를 추가
(sql문으로 즉각 수정이 가능하나. flyway 사용 목적에 맞게 스크립트 추가)


### 📸 스크린샷
<img width="1408" height="439" alt="image" src="https://github.com/user-attachments/assets/99e6dd60-4055-441d-9683-2a3d661f7898" />


### 📃 진행사항
- [x] flyway 마이그레이션 스크립트 추가


### ⚙️ 기타사항
x

개발기간: 0.5h