### PR TITLE
[FIX]학번 관련 컬럼 모두 nullable로 변경

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/controller/UserController.java
+++ b/app-main/src/main/java/net/causw/app/main/controller/UserController.java
@@ -231,7 +231,8 @@ public class UserController {
             @ApiResponse(responseCode = "4001", description = "중복된 이메일입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
             @ApiResponse(responseCode = "4003", description = "비밀번호 형식이 잘못되었습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
             @ApiResponse(responseCode = "4003", description = "입학년도를 다시 확인해주세요.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
-            @ApiResponse(responseCode = "4001", description = "이미 존재하는 닉네임입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
+            @ApiResponse(responseCode = "4001", description = "이미 존재하는 닉네임입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+            @ApiResponse(responseCode = "4001", description = "이미 존재하는 전화번호입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
     })
     public UserResponseDto signUp(
             @Valid @RequestBody UserCreateRequestDto userCreateDto
@@ -300,7 +301,7 @@ public class UserController {
      */
     @GetMapping(value = "/{studentId}/is-duplicated-student-id")
     @ResponseStatus(value = HttpStatus.OK)
-    @Operation(summary = "닉네임 중복 확인 API")
+    @Operation(summary = "학번 중복 확인 API")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "4001", description = "탈퇴한 계정의 재가입은 관리자에게 문의해주세요.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
@@ -308,6 +309,22 @@ public class UserController {
     })
     public DuplicatedCheckResponseDto isDuplicatedStudentId(@PathVariable("studentId") String studentId) {
         return this.userService.isDuplicatedStudentId(studentId);
+    }
+
+    /**
+     * 전화번호 중복 확인 컨트롤러
+     * @param phoneNumber
+     * @return DuplicatedCheckResponseDto
+     */
+    @GetMapping(value = "/{phoneNumber}/is-duplicated-phone-number")
+    @ResponseStatus(value = HttpStatus.OK)
+    @Operation(summary = "전화번호 중복 확인 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "4001", description = "탈퇴한 계정의 재가입은 관리자에게 문의해주세요.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
+    })
+    public DuplicatedCheckResponseDto isDuplicatedPhoneNumber(@PathVariable("phoneNumber") String phoneNumber) {
+        return this.userService.isDuplicatedPhoneNumber(phoneNumber);
     }
 
     /**
@@ -329,7 +346,8 @@ public class UserController {
             @ApiResponse(responseCode = "4012", description = "접근 권한이 없습니다. 다시 로그인 해주세요. 문제 반복시 관리자에게 문의해주세요.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
             @ApiResponse(responseCode = "4003", description = "입학년도를 다시 확인해주세요.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
             @ApiResponse(responseCode = "5000", description = "User id checked, but exception occurred", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
-            @ApiResponse(responseCode = "4001", description = "이미 존재하는 닉네임입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
+            @ApiResponse(responseCode = "4001", description = "이미 존재하는 닉네임입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+            @ApiResponse(responseCode = "4001", description = "이미 존재하는 전화번호입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
     })
     public UserResponseDto update(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/app-main/src/main/java/net/causw/app/main/domain/model/entity/user/User.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/entity/user/User.java
@@ -164,6 +164,7 @@ public class User extends BaseEntity {
     }
 
     public void updateInfo(UserCreateRequestDto userCreateRequestDto, String encodedPassword) {
+        this.email = userCreateRequestDto.getEmail();
         this.name = userCreateRequestDto.getName();
         this.nickname = userCreateRequestDto.getNickname();
         this.phoneNumber = userCreateRequestDto.getPhoneNumber();

--- a/app-main/src/main/java/net/causw/app/main/domain/model/entity/user/User.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/entity/user/User.java
@@ -163,6 +163,18 @@ public class User extends BaseEntity {
         this.rejectionOrDropReason = reason;
     }
 
+    public void updateInfo(UserCreateRequestDto userCreateRequestDto, String encodedPassword) {
+        this.name = userCreateRequestDto.getName();
+        this.nickname = userCreateRequestDto.getNickname();
+        this.phoneNumber = userCreateRequestDto.getPhoneNumber();
+        this.studentId = userCreateRequestDto.getStudentId();
+        this.admissionYear = userCreateRequestDto.getAdmissionYear();
+        this.major = userCreateRequestDto.getMajor();
+        this.password = encodedPassword;
+        this.state = UserState.AWAIT;
+        this.rejectionOrDropReason = null; // 거절 사유 초기화
+    }
+
     public void removeFcmToken(String targetToken){
         this.fcmTokens.remove(targetToken);
     }

--- a/app-main/src/main/java/net/causw/app/main/domain/model/entity/userAcademicRecord/UserAcademicRecordLog.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/entity/userAcademicRecord/UserAcademicRecordLog.java
@@ -26,7 +26,7 @@ public class UserAcademicRecordLog extends BaseEntity {
     @Column(name = "controlled_user_name", nullable = false)
     private String controlledUserName;
 
-    @Column(name = "controlled_user_student_id", nullable = false)
+    @Column(name = "controlled_user_student_id", nullable = true)
     private String controlledUserStudentId;
 
     @Column(name = "target_user_email", nullable = false)

--- a/app-main/src/main/java/net/causw/app/main/domain/model/entity/userCouncilFee/CouncilFeeFakeUser.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/entity/userCouncilFee/CouncilFeeFakeUser.java
@@ -17,7 +17,7 @@ public class CouncilFeeFakeUser extends BaseEntity {
     @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "student_id", nullable = false)
+    @Column(name = "student_id", nullable = true)
     private String studentId;
 
     @Column(name = "phone_number", nullable = false)

--- a/app-main/src/main/java/net/causw/app/main/domain/model/entity/userCouncilFee/UserCouncilFeeLog.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/entity/userCouncilFee/UserCouncilFeeLog.java
@@ -26,7 +26,7 @@ public class UserCouncilFeeLog extends BaseEntity {
     @Column(name = "controlled_user_name", nullable = false)
     private String controlledUserName;
 
-    @Column(name = "controlled_user_student_id", nullable = false)
+    @Column(name = "controlled_user_student_id", nullable = true)
     private String controlledUserStudentId;
 
     @Enumerated(EnumType.STRING)
@@ -49,7 +49,7 @@ public class UserCouncilFeeLog extends BaseEntity {
     @Column(name = "user_name", nullable = false)
     private String userName;
 
-    @Column(name = "student_id", nullable = false)
+    @Column(name = "student_id", nullable = true)
     private String studentId;
 
     @Column(name = "admission_year", nullable = false)

--- a/app-main/src/main/java/net/causw/app/main/domain/validation/UserStateValidator.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/validation/UserStateValidator.java
@@ -1,5 +1,7 @@
 package net.causw.app.main.domain.validation;
 
+import jakarta.mail.Message;
+import net.causw.global.constant.MessageUtil;
 import net.causw.global.exception.ErrorCode;
 import net.causw.global.exception.UnauthorizedException;
 import net.causw.app.main.domain.model.enums.user.UserState;
@@ -21,21 +23,21 @@ public class UserStateValidator extends AbstractValidator {
         if (this.userState == UserState.DROP) {
             throw new UnauthorizedException(
                     ErrorCode.BLOCKED_USER,
-                    "추방된 사용자 입니다."
+                    MessageUtil.USER_DROPPED_CONTACT_EMAIL
             );
         }
 
         if (this.userState == UserState.INACTIVE) {
             throw new UnauthorizedException(
                     ErrorCode.INACTIVE_USER,
-                    "비활성화된 사용자 입니다."
+                    MessageUtil.USER_INACTIVE_CAN_REJOIN
             );
         }
 
         if (this.userState == UserState.DELETED) {
             throw new UnauthorizedException(
                     ErrorCode.DELETED_USER,
-                    "삭제된 사용자 입니다."
+                    MessageUtil.USER_DELETED
             );
         }
     }

--- a/app-main/src/main/java/net/causw/app/main/dto/user/UserCreateRequestDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/user/UserCreateRequestDto.java
@@ -30,8 +30,7 @@ public class UserCreateRequestDto {
     @Schema(description = "비밀번호", example = "password00!!")
     private String password;
 
-    @NotBlank(message = "학번을 입력해 주세요.")
-    @Schema(description = "학번", example = "20209999")
+    @Schema(description = "학번 (선택사항)", example = "20209999")
     private String studentId;
 
     @NotNull(message = "입학년도를 입력해 주세요.")
@@ -46,6 +45,7 @@ public class UserCreateRequestDto {
     @Schema(description = "학부/학과", example = "소프트웨어학부")
     private String major;
 
+    @NotBlank(message = "전화번호를 입력해 주세요.")
     @Schema(description = "전화번호", example = "010-1234-5678", requiredMode = Schema.RequiredMode.REQUIRED)
     @Pattern(regexp = "^01(?:0|1|[6-9])-(\\d{3}|\\d{4})-\\d{4}$", message = "전화번호 형식에 맞지 않습니다.")
     private String phoneNumber;

--- a/app-main/src/main/java/net/causw/app/main/infrastructure/security/SecurityEndpoints.java
+++ b/app-main/src/main/java/net/causw/app/main/infrastructure/security/SecurityEndpoints.java
@@ -38,6 +38,7 @@ public class SecurityEndpoints {
             of("/api/v1/users/{email}/is-duplicated", GET),
             of("/api/v1/users/{nickname}/is-duplicated-nickname", GET),
             of("/api/v1/users/{studentId}/is-duplicated-student-id", GET),
+            of("/api/v1/users/{phoneNumber}/is-duplicated-phone-number", GET),
             of("/api/v1/users/password", PUT),
             of("/api/v1/users/token/update", PUT),
             of("/api/v1/storage/**"),

--- a/app-main/src/main/java/net/causw/app/main/service/circle/CircleService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/circle/CircleService.java
@@ -471,7 +471,6 @@ public class CircleService {
                 .consistOf(UserStateValidator.of(user.getState()))
                 .consistOf(UserRoleIsNoneValidator.of(roles))
                 .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
-                .consistOf(StudentIdIsNullValidator.of(user.getStudentId()))
                 .validate();
 
         CircleMember circleMember = circleMemberRepository.findByUser_IdAndCircle_Id(user.getId(), circle.getId())

--- a/app-main/src/main/java/net/causw/app/main/service/user/UserService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/user/UserService.java
@@ -548,57 +548,59 @@ public class UserService {
 
     @Transactional
     public UserResponseDto signUp(UserCreateRequestDto userCreateRequestDto) {
-        // email, nickname, phoneNumber, studentId 중복 검사
-        this.userRepository.findByEmail(userCreateRequestDto.getEmail()).ifPresent(
-                email -> {
-                    throw new BadRequestException(
-                            ErrorCode.ROW_ALREADY_EXIST,
-                            MessageUtil.EMAIL_ALREADY_EXIST
-                    );
-                }
-        );
 
-        this.userRepository.findByNickname(userCreateRequestDto.getNickname()).ifPresent(
-                nickname -> {
-                    throw new BadRequestException(
-                            ErrorCode.ROW_ALREADY_EXIST,
-                            MessageUtil.NICKNAME_ALREADY_EXIST
-                    );
-                }
-        );
+        // 이메일로 기존 사용자가 있는지 먼저 확인
+        Optional<User> optionalUser = userRepository.findByEmail(userCreateRequestDto.getEmail());
 
-        this.userRepository.findByPhoneNumber(userCreateRequestDto.getPhoneNumber()).ifPresent(
-                phoneNumber -> {
-                    throw new BadRequestException(
-                            ErrorCode.ROW_ALREADY_EXIST,
-                            MessageUtil.PHONE_NUMBER_ALREADY_EXIST
-                    );
-                }
-        );
+        // AWAIT, REJECT, INACTIVE 상태일 경우, 정보 업데이트 허용
+        if (optionalUser.isPresent()) {
+            User existingUser = optionalUser.get();
+            UserState state = existingUser.getState();
 
-        if (userCreateRequestDto.getStudentId() != null){
-            this.userRepository.findByStudentId(userCreateRequestDto.getStudentId()).ifPresent(
-                studentId -> {
-                    throw new BadRequestException(
-                        ErrorCode.ROW_ALREADY_EXIST,
-                        MessageUtil.STUDENT_ID_ALREADY_EXIST
-                    );
-                }
-            );
+            if (state == UserState.AWAIT || state == UserState.REJECT || state == UserState.INACTIVE) {
+                validateUniqueness(userCreateRequestDto, existingUser);
+
+                existingUser.updateInfo(userCreateRequestDto, passwordEncoder.encode(userCreateRequestDto.getPassword()));
+                userRepository.save(existingUser);
+                ValidatorBucket.of()
+                        .consistOf(ConstraintValidator.of(existingUser, this.validator))
+                        .consistOf(PasswordFormatValidator.of(userCreateRequestDto.getPassword()))
+                        .consistOf(AdmissionYearValidator.of(userCreateRequestDto.getAdmissionYear()))
+                        .consistOf(PhoneNumberFormatValidator.of(userCreateRequestDto.getPhoneNumber()))
+                        .validate();
+
+                return UserDtoMapper.INSTANCE.toUserResponseDto(existingUser, null, null);
+            }
+            // ACTIVE일 경우 중복 에러
+            else if (state == UserState.ACTIVE){
+                throw new BadRequestException(ErrorCode.ROW_ALREADY_EXIST, MessageUtil.EMAIL_ALREADY_EXIST);
+            }
+            // DROP일 경우, 문의 에러 반환
+            else if (state == UserState.DROP) {
+                throw new BadRequestException(ErrorCode.ROW_ALREADY_EXIST, MessageUtil.USER_DROPPED_CONTACT_EMAIL);
+            } else {
+                throw new InternalServerException(ErrorCode.INTERNAL_SERVER, MessageUtil.INTERNAL_SERVER_ERROR);
+            }
         }
+        // 기존 사용자가 없는 경우 -> 신규 가입
+        else {
 
-        User user = User.from(userCreateRequestDto, passwordEncoder.encode(userCreateRequestDto.getPassword()));
-        this.userRepository.save(user);
+            validateUniqueness(userCreateRequestDto, null);
 
-        // password, admission year 값 등 검사
-        ValidatorBucket.of()
-                .consistOf(ConstraintValidator.of(user, this.validator))
-                .consistOf(PasswordFormatValidator.of(userCreateRequestDto.getPassword()))
-                .consistOf(AdmissionYearValidator.of(userCreateRequestDto.getAdmissionYear()))
-                .consistOf(PhoneNumberFormatValidator.of(userCreateRequestDto.getPhoneNumber()))
-                .validate();
+            // 새 사용자 생성
+            User newUser = User.from(userCreateRequestDto, passwordEncoder.encode(userCreateRequestDto.getPassword()));
+            this.userRepository.save(newUser);
 
-        return UserDtoMapper.INSTANCE.toUserResponseDto(user, null, null);
+            // 유효성 검사 수행
+            ValidatorBucket.of()
+                    .consistOf(ConstraintValidator.of(newUser, this.validator))
+                    .consistOf(PasswordFormatValidator.of(userCreateRequestDto.getPassword()))
+                    .consistOf(AdmissionYearValidator.of(userCreateRequestDto.getAdmissionYear()))
+                    .consistOf(PhoneNumberFormatValidator.of(userCreateRequestDto.getPhoneNumber()))
+                    .validate();
+
+            return UserDtoMapper.INSTANCE.toUserResponseDto(newUser, null, null);
+        }
     }
 
     @Transactional
@@ -630,7 +632,7 @@ public class UserService {
 
         return UserDtoMapper.INSTANCE.toUserSignInResponseDto(
                 jwtTokenProvider.createAccessToken(user.getId(), user.getRoles(), user.getState()),
-                jwtTokenProvider.createRefreshToken()
+                refreshToken
         );
     }
 
@@ -645,14 +647,19 @@ public class UserService {
         Optional<User> userFoundByEmail = userRepository.findByEmail(email);
         if (userFoundByEmail.isPresent()) {
             UserState state = userFoundByEmail.get().getState();
-            if (state.equals(UserState.INACTIVE) || state.equals(UserState.DROP)) {
+            // ACTIVE 상태일 경우 중복
+            if (state == UserState.ACTIVE ) {
+                return UserDtoMapper.INSTANCE.toDuplicatedCheckResponseDto(true);
+            }
+            // DROP 상태일 경우, 문의 메시지
+            else if (state == UserState.DROP) {
                 throw new BadRequestException(
                         ErrorCode.ROW_ALREADY_EXIST,
-                        MessageUtil.USER_ALREADY_APPLY
+                        MessageUtil.USER_DROPPED_CONTACT_EMAIL
                 );
             }
         }
-        return UserDtoMapper.INSTANCE.toDuplicatedCheckResponseDto(userFoundByEmail.isPresent());
+        return UserDtoMapper.INSTANCE.toDuplicatedCheckResponseDto(false);
     }
 
     /**
@@ -667,14 +674,20 @@ public class UserService {
         Optional<User> userFoundByNickname = userRepository.findByNickname(nickname);
         if (userFoundByNickname.isPresent()) {
             UserState state = userFoundByNickname.get().getState();
-            if (state.equals(UserState.INACTIVE) || state.equals(UserState.DROP)) {
+
+            // ACTIVE 상태일 경우 중복
+            if (state == UserState.ACTIVE ) {
+                return UserDtoMapper.INSTANCE.toDuplicatedCheckResponseDto(true);
+            }
+            // DROP 상태일 경우, 문의 메시지
+            else if (state == UserState.DROP) {
                 throw new BadRequestException(
                         ErrorCode.ROW_ALREADY_EXIST,
-                        MessageUtil.USER_ALREADY_APPLY
+                        MessageUtil.USER_DROPPED_CONTACT_EMAIL
                 );
             }
         }
-        return UserDtoMapper.INSTANCE.toDuplicatedCheckResponseDto(userFoundByNickname.isPresent());
+        return UserDtoMapper.INSTANCE.toDuplicatedCheckResponseDto(false);
     }
 
     @Transactional(readOnly = true)
@@ -682,14 +695,19 @@ public class UserService {
         Optional<User> userFoundByStudentId = userRepository.findByStudentId(studentId);
         if (userFoundByStudentId.isPresent()) {
             UserState state = userFoundByStudentId.get().getState();
-            if (state.equals(UserState.INACTIVE) || state.equals(UserState.DROP)) {
+            // ACTIVE 상태일 경우 중복
+            if (state == UserState.ACTIVE ) {
+                return UserDtoMapper.INSTANCE.toDuplicatedCheckResponseDto(true);
+            }
+            // DROP 상태일 경우, 문의 메시지
+            else if (state == UserState.DROP) {
                 throw new BadRequestException(
                         ErrorCode.ROW_ALREADY_EXIST,
-                        MessageUtil.USER_ALREADY_APPLY
+                        MessageUtil.USER_DROPPED_CONTACT_EMAIL
                 );
             }
         }
-        return UserDtoMapper.INSTANCE.toDuplicatedCheckResponseDto(userFoundByStudentId.isPresent());
+        return UserDtoMapper.INSTANCE.toDuplicatedCheckResponseDto(false);
     }
 
     /**
@@ -703,14 +721,19 @@ public class UserService {
         Optional<User> userFoundByPhoneNumber = userRepository.findByPhoneNumber(phoneNumber);
         if (userFoundByPhoneNumber.isPresent()) {
             UserState state = userFoundByPhoneNumber.get().getState();
-            if (state.equals(UserState.INACTIVE) || state.equals(UserState.DROP)) {
+            // ACTIVE 상태일 경우 중복
+            if (state == UserState.ACTIVE ) {
+                return UserDtoMapper.INSTANCE.toDuplicatedCheckResponseDto(true);
+            }
+            // DROP 상태일 경우, 문의 메시지
+            else if (state == UserState.DROP) {
                 throw new BadRequestException(
                         ErrorCode.ROW_ALREADY_EXIST,
-                        MessageUtil.USER_ALREADY_APPLY
+                        MessageUtil.USER_DROPPED_CONTACT_EMAIL
                 );
             }
         }
-        return UserDtoMapper.INSTANCE.toDuplicatedCheckResponseDto(userFoundByPhoneNumber.isPresent());
+        return UserDtoMapper.INSTANCE.toDuplicatedCheckResponseDto(false);
     }
 
     @Transactional
@@ -993,6 +1016,47 @@ public class UserService {
         return UserDtoMapper.INSTANCE.toUserResponseDto(droppedUser, null, null);
     }
 
+    /**
+     * 사용자 정보의 유일성을 검증하는 헬퍼 메소드.
+     * DB에 저장하기 전에 호출 애플리케이션 단에서 미리 중복 확인
+     *
+     * @param dto         새로 가입 또는 수정하려는 정보
+     * @param currentUser 정보를 수정하려는 기존 사용자 (신규 가입 시에는 null)
+     */
+    private void validateUniqueness(UserCreateRequestDto dto, User currentUser) {
+        // 닉네임 검사
+        userRepository.findByNickname(dto.getNickname()).ifPresent(foundUser -> {
+            // 다른 유저가 이 닉네임을 이미 사용하고 있다면 에러 발생
+            if (currentUser == null || !foundUser.getId().equals(currentUser.getId())) {
+                if (foundUser.getState() == UserState.ACTIVE | foundUser.getState() == UserState.DROP) {
+                    throw new BadRequestException(ErrorCode.ROW_ALREADY_EXIST, MessageUtil.NICKNAME_ALREADY_EXIST);
+                }
+            }
+        });
+
+        // 전화번호 검사
+        userRepository.findByPhoneNumber(dto.getPhoneNumber()).ifPresent(foundUser -> {
+            // 다른 유저가 이 전화번호를 이미 사용하고 있다면 에러 발생
+            if (currentUser == null || !foundUser.getId().equals(currentUser.getId())) {
+                if (foundUser.getState() == UserState.ACTIVE | foundUser.getState() == UserState.DROP) {
+                    throw new BadRequestException(ErrorCode.ROW_ALREADY_EXIST, MessageUtil.PHONE_NUMBER_ALREADY_EXIST);
+                }
+            }
+        });
+
+        // 학번 검사
+        if (dto.getStudentId() != null) {
+            userRepository.findByStudentId(dto.getStudentId()).ifPresent(foundUser -> {
+                // 다른 유저가 이 학번을 이미 사용하고 있다면 에러 발생
+                if (currentUser == null || !foundUser.getId().equals(currentUser.getId())) {
+                    if (foundUser.getState() == UserState.ACTIVE | foundUser.getState() == UserState.DROP) {
+                        throw new BadRequestException(ErrorCode.ROW_ALREADY_EXIST, MessageUtil.STUDENT_ID_ALREADY_EXIST);
+                    }
+                }
+            });
+        }
+    }
+
     @Transactional(readOnly = true)
     public UserAdmissionResponseDto findAdmissionById(User requestUser, String admissionId) {
         Set<Role> roles = requestUser.getRoles();
@@ -1116,6 +1180,9 @@ public class UserService {
                 .consistOf(UserRoleIsNoneValidator.of(roles))
                 .consistOf(UserRoleValidator.of(roles, Set.of()))
                 .validate();
+
+        //승인 전 중복체크
+        validateDuplicateBeforeAccept(userAdmission.getUser());
 
         // 사용자 역할을 NONE에서 COMMON으로 변경
         userRoleService.updateRole(userAdmission.getUser(), Role.COMMON);
@@ -1479,6 +1546,46 @@ public class UserService {
                     return UserDtoMapper.INSTANCE.toUserResponseDto(user);
                 }
             }).toList();
+    }
+    private void validateDuplicateBeforeAccept(User user) {
+        // 이메일, 닉네임, 전화번호, 학번이 다른 ACTIVE 사용자와 중복되는지 확인
+        userRepository.findByEmail(user.getEmail()).ifPresent(existingUser -> {
+            if (!existingUser.getId().equals(user.getId()) && existingUser.getState() == UserState.ACTIVE) {
+                throw new BadRequestException(
+                        ErrorCode.ROW_ALREADY_EXIST,
+                        MessageUtil.EMAIL_ALREADY_EXIST
+                );
+            }
+        });
+
+        userRepository.findByNickname(user.getNickname()).ifPresent(existingUser -> {
+            if (!existingUser.getId().equals(user.getId()) && existingUser.getState() == UserState.ACTIVE) {
+                throw new BadRequestException(
+                        ErrorCode.ROW_ALREADY_EXIST,
+                        MessageUtil.NICKNAME_ALREADY_EXIST
+                );
+            }
+        });
+
+        userRepository.findByPhoneNumber(user.getPhoneNumber()).ifPresent(existingUser -> {
+            if (!existingUser.getId().equals(user.getId()) && existingUser.getState() == UserState.ACTIVE) {
+                throw new BadRequestException(
+                        ErrorCode.ROW_ALREADY_EXIST,
+                        MessageUtil.PHONE_NUMBER_ALREADY_EXIST
+                );
+            }
+        });
+
+        if (user.getStudentId() != null) {
+            userRepository.findByStudentId(user.getStudentId()).ifPresent(existingUser -> {
+                if (!existingUser.getId().equals(user.getId()) && existingUser.getState() == UserState.ACTIVE) {
+                    throw new BadRequestException(
+                            ErrorCode.ROW_ALREADY_EXIST,
+                            MessageUtil.STUDENT_ID_ALREADY_EXIST
+                    );
+                }
+            });
+        }
     }
 
 

--- a/app-main/src/main/resources/db/migration/V20250811191319__ModifyAllStudentIdNullable.sql
+++ b/app-main/src/main/resources/db/migration/V20250811191319__ModifyAllStudentIdNullable.sql
@@ -1,0 +1,24 @@
+-- Migration: ModifyAllStudentIdNullable
+-- 사용자 테이블: 학번 NULL 허용
+ALTER TABLE tb_user
+    MODIFY COLUMN student_id VARCHAR(255) NULL;
+
+-- 학적 로그 테이블: 대상 사용자/관리자 학번 NULL 허용
+ALTER TABLE tb_user_academic_record_log
+    MODIFY COLUMN target_user_student_id VARCHAR(255) NULL;
+
+ALTER TABLE tb_user_academic_record_log
+    MODIFY COLUMN controlled_user_student_id VARCHAR(255) NULL;
+
+-- 학생회비 사용자 테이블: 학번 NULL 허용
+ALTER TABLE tb_council_fee_fake_user
+    MODIFY COLUMN student_id VARCHAR(255) NULL;
+
+-- 학생회비 로그 테이블: 대상 사용자/관리자 학번 NULL 허용
+ALTER TABLE tb_user_council_fee_log
+    MODIFY COLUMN student_id VARCHAR(255) NULL;
+
+ALTER TABLE tb_user_council_fee_log
+    MODIFY COLUMN controlled_user_student_id VARCHAR(255) NULL;
+
+

--- a/app-main/src/test/java/net/causw/app/main/service/user/UserServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/service/user/UserServiceTest.java
@@ -347,5 +347,26 @@ class UserServiceTest {
       assertThrows(BadRequestException.class, () -> userService.signUp(signUpRequest));
       verify(userRepository, never()).save(any(User.class));
     }
+
+    @Test
+    @DisplayName("탈퇴(INACTIVE)한 사용자가 재가입 성공")
+    void signUp_InactiveUser_Success() {
+      // given
+      existingUser.setState(UserState.INACTIVE);
+      given(userRepository.findByEmail(signUpRequest.getEmail()))
+              .willReturn(Optional.of(existingUser));
+
+      given(userRepository.findByNickname(anyString())).willReturn(Optional.of(existingUser));
+      given(userRepository.findByPhoneNumber(anyString())).willReturn(Optional.of(existingUser));
+      given(userRepository.findByStudentId(anyString())).willReturn(Optional.of(existingUser));
+
+      // when
+      UserResponseDto result = userService.signUp(signUpRequest);
+
+      // then - 재가입 신청이 제대로 되었는지 확인
+      verify(userRepository, times(1)).save(existingUser);
+      assertThat(existingUser.getState()).isEqualTo(UserState.AWAIT);
+      assertThat(result).isNotNull();
+    }
   }
 }

--- a/app-main/src/test/java/net/causw/app/main/service/user/UserServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/service/user/UserServiceTest.java
@@ -3,9 +3,14 @@ package net.causw.app.main.service.user;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+
+import jakarta.validation.Validator;
 import net.causw.app.main.domain.model.entity.post.LikePost;
 import net.causw.app.main.domain.model.entity.post.Post;
+import net.causw.app.main.domain.model.entity.uuidFile.joinEntity.UserProfileImage;
+import net.causw.app.main.dto.user.UserCreateRequestDto;
 import net.causw.app.main.repository.post.FavoritePostRepository;
 import net.causw.app.main.repository.post.LikePostRepository;
 import net.causw.app.main.repository.post.PostRepository;
@@ -25,6 +30,8 @@ import net.causw.app.main.domain.model.enums.user.UserState;
 
 import net.causw.app.main.util.ObjectFixtures;
 import net.causw.global.constant.StaticValue;
+import net.causw.global.exception.BadRequestException;
+import net.causw.global.exception.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -37,8 +44,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -46,10 +56,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -78,6 +85,12 @@ class UserServiceTest {
 
   @Mock
   HttpServletResponse response;
+
+  @Mock
+  PasswordEncoder passwordEncoder;
+
+  @Mock
+  Validator validator;
 
 
   @Nested
@@ -220,5 +233,119 @@ class UserServiceTest {
 
     }
 
+  }
+
+  @Nested
+  @DisplayName("회원가입 테스트")
+  class SignUpTest {
+
+    private UserCreateRequestDto signUpRequest;
+    private User existingUser;
+
+    @BeforeEach
+    void setUp() {
+      signUpRequest = ObjectFixtures.getUserCreateRequestDto();
+      existingUser = ObjectFixtures.getUser();
+
+      ReflectionTestUtils.setField(existingUser, "id", "testUserId");
+
+      // 공통 Mock
+      lenient().when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
+      lenient().when(userDtoMapper.toUserResponseDto(any(User.class), any(), any()))
+              .thenReturn(mock(UserResponseDto.class));
+    }
+
+    @Test
+    @DisplayName("신규 사용자 회원가입 성공")
+    void signUp_NewUser_Success() {
+      // given - 모든 조회에서 빈 결과 반환
+      given(userRepository.findByEmail(anyString())).willReturn(Optional.empty());
+      given(userRepository.findByPhoneNumber(anyString())).willReturn(Optional.empty());
+      given(userRepository.findByStudentId(anyString())).willReturn(Optional.empty());
+      given(userRepository.findByNickname(anyString())).willReturn(Optional.empty());
+
+      // when
+      UserResponseDto result = userService.signUp(signUpRequest);
+
+      // then
+      verify(userRepository, times(1)).save(any(User.class));
+      assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("거절 상태 사용자의 재가입 성공")
+    void signUp_RejectedUser_Success() {
+      // given
+      existingUser.setState(UserState.REJECT);
+      given(userRepository.findByEmail(signUpRequest.getEmail()))
+              .willReturn(Optional.of(existingUser));
+      // 다른 필드들은 동일한 사용자로 반환
+      given(userRepository.findByNickname(anyString())).willReturn(Optional.of(existingUser));
+      given(userRepository.findByPhoneNumber(anyString())).willReturn(Optional.of(existingUser));
+      given(userRepository.findByStudentId(anyString())).willReturn(Optional.of(existingUser));
+
+      // when
+      UserResponseDto result = userService.signUp(signUpRequest);
+
+      // then
+      verify(userRepository, times(1)).save(existingUser);
+      assertThat(existingUser.getState()).isEqualTo(UserState.AWAIT);
+      assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("이메일 오타로 인한 유령 계정 복구 성공")
+    void signUp_EmailTypoRecovery_Success() {
+      // given
+      User ghostUser = ObjectFixtures.getUser();
+      ghostUser.setState(UserState.REJECT);
+      ReflectionTestUtils.setField(ghostUser, "id", "ghostUserId");
+
+      // 잘못 입력한 이메일, 제대로 입력한 전화번호 상황
+      given(userRepository.findByEmail(signUpRequest.getEmail())).willReturn(Optional.empty());
+      given(userRepository.findByPhoneNumber(signUpRequest.getPhoneNumber()))
+              .willReturn(Optional.of(ghostUser));
+      // 다른 정보들은 유령 계정과 일치
+      given(userRepository.findByNickname(anyString())).willReturn(Optional.of(ghostUser));
+      given(userRepository.findByStudentId(anyString())).willReturn(Optional.of(ghostUser));
+
+      // when
+      UserResponseDto result = userService.signUp(signUpRequest);
+
+      // then - 유령 계정이 업데이트되어 저장되었는지 확인
+      verify(userRepository, times(1)).save(ghostUser);
+      assertThat(ghostUser.getEmail()).isEqualTo(signUpRequest.getEmail()); // 이메일 교정 확인
+      assertThat(ghostUser.getState()).isEqualTo(UserState.AWAIT);
+      assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("ACTIVE 유저와 동일한 이메일로 가입 시도 시 실패")
+    void signUp_DuplicateActiveUserEmail_ThrowsException() {
+      // given
+      existingUser.setState(UserState.ACTIVE);
+      given(userRepository.findByEmail(signUpRequest.getEmail()))
+              .willReturn(Optional.of(existingUser));
+
+      // when & then
+      BadRequestException exception = assertThrows(BadRequestException.class,
+              () -> userService.signUp(signUpRequest));
+
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ROW_ALREADY_EXIST);
+      verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("추방(DROP)된 사용자의 재가입 시도 시 실패")
+    void signUp_DroppedUser_ThrowsException() {
+      // given
+      existingUser.setState(UserState.DROP);
+      given(userRepository.findByEmail(signUpRequest.getEmail()))
+              .willReturn(Optional.of(existingUser));
+
+      // when & then
+      assertThrows(BadRequestException.class, () -> userService.signUp(signUpRequest));
+      verify(userRepository, never()).save(any(User.class));
+    }
   }
 }

--- a/app-main/src/test/java/net/causw/app/main/util/ObjectFixtures.java
+++ b/app-main/src/test/java/net/causw/app/main/util/ObjectFixtures.java
@@ -20,20 +20,24 @@ import net.causw.app.main.domain.model.enums.userAcademicRecord.AcademicStatus;
 public class ObjectFixtures {
 
   public static User getUser() {
-    UserCreateRequestDto userCreateRequestDto = new UserCreateRequestDto(
-        "email@cau.ac.kr",
-        "name",
-        "password",
-        "20002000",
-        2000,
-        "nickName",
-        "major",
-        "010-2000-2000"
-    );
-
+    UserCreateRequestDto userCreateRequestDto = getUserCreateRequestDto();
     User user = User.from(userCreateRequestDto, "password");
     user.setCurrentCompletedSemester(4);
     return user;
+  }
+
+
+  public static UserCreateRequestDto getUserCreateRequestDto() {
+    return new UserCreateRequestDto(
+            "email@cau.ac.kr",
+            "name",
+            "password123!",
+            "20002000",
+            2000,
+            "nickName",
+            "major",
+            "010-2000-2000"
+    );
   }
 
   public static CouncilFeeFakeUser getCouncilFeeFakeUser() {

--- a/global/src/main/java/net/causw/global/constant/MessageUtil.java
+++ b/global/src/main/java/net/causw/global/constant/MessageUtil.java
@@ -111,7 +111,7 @@ public class MessageUtil {
     public static final String GRANT_ROLE_NOT_ALLOWED = "권한을 부여할 수 없습니다.";
     public static final String DELEGATE_ROLE_NOT_ALLOWED = "권한을 위임할 수 없습니다.";
     public static final String USER_DROPPED_CONTACT_EMAIL = "추방된 계정입니다. 재가입 문의는 caucsedongne@gmail.com으로 연락해주세요";
-    public static final String USER_INACTIVE_CAN_REJOIN = "탈퇴한 계정입니다. 동일한 정보로 재가입해주세요";
+    public static final String USER_INACTIVE_CAN_REJOIN = "탈퇴한 계정입니다. 새롭게 회원가입을 진행해주세요";
     public static final String USER_DELETED =  "삭제된 계정입니다. 회원가입 페이지에서 새로운 정보로 가입해주세요.";
 
     // Flag

--- a/global/src/main/java/net/causw/global/constant/MessageUtil.java
+++ b/global/src/main/java/net/causw/global/constant/MessageUtil.java
@@ -110,6 +110,9 @@ public class MessageUtil {
     public static final String INVALID_USER_APPLICATION_USER_STATE = "사용자 인증을 할 수 없는 상태의 사용자입니다(AWAIT / REJECT 상태만 인증 가능합니다).";
     public static final String GRANT_ROLE_NOT_ALLOWED = "권한을 부여할 수 없습니다.";
     public static final String DELEGATE_ROLE_NOT_ALLOWED = "권한을 위임할 수 없습니다.";
+    public static final String USER_DROPPED_CONTACT_EMAIL = "추방된 계정입니다. 재가입 문의는 caucsedongne@gmail.com으로 연락해주세요";
+    public static final String USER_INACTIVE_CAN_REJOIN = "탈퇴한 계정입니다. 동일한 정보로 재가입해주세요";
+    public static final String USER_DELETED =  "삭제된 계정입니다. 회원가입 페이지에서 새로운 정보로 가입해주세요.";
 
     // Flag
     public static final String FLAG_UPDATE_FAILED = "플래그 업데이트에 실패했습니다.";


### PR DESCRIPTION
### 🚩 관련사항
#905 


### 📢 전달사항
- 회원가입 후 학적인증 에러가 발생
- 그 외 학번관련해서 null로 받는데, 다른 엔티티에서도 null을 허용으로 하도록 함


### 📸 스크린샷

<img width="1440" height="850" alt="스크린샷 2025-08-11 오후 8 32 46" src="https://github.com/user-attachments/assets/a28f1db3-66e7-480d-af81-0594d2456271" />

<img width="515" height="716" alt="스크린샷 2025-08-11 오후 8 34 20" src="https://github.com/user-attachments/assets/0d0af467-47ae-4cdc-9da7-cd55a491f99a" />


<img width="1251" height="732" alt="스크린샷 2025-08-11 오후 8 34 48" src="https://github.com/user-attachments/assets/e280d887-ecd0-4872-b544-9ebfb4335980" />



### 📃 진행사항

- [ ] 학번 관련 모든 컬럼 nullable = true로 바꾸기
- [ ] 학적인증 잘 되는지 테스트하기

### ⚙️ 기타사항
update로직에서 이메일까지 update하는 로직을 빼먹었었는데, 추가했습니다!

개발기간: 1d