### PR TITLE
fix: 경조사 관리 목록 정렬 & 내 경조사 목록 정렬 및 DTO 수정

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/controller/CeremonyController.java
+++ b/app-main/src/main/java/net/causw/app/main/controller/CeremonyController.java
@@ -3,9 +3,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import net.causw.app.main.domain.model.enums.ceremony.CeremonyContext;
+import net.causw.app.main.dto.notification.CeremonyListNotificationDto;
 import net.causw.app.main.service.ceremony.CeremonyService;
 import net.causw.app.main.dto.ceremony.*;
-import net.causw.app.main.dto.notification.CeremonyNotificationDto;
 import net.causw.app.main.infrastructure.security.userdetails.CustomUserDetails;
 import net.causw.app.main.domain.model.enums.ceremony.CeremonyState;
 import org.springframework.data.domain.Page;
@@ -48,7 +48,7 @@ public class CeremonyController {
     @ResponseStatus(value = HttpStatus.OK)
     @Operation(summary = "사용자 본인의 경조사 신청 내역 조회",
             description = "사용자 본인의 경조사 신청 내역을 조회합니다.")
-    public Page<CeremonyNotificationDto> getCeremonies(
+    public Page<CeremonyListNotificationDto> getCeremonies(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(name = "ceremonyState", defaultValue = "ACCEPT") CeremonyState state,
             @RequestParam(name = "pageNum", defaultValue = "0") Integer pageNum
@@ -62,7 +62,7 @@ public class CeremonyController {
     @PreAuthorize("@security.hasRoleGroup(@RoleGroup.EXECUTIVES)")
     @Operation(summary = "전체 경조사 승인 대기 목록 조회(관리자용)",
             description = "전체 경조사 승인 대기 목록을 조회합니다.")
-    public Page<CeremonyNotificationDto> getAllUserAwaitingCeremonyPage(
+    public Page<CeremonyListNotificationDto> getAllUserAwaitingCeremonyPage(
             @RequestParam(name = "pageNum", defaultValue = "0") Integer pageNum
     ) {
         return ceremonyService.getAllUserAwaitingCeremonyPage(pageNum);

--- a/app-main/src/main/java/net/causw/app/main/dto/notification/CeremonyListNotificationDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/notification/CeremonyListNotificationDto.java
@@ -2,9 +2,6 @@ package net.causw.app.main.dto.notification;
 
 import lombok.Builder;
 import lombok.Getter;
-import net.causw.app.main.domain.model.entity.ceremony.Ceremony;
-
-import java.time.format.DateTimeFormatter;
 
 @Getter
 @Builder
@@ -15,19 +12,4 @@ public class CeremonyListNotificationDto {
     private String date;        // 20xx.0x.0x ~ 20xx.0x.0x
     private String description; // 설명
     private String createdAt;   // 알림 신청일
-
-    public static CeremonyListNotificationDto of(Ceremony ceremony) {
-        return CeremonyListNotificationDto.builder()
-                .id(ceremony.getId())
-                .writer(String.format("%s(%s)",
-                        ceremony.getUser().getName(),
-                        ceremony.getUser().getAdmissionYear() % 100))
-                .category(ceremony.getCeremonyCategory().getLabel())
-                .date(String.format("%s ~ %s",
-                        ceremony.getStartDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")),
-                        ceremony.getEndDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd"))))
-                .description(ceremony.getDescription())
-                .createdAt(ceremony.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
-                .build();
-    }
 }

--- a/app-main/src/main/java/net/causw/app/main/dto/notification/CeremonyListNotificationDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/notification/CeremonyListNotificationDto.java
@@ -1,0 +1,33 @@
+package net.causw.app.main.dto.notification;
+
+import lombok.Builder;
+import lombok.Getter;
+import net.causw.app.main.domain.model.entity.ceremony.Ceremony;
+
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@Builder
+public class CeremonyListNotificationDto {
+    private String id;
+    private String writer;      // 이름(학번)
+    private String category;    // 경조사 종류
+    private String date;        // 20xx.0x.0x ~ 20xx.0x.0x
+    private String description; // 설명
+    private String createdAt;   // 알림 신청일
+
+    public static CeremonyListNotificationDto of(Ceremony ceremony) {
+        return CeremonyListNotificationDto.builder()
+                .id(ceremony.getId())
+                .writer(String.format("%s(%s)",
+                        ceremony.getUser().getName(),
+                        ceremony.getUser().getAdmissionYear() % 100))
+                .category(ceremony.getCeremonyCategory().getLabel())
+                .date(String.format("%s ~ %s",
+                        ceremony.getStartDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")),
+                        ceremony.getEndDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd"))))
+                .description(ceremony.getDescription())
+                .createdAt(ceremony.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
+                .build();
+    }
+}

--- a/app-main/src/main/java/net/causw/app/main/dto/util/dtoMapper/NotificationDtoMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/util/dtoMapper/NotificationDtoMapper.java
@@ -1,10 +1,14 @@
 package net.causw.app.main.dto.util.dtoMapper;
 
+import net.causw.app.main.domain.model.entity.ceremony.Ceremony;
 import net.causw.app.main.domain.model.entity.notification.Notification;
+import net.causw.app.main.dto.notification.CeremonyListNotificationDto;
 import net.causw.app.main.dto.notification.NotificationResponseDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
+
+import java.time.format.DateTimeFormatter;
 
 @Mapper(componentModel = "spring")
 public interface NotificationDtoMapper {
@@ -21,5 +25,26 @@ public interface NotificationDtoMapper {
     NotificationResponseDto toNotificationResponseDto(String notificationLogId, Notification notification, Boolean isRead);
 
 
+    @Mapping(target = "id", source = "id")
+    @Mapping(target = "writer", expression = "java(formatWriter(ceremony))")
+    @Mapping(target = "category", source = "ceremonyCategory.label")
+    @Mapping(target = "date", expression = "java(formatDateRange(ceremony))")
+    @Mapping(target = "description", source = "description")
+    @Mapping(target = "createdAt", expression = "java(formatCreatedAt(ceremony))")
+    CeremonyListNotificationDto toCeremonyListNotificationDto(Ceremony ceremony);
 
+    default String formatWriter(Ceremony ceremony) {
+        return String.format("%s(%s)",
+                ceremony.getUser().getName(),
+                ceremony.getUser().getAdmissionYear() % 100);
+    }
+    default String formatDateRange(Ceremony ceremony) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        return String.format("%s ~ %s",
+                ceremony.getStartDate().format(formatter),
+                ceremony.getEndDate().format(formatter));
+    }
+    default String formatCreatedAt(Ceremony ceremony) {
+        return ceremony.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+    }
 }

--- a/app-main/src/main/java/net/causw/app/main/repository/ceremony/CeremonyRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/ceremony/CeremonyRepository.java
@@ -11,8 +11,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface CeremonyRepository extends JpaRepository<Ceremony, String> {
-    Page<Ceremony> findAllByUserAndCeremonyState(User user, CeremonyState ceremonyState, Pageable pageable);
-    Page<Ceremony> findByCeremonyState(CeremonyState ceremonyState, Pageable pageable);
+    Page<Ceremony> findAllByUserAndCeremonyStateOrderByCreatedAtDesc(User user, CeremonyState ceremonyState, Pageable pageable);
+    Page<Ceremony> findByCeremonyStateOrderByCreatedAtDesc(CeremonyState ceremonyState, Pageable pageable);
 
     Optional<Ceremony> findByIdAndUser(String id, User user);
 

--- a/app-main/src/main/java/net/causw/app/main/service/ceremony/CeremonyService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/ceremony/CeremonyService.java
@@ -7,6 +7,7 @@ import net.causw.app.main.domain.model.entity.notification.CeremonyNotificationS
 import net.causw.app.main.domain.model.enums.ceremony.CeremonyContext;
 import net.causw.app.main.domain.model.enums.user.Role;
 import net.causw.app.main.dto.notification.CeremonyListNotificationDto;
+import net.causw.app.main.dto.util.dtoMapper.NotificationDtoMapper;
 import net.causw.app.main.repository.notification.CeremonyNotificationSettingRepository;
 import net.causw.app.main.repository.ceremony.CeremonyRepository;
 import net.causw.app.main.domain.model.entity.user.User;
@@ -95,14 +96,14 @@ public class CeremonyService {
     public Page<CeremonyListNotificationDto> getUserCeremonyResponses(User user, CeremonyState state, Integer pageNum) {
         Page<Ceremony> ceremonies = ceremonyRepository.findAllByUserAndCeremonyStateOrderByCreatedAtDesc(user, state, pageableFactory.create(pageNum, StaticValue.DEFAULT_PAGE_SIZE));
 
-        return ceremonies.map(CeremonyListNotificationDto::of);
+        return ceremonies.map(NotificationDtoMapper.INSTANCE::toCeremonyListNotificationDto);
     }
 
     @Transactional(readOnly = true)
     public Page<CeremonyListNotificationDto> getAllUserAwaitingCeremonyPage(Integer pageNum) {
         Page<Ceremony> ceremonies = ceremonyRepository.findByCeremonyStateOrderByCreatedAtDesc(CeremonyState.AWAIT, pageableFactory.create(pageNum, StaticValue.DEFAULT_PAGE_SIZE));
 
-        return ceremonies.map(CeremonyListNotificationDto::of);
+        return ceremonies.map(NotificationDtoMapper.INSTANCE::toCeremonyListNotificationDto);
     }
 
     @Transactional(readOnly = true)

--- a/app-main/src/main/java/net/causw/app/main/service/ceremony/CeremonyService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/ceremony/CeremonyService.java
@@ -6,12 +6,12 @@ import net.causw.app.main.domain.model.entity.ceremony.Ceremony;
 import net.causw.app.main.domain.model.entity.notification.CeremonyNotificationSetting;
 import net.causw.app.main.domain.model.enums.ceremony.CeremonyContext;
 import net.causw.app.main.domain.model.enums.user.Role;
+import net.causw.app.main.dto.notification.CeremonyListNotificationDto;
 import net.causw.app.main.repository.notification.CeremonyNotificationSettingRepository;
 import net.causw.app.main.repository.ceremony.CeremonyRepository;
 import net.causw.app.main.domain.model.entity.user.User;
 import net.causw.app.main.domain.model.entity.uuidFile.UuidFile;
 import net.causw.app.main.dto.ceremony.*;
-import net.causw.app.main.dto.notification.CeremonyNotificationDto;
 import net.causw.app.main.dto.util.dtoMapper.CeremonyDtoMapper;
 import net.causw.app.main.service.notification.CeremonyNotificationService;
 import net.causw.app.main.service.pageable.PageableFactory;
@@ -92,17 +92,17 @@ public class CeremonyService {
     }
 
     @Transactional(readOnly = true)
-    public Page<CeremonyNotificationDto> getUserCeremonyResponses(User user, CeremonyState state, Integer pageNum) {
-        Page<Ceremony> ceremonies = ceremonyRepository.findAllByUserAndCeremonyState(user, state, pageableFactory.create(pageNum, StaticValue.DEFAULT_PAGE_SIZE));
+    public Page<CeremonyListNotificationDto> getUserCeremonyResponses(User user, CeremonyState state, Integer pageNum) {
+        Page<Ceremony> ceremonies = ceremonyRepository.findAllByUserAndCeremonyStateOrderByCreatedAtDesc(user, state, pageableFactory.create(pageNum, StaticValue.DEFAULT_PAGE_SIZE));
 
-        return ceremonies.map(CeremonyNotificationDto::of);
+        return ceremonies.map(CeremonyListNotificationDto::of);
     }
 
     @Transactional(readOnly = true)
-    public Page<CeremonyNotificationDto> getAllUserAwaitingCeremonyPage(Integer pageNum) {
-        Page<Ceremony> ceremonies = ceremonyRepository.findByCeremonyState(CeremonyState.AWAIT, pageableFactory.create(pageNum, StaticValue.DEFAULT_PAGE_SIZE));
+    public Page<CeremonyListNotificationDto> getAllUserAwaitingCeremonyPage(Integer pageNum) {
+        Page<Ceremony> ceremonies = ceremonyRepository.findByCeremonyStateOrderByCreatedAtDesc(CeremonyState.AWAIT, pageableFactory.create(pageNum, StaticValue.DEFAULT_PAGE_SIZE));
 
-        return ceremonies.map(CeremonyNotificationDto::of);
+        return ceremonies.map(CeremonyListNotificationDto::of);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
### 🚩 관련사항
#903 
https://www.notion.so/2463d138d33c80f89d03fa73e3d24b67?source=copy_link

### 📢 전달사항
관리자의 경조사 관리 페이지에서 대기중인 경조사 목록이 최신순으로 정렬되지 않아 이를 해결합니다.
또한 해당 페이지의 디자인이 변경되면서 이에 따라 DTO를 수정합니다.
내 경조사 목록도 동일하게 수정합니다.


### 📸 스크린샷
<img width="400" height="862" alt="image" src="https://github.com/user-attachments/assets/6742cab4-1472-48d0-9264-9038c6a8ad4f" />

**전체 경조사 승인 대기 목록 조회 (관리자용) `/api/v1/ceremony/list/await`**

<img width="400" height="850" alt="image" src="https://github.com/user-attachments/assets/491ef64c-c1f6-46ce-889d-f21579688791" />

**사용자 본인의 경조사 신청 내역 조회 `/api/v1/ceremony`**

### 📃 진행사항
- [x] 경조사 목록 최신순 정렬
- [x] DTO 수정
- [x] 내 경조사 목록 수정


### ⚙️ 기타사항
x

개발기간: 1h