### PR TITLE
bug: 경조사 알림 최초 설정 오류 해결

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/dto/ceremony/CreateCeremonyNotificationSettingDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/ceremony/CreateCeremonyNotificationSettingDto.java
@@ -19,4 +19,11 @@ public class CreateCeremonyNotificationSettingDto {
     @NotNull
     @Schema(description = "푸시알람 수신 여부에 대한 flag")
     private boolean notificationActive;
+
+    // 생성자
+    public CreateCeremonyNotificationSettingDto(Set<String> subscribedAdmissionYears, boolean setAll, boolean notificationActive) {
+        this.subscribedAdmissionYears = subscribedAdmissionYears;
+        this.setAll = setAll;
+        this.notificationActive = notificationActive;
+    }
 }

--- a/app-main/src/main/java/net/causw/app/main/repository/notification/CeremonyNotificationSettingRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/notification/CeremonyNotificationSettingRepository.java
@@ -14,6 +14,8 @@ import java.util.Optional;
 public interface CeremonyNotificationSettingRepository extends JpaRepository<CeremonyNotificationSetting, String> {
     Optional<CeremonyNotificationSetting> findByUser(User user);
 
+    boolean existsByUser(User user);
+
     @Query("SELECT DISTINCT c FROM CeremonyNotificationSetting c " +
             "WHERE :admissionYear MEMBER OF c.subscribedAdmissionYears OR c.isSetAll = true")
     List<CeremonyNotificationSetting> findByAdmissionYearOrSetAll(@Param("admissionYear") Integer admissionYear);

--- a/app-main/src/main/java/net/causw/app/main/service/userAcademicRecord/UserAcademicRecordApplicationService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/userAcademicRecord/UserAcademicRecordApplicationService.java
@@ -262,6 +262,16 @@ public class UserAcademicRecordApplicationService {
                 createUserAcademicRecordApplicationRequestDto.getGraduationType());
             userRepository.save(user);
 
+            // 경조사 알림 설정 기본값 생성
+            if (!ceremonyNotificationSettingRepository.existsByUser(user)) {
+                CreateCeremonyNotificationSettingDto defaultDto = new CreateCeremonyNotificationSettingDto(
+                        Collections.emptySet(),
+                        true,
+                        true
+                );
+                ceremonyService.createCeremonyNotificationSettings(user, defaultDto);
+            }
+
             userAcademicRecordLog = UserAcademicRecordLog.createWithGraduation(
                 user,
                 user,
@@ -280,6 +290,16 @@ public class UserAcademicRecordApplicationService {
             // 학적 상태 변경
             user.setAcademicStatus(createUserAcademicRecordApplicationRequestDto.getTargetAcademicStatus());
             userRepository.save(user);
+
+            // 경조사 알림 설정 기본값 생성
+            if (!ceremonyNotificationSettingRepository.existsByUser(user)) {
+                CreateCeremonyNotificationSettingDto defaultDto = new CreateCeremonyNotificationSettingDto(
+                        Collections.emptySet(),
+                        true,
+                        true
+                );
+                ceremonyService.createCeremonyNotificationSettings(user, defaultDto);
+            }
 
             userAcademicRecordLog = UserAcademicRecordLog.create(
                 user,

--- a/app-main/src/main/java/net/causw/app/main/service/userAcademicRecord/UserAcademicRecordApplicationService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/userAcademicRecord/UserAcademicRecordApplicationService.java
@@ -2,6 +2,8 @@ package net.causw.app.main.service.userAcademicRecord;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import net.causw.app.main.dto.ceremony.CreateCeremonyNotificationSettingDto;
+import net.causw.app.main.repository.notification.CeremonyNotificationSettingRepository;
 import net.causw.app.main.repository.user.UserRepository;
 import net.causw.app.main.repository.userAcademicRecord.UserAcademicRecordApplicationRepository;
 import net.causw.app.main.repository.userAcademicRecord.UserAcademicRecordLogRepository;
@@ -15,6 +17,7 @@ import net.causw.app.main.dto.userAcademicRecordApplication.*;
 import net.causw.app.main.dto.util.dtoMapper.SemesterDtoMapper;
 import net.causw.app.main.dto.util.dtoMapper.UserAcademicRecordDtoMapper;
 import net.causw.app.main.repository.userInfo.UserInfoRepository;
+import net.causw.app.main.service.ceremony.CeremonyService;
 import net.causw.app.main.service.excel.UserAcademicRecordExcelService;
 import net.causw.app.main.service.semester.SemesterService;
 import net.causw.app.main.service.userInfo.UserInfoService;
@@ -35,6 +38,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 @MeasureTime
@@ -51,6 +55,8 @@ public class UserAcademicRecordApplicationService {
     private final SemesterService semesterService;
     private final UserAcademicRecordExcelService userAcademicRecordExcelService;
     private final UserInfoService userInfoService;
+    private final CeremonyNotificationSettingRepository ceremonyNotificationSettingRepository;
+    private final CeremonyService ceremonyService;
 
     public void exportUserAcademicRecordListToExcel(HttpServletResponse response) {
         String fileName = "학적상태명단";
@@ -180,6 +186,16 @@ public class UserAcademicRecordApplicationService {
             targetUser.setAcademicStatus(userAcademicRecordApplication.getTargetAcademicStatus());
             targetUser.setCurrentCompletedSemester(userAcademicRecordApplication.getTargetCompletedSemester());
             userRepository.save(targetUser);
+
+            // 경조사 알림 설정 기본값 생성
+            if (!ceremonyNotificationSettingRepository.existsByUser(targetUser)) {
+                CreateCeremonyNotificationSettingDto defaultDto = new CreateCeremonyNotificationSettingDto(
+                        Collections.emptySet(),
+                        true,
+                        true
+                );
+                ceremonyService.createCeremonyNotificationSettings(targetUser, defaultDto);
+            }
         }
 
         // 학적 증빙 신청서 상태 변경

--- a/app-main/src/main/resources/db/migration/V20250809015435__CreateDefaultCeremonyNotificationSettings.sql
+++ b/app-main/src/main/resources/db/migration/V20250809015435__CreateDefaultCeremonyNotificationSettings.sql
@@ -1,6 +1,6 @@
 -- Migration: CreateDefaultCeremonyNotificationSettings
 
-INSERT INTO TB_CEREMONY_PUSH_NOTIFICATION (
+INSERT INTO tb_ceremony_push_notification (
     id,
     user_id,
     is_notification_active,
@@ -18,6 +18,6 @@ SELECT
 FROM tb_user u
 WHERE u.academic_status IN ('ENROLLED', 'GRADUATED', 'LEAVE_OF_ABSENCE')
   AND NOT EXISTS (
-    SELECT 1 FROM TB_CEREMONY_PUSH_NOTIFICATION cpn
+    SELECT 1 FROM tb_ceremony_push_notification cpn
     WHERE cpn.user_id = u.id
 );

--- a/app-main/src/main/resources/db/migration/V20250809015435__CreateDefaultCeremonyNotificationSettings.sql
+++ b/app-main/src/main/resources/db/migration/V20250809015435__CreateDefaultCeremonyNotificationSettings.sql
@@ -1,0 +1,23 @@
+-- Migration: CreateDefaultCeremonyNotificationSettings
+
+INSERT INTO TB_CEREMONY_PUSH_NOTIFICATION (
+    id,
+    user_id,
+    is_notification_active,
+    is_set_all,
+    created_at,
+    updated_at
+)
+SELECT
+    UUID() as id,
+    u.id as user_id,
+    true as is_notification_active,
+    true as is_set_all,
+    NOW() as created_at,
+    NOW() as updated_at
+FROM tb_user u
+WHERE u.academic_status IN ('ENROLLED', 'GRADUATED', 'LEAVE_OF_ABSENCE')
+  AND NOT EXISTS (
+    SELECT 1 FROM TB_CEREMONY_PUSH_NOTIFICATION cpn
+    WHERE cpn.user_id = u.id
+);

--- a/app-main/src/main/resources/db/migration/V20250809015435__CreateDefaultCeremonyNotificationSettings.sql
+++ b/app-main/src/main/resources/db/migration/V20250809015435__CreateDefaultCeremonyNotificationSettings.sql
@@ -17,7 +17,13 @@ SELECT
     NOW() as updated_at
 FROM tb_user u
 WHERE u.academic_status IN ('ENROLLED', 'GRADUATED', 'LEAVE_OF_ABSENCE')
-  AND NOT EXISTS (
+AND u.state = 'ACTIVE'
+AND EXISTS (
+    SELECT 1 FROM user_roles ur
+    WHERE ur.user_id = u.id
+    AND ur.role != 'NONE'
+)
+AND NOT EXISTS (
     SELECT 1 FROM tb_ceremony_push_notification cpn
     WHERE cpn.user_id = u.id
 );


### PR DESCRIPTION
### 🚩 관련사항
#900 
https://www.notion.so/2463d138d33c80d89716de573cf1ff1f?source=copy_link

### 📢 전달사항
현재 경조사 알림이 전달되기 위해서는 사용자가 경조사 알림 생성(`POST /api/v1/ceremony/notification-setting`)을 직접 실행해야 `CeremonyNotificationSetting`이 생성되어 알림이 전달 가능해집니다.
따라서 회원가입 시(정확히는 학적 승인 시)에 자동적으로 초기 설정 (전체 학번에게 받음)으로 알림 설정이 생성되게 구현하였습니다.


### 📸 스크린샷
<img width="2718" height="120" alt="image" src="https://github.com/user-attachments/assets/90304d99-e963-4880-bfb1-34098d98ef3e" />

tb_user에서 해당 회원의 id 확인

<img width="2694" height="116" alt="image" src="https://github.com/user-attachments/assets/f62ccfca-5673-4a61-a543-bf69aa97f31b" />

tb_ceremony_push_notification에서 알림 설정 생성 확인 (is_set_all이 true)

<img width="2717" height="118" alt="image" src="https://github.com/user-attachments/assets/8b600c60-35f1-484d-8420-327161498be6" />

이후 경조사 알림 승인 시

<img width="400" height="848" alt="image" src="https://github.com/user-attachments/assets/2a5743ca-d980-47a3-8795-633f391421d7" />

이렇게 알림이 정상적으로 수신된 것을 확인할 수 있음

### 📃 진행사항
- [x] 경조사 알림 설정 초기 생성

### ⚙️ 기타사항
x

개발기간: 2h