### PR TITLE
hotfix : 학적인증 과정에서 학번 null 에러 발생

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/model/entity/user/User.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/entity/user/User.java
@@ -164,6 +164,7 @@ public class User extends BaseEntity {
     }
 
     public void updateInfo(UserCreateRequestDto userCreateRequestDto, String encodedPassword) {
+        this.email = userCreateRequestDto.getEmail();
         this.name = userCreateRequestDto.getName();
         this.nickname = userCreateRequestDto.getNickname();
         this.phoneNumber = userCreateRequestDto.getPhoneNumber();

--- a/app-main/src/main/java/net/causw/app/main/domain/model/entity/userAcademicRecord/UserAcademicRecordLog.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/entity/userAcademicRecord/UserAcademicRecordLog.java
@@ -26,7 +26,7 @@ public class UserAcademicRecordLog extends BaseEntity {
     @Column(name = "controlled_user_name", nullable = false)
     private String controlledUserName;
 
-    @Column(name = "controlled_user_student_id", nullable = false)
+    @Column(name = "controlled_user_student_id", nullable = true)
     private String controlledUserStudentId;
 
     @Column(name = "target_user_email", nullable = false)

--- a/app-main/src/main/java/net/causw/app/main/domain/model/entity/userCouncilFee/CouncilFeeFakeUser.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/entity/userCouncilFee/CouncilFeeFakeUser.java
@@ -17,7 +17,7 @@ public class CouncilFeeFakeUser extends BaseEntity {
     @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "student_id", nullable = false)
+    @Column(name = "student_id", nullable = true)
     private String studentId;
 
     @Column(name = "phone_number", nullable = false)

--- a/app-main/src/main/java/net/causw/app/main/domain/model/entity/userCouncilFee/UserCouncilFeeLog.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/entity/userCouncilFee/UserCouncilFeeLog.java
@@ -26,7 +26,7 @@ public class UserCouncilFeeLog extends BaseEntity {
     @Column(name = "controlled_user_name", nullable = false)
     private String controlledUserName;
 
-    @Column(name = "controlled_user_student_id", nullable = false)
+    @Column(name = "controlled_user_student_id", nullable = true)
     private String controlledUserStudentId;
 
     @Enumerated(EnumType.STRING)
@@ -49,7 +49,7 @@ public class UserCouncilFeeLog extends BaseEntity {
     @Column(name = "user_name", nullable = false)
     private String userName;
 
-    @Column(name = "student_id", nullable = false)
+    @Column(name = "student_id", nullable = true)
     private String studentId;
 
     @Column(name = "admission_year", nullable = false)

--- a/app-main/src/main/java/net/causw/app/main/service/circle/CircleService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/circle/CircleService.java
@@ -471,7 +471,6 @@ public class CircleService {
                 .consistOf(UserStateValidator.of(user.getState()))
                 .consistOf(UserRoleIsNoneValidator.of(roles))
                 .consistOf(TargetIsDeletedValidator.of(circle.getIsDeleted(), StaticValue.DOMAIN_CIRCLE))
-                .consistOf(StudentIdIsNullValidator.of(user.getStudentId()))
                 .validate();
 
         CircleMember circleMember = circleMemberRepository.findByUser_IdAndCircle_Id(user.getId(), circle.getId())

--- a/app-main/src/main/resources/db/migration/V20250811211017__ModifyAllStudentIdNullable.sql
+++ b/app-main/src/main/resources/db/migration/V20250811211017__ModifyAllStudentIdNullable.sql
@@ -1,0 +1,22 @@
+-- Migration: ModifyAllStudentIdNullable
+-- 사용자 테이블: 학번 NULL 허용
+ALTER TABLE tb_user
+    MODIFY COLUMN student_id VARCHAR(255) NULL;
+
+-- 학적 로그 테이블: 대상 사용자/관리자 학번 NULL 허용
+ALTER TABLE tb_user_academic_record_log
+    MODIFY COLUMN target_user_student_id VARCHAR(255) NULL;
+
+ALTER TABLE tb_user_academic_record_log
+    MODIFY COLUMN controlled_user_student_id VARCHAR(255) NULL;
+
+-- 학생회비 사용자 테이블: 학번 NULL 허용
+ALTER TABLE tb_council_fee_fake_user
+    MODIFY COLUMN student_id VARCHAR(255) NULL;
+
+-- 학생회비 로그 테이블: 대상 사용자/관리자 학번 NULL 허용
+ALTER TABLE tb_user_council_fee_log
+    MODIFY COLUMN student_id VARCHAR(255) NULL;
+
+ALTER TABLE tb_user_council_fee_log
+    MODIFY COLUMN controlled_user_student_id VARCHAR(255) NULL;


### PR DESCRIPTION
### 🚩 관련사항
#910 

### 📢 전달사항
- 회원가입 후 학적인증 에러가 발생
- 그 외 학번관련해서 null로 받는데, 다른 엔티티에서도 null을 허용으로 하도록 함


### 📸 스크린샷

<img width="1440" height="850" alt="스크린샷 2025-08-11 오후 8 32 46" src="https://github.com/user-attachments/assets/a28f1db3-66e7-480d-af81-0594d2456271" />

<img width="515" height="716" alt="스크린샷 2025-08-11 오후 8 34 20" src="https://github.com/user-attachments/assets/0d0af467-47ae-4cdc-9da7-cd55a491f99a" />


<img width="1251" height="732" alt="스크린샷 2025-08-11 오후 8 34 48" src="https://github.com/user-attachments/assets/e280d887-ecd0-4872-b544-9ebfb4335980" />



### 📃 진행사항

- [x] 학번 관련 모든 컬럼 nullable = true로 바꾸기
- [x] 학적인증 잘 되는지 테스트하기

### ⚙️ 기타사항
update로직에서 이메일까지 update하는 로직을 빼먹었었는데, 추가했습니다!

개발기간: 1d