### PR TITLE
feat : 댓글/대댓글 좋아요 취소 기능 추가

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/controller/ChildCommentController.java
+++ b/app-main/src/main/java/net/causw/app/main/controller/ChildCommentController.java
@@ -160,7 +160,7 @@ public class ChildCommentController {
     @Operation(summary = "대댓글 좋아요 취소 API(완료)",
             description = "특정 유저가 특정 대댓글에 좋아요를 누른 걸 취소하는 Api 입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "Created", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "4000", description = "로그인된 사용자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
             @ApiResponse(responseCode = "4000", description = "대댓글을 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
             @ApiResponse(responseCode = "4000", description = "좋아요를 누르지 않은 대댓글입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
@@ -170,7 +170,7 @@ public class ChildCommentController {
             @ApiResponse(responseCode = "4109", description = "가입이 거절된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
             @ApiResponse(responseCode = "4012", description = "접근 권한이 없습니다. 다시 로그인 해주세요. 문제 반복시 관리자에게 문의해주세요.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
     })
-    public void cancelLikePost(
+    public void cancelLikeChildComment(
             @PathVariable("id") String id,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ){

--- a/app-main/src/main/java/net/causw/app/main/controller/ChildCommentController.java
+++ b/app-main/src/main/java/net/causw/app/main/controller/ChildCommentController.java
@@ -8,11 +8,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import net.causw.app.main.service.comment.ChildCommentService;
+
 import net.causw.app.main.dto.comment.ChildCommentCreateRequestDto;
 import net.causw.app.main.dto.comment.ChildCommentResponseDto;
 import net.causw.app.main.dto.comment.ChildCommentUpdateRequestDto;
 import net.causw.app.main.infrastructure.security.userdetails.CustomUserDetails;
+import net.causw.app.main.service.comment.ChildCommentService;
 import net.causw.global.exception.BadRequestException;
 import net.causw.global.exception.UnauthorizedException;
 import org.springframework.http.HttpStatus;
@@ -152,5 +153,27 @@ public class ChildCommentController {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         this.childCommentService.likeChildComment(userDetails.getUser(), id);
+    }
+
+    @DeleteMapping(value ="/{id}/like" )
+    @ResponseStatus(value = HttpStatus.OK)
+    @Operation(summary = "대댓글 좋아요 취소 API(완료)",
+            description = "특정 유저가 특정 대댓글에 좋아요를 누른 걸 취소하는 Api 입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Created", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "4000", description = "로그인된 사용자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+            @ApiResponse(responseCode = "4000", description = "대댓글을 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+            @ApiResponse(responseCode = "4000", description = "좋아요를 누르지 않은 대댓글입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+            @ApiResponse(responseCode = "4102", description = "추방된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+            @ApiResponse(responseCode = "4103", description = "비활성화된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+            @ApiResponse(responseCode = "4104", description = "대기 중인 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+            @ApiResponse(responseCode = "4109", description = "가입이 거절된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+            @ApiResponse(responseCode = "4012", description = "접근 권한이 없습니다. 다시 로그인 해주세요. 문제 반복시 관리자에게 문의해주세요.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+    })
+    public void cancelLikePost(
+            @PathVariable("id") String id,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ){
+        this.childCommentService.cancelLikeChildComment(userDetails.getUser(), id);
     }
 }

--- a/app-main/src/main/java/net/causw/app/main/controller/CommentController.java
+++ b/app-main/src/main/java/net/causw/app/main/controller/CommentController.java
@@ -209,4 +209,26 @@ public class CommentController {
     ){
         return commentService.setCommentSubscribe(userDetails.getUser(), id, false);
     }
+
+    @DeleteMapping(value ="/{id}/like" )
+    @ResponseStatus(value = HttpStatus.OK)
+    @Operation(summary = "댓글 좋아요 취소 API(완료)",
+            description = "특정 유저가 특정 댓글에 좋아요를 누른 걸 취소하는 Api 입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Created", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "4000", description = "로그인된 사용자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+            @ApiResponse(responseCode = "4000", description = "댓글을 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+            @ApiResponse(responseCode = "4000", description = "좋아요를 누르지 않은 댓글입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+            @ApiResponse(responseCode = "4102", description = "추방된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+            @ApiResponse(responseCode = "4103", description = "비활성화된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+            @ApiResponse(responseCode = "4104", description = "대기 중인 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+            @ApiResponse(responseCode = "4109", description = "가입이 거절된 사용자 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UnauthorizedException.class))),
+            @ApiResponse(responseCode = "4012", description = "접근 권한이 없습니다. 다시 로그인 해주세요. 문제 반복시 관리자에게 문의해주세요.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+    })
+    public void cancelLikeComment(
+            @PathVariable("id") String id,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ){
+        this.commentService.cancelLikeComment(userDetails.getUser(), id);
+    }
 }

--- a/app-main/src/main/java/net/causw/app/main/controller/CommentController.java
+++ b/app-main/src/main/java/net/causw/app/main/controller/CommentController.java
@@ -215,7 +215,7 @@ public class CommentController {
     @Operation(summary = "댓글 좋아요 취소 API(완료)",
             description = "특정 유저가 특정 댓글에 좋아요를 누른 걸 취소하는 Api 입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "Created", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "4000", description = "로그인된 사용자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
             @ApiResponse(responseCode = "4000", description = "댓글을 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
             @ApiResponse(responseCode = "4000", description = "좋아요를 누르지 않은 댓글입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),

--- a/app-main/src/main/java/net/causw/app/main/repository/comment/LikeChildCommentRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/comment/LikeChildCommentRepository.java
@@ -8,6 +8,6 @@ public interface LikeChildCommentRepository extends JpaRepository<LikeChildComme
 
     Long countByChildCommentId(String childCommentId);
 
-    void deleteLikeByChildCommentIdAndUserId(String postId, String childCommentId);
+    void deleteLikeByChildCommentIdAndUserId(String childCommentId, String userId);
 
 }

--- a/app-main/src/main/java/net/causw/app/main/repository/comment/LikeChildCommentRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/comment/LikeChildCommentRepository.java
@@ -8,4 +8,6 @@ public interface LikeChildCommentRepository extends JpaRepository<LikeChildComme
 
     Long countByChildCommentId(String childCommentId);
 
+    void deleteLikeByChildCommentIdAndUserId(String postId, String childCommentId);
+
 }

--- a/app-main/src/main/java/net/causw/app/main/repository/comment/LikeCommentRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/comment/LikeCommentRepository.java
@@ -8,4 +8,5 @@ public interface LikeCommentRepository extends JpaRepository<LikeComment, Long> 
 
     Long countByCommentId(String commentId);
 
+    void deleteLikeByCommentIdAndUserId(String commentId, String userId);
 }

--- a/global/src/main/java/net/causw/global/constant/MessageUtil.java
+++ b/global/src/main/java/net/causw/global/constant/MessageUtil.java
@@ -68,6 +68,10 @@ public class MessageUtil {
     public static final String POST_NOT_LIKED = "좋아요을 누르지 않은 게시글입니다.";
     public static final String POST_ALREADY_FAVORITED = "즐겨찾기를 이미 누른 게시글 입니다.";
     public static final String COMMENT_ALREADY_LIKED = "좋아요를 이미 누른 댓글입니다.";
+    public static final String COMMENT_NOT_LIKED = "좋아요를 누르지 않은 댓글입니다.";
+    public static final String CHILD_COMMENT_NOT_LIKED = "좋아요를 누르지 않은 대댓글입니다.";
+
+
     public static final String CHILD_COMMENT_ALREADY_LIKED = "좋아요를 이미 누른 대댓글입니다.";
     public static final String FAVORITE_POST_NOT_FOUND = "즐겨찾기가 되어 있지 않습니다.";
     public static final String FAVORITE_POST_ALREADY_DELETED = "즐겨찾기가 이미 취소되어 있습니다.";


### PR DESCRIPTION
### 🚩 관련사항
https://www.notion.so/2463d138d33c80d6bf30eb7bf01e7fd1?source=copy_link

### 📢 전달사항
게시글의 좋아요 취소를 @bingle625 이 개발한 히스토리가 있어 댓글, 대댓글에도 적용하여 취소 API를 개발하였습니다.

### 📸 스크린샷
댓글 좋아요 삭제
<img width="1615" height="967" alt="image" src="https://github.com/user-attachments/assets/63f7dfaa-bc7a-48eb-87e5-df74d186fb08" />

대댓글 좋아요 삭제
<img width="1600" height="1039" alt="image" src="https://github.com/user-attachments/assets/826629fc-747a-44c7-89bb-c047e13cba37" />
### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 