### PR TITLE
fix: 사진이 포함된 게시글인데 썸네일에 사진이 보이지 않음

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/service/uuidFile/UuidFileService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/uuidFile/UuidFileService.java
@@ -126,7 +126,7 @@ public class UuidFileService extends StorageManager {
         if (extension == null) {
             throw new BadRequestException(ErrorCode.INVALID_FILE_EXTENSION, MessageUtil.FILE_EXTENSION_IS_NULL);
         }
-        return extension;
+        return extension.toLowerCase();
     }
 
     // 파일 크기, 확장자, Null 검증


### PR DESCRIPTION
### 🚩 관련사항
#898 
https://www.notion.so/2463d138d33c8064ba6fe4ea5b61c7e5?source=copy_link


### 📢 전달사항
사진이 있는 게시글은 원래 썸네일에 사진이 있어야하는데, 보이지 않음
이유는 일부 파일은 파일확장자가 대문자로 되어있는데, 소문자만 비교하는 문제가 있었음.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.
<img width="375" height="231" alt="스크린샷 2025-08-06 오후 8 44 30" src="https://github.com/user-attachments/assets/c59d276e-41bf-4ae3-a25a-c61c311bb300" />
<img width="801" height="166" alt="스크린샷 2025-08-06 오후 8 44 27" src="https://github.com/user-attachments/assets/d9c1f50a-aad2-4880-884f-149a0c97c2a7" />
<img width="160" height="24" alt="스크린샷 2025-08-06 오후 9 45 24" src="https://github.com/user-attachments/assets/ced316fa-4bf8-44b2-827f-93ee189386db" />

### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 1d