### PR TITLE
feat: 탈퇴 사용자 비활성 사용자로 전환

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/dto/comment/ChildCommentResponseDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/comment/ChildCommentResponseDto.java
@@ -23,6 +23,9 @@ public class ChildCommentResponseDto {
     @Schema(description = "대댓글 작성자 닉네임", example = "푸앙이")
     private String writerNickname;
 
+    @Schema(description = "표시될 대댓글 작성자 닉네임", example = "[닉네임/비활성 유저/익명]")
+    private String displayWriterNickname;
+
     private Integer writerAdmissionYear;
     private String writerProfileImage;
     private Boolean updatable;

--- a/app-main/src/main/java/net/causw/app/main/dto/comment/CommentResponseDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/comment/CommentResponseDto.java
@@ -25,6 +25,9 @@ public class CommentResponseDto {
     @Schema(description = "댓글 작성자 닉네임", example = "푸앙이")
     private String writerNickname;
 
+    @Schema(description = "표시될 댓글 작성자 닉네임", example = "[닉네임/비활성 유저/익명]")
+    private String displayWriterNickname;
+
     @Schema(description = "작성자의 입학연도", example = "2022")
     private Integer writerAdmissionYear;
 

--- a/app-main/src/main/java/net/causw/app/main/dto/post/PostContentDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/post/PostContentDto.java
@@ -22,6 +22,9 @@ public class PostContentDto {
     @Schema(description = "게시글 작성자 닉네임")
     private String writerNickname;
 
+    @Schema(description = "표시될 게시글 작성자 닉네임", example = "[닉네임/비활성 유저/익명]")
+    private String displayWriterNickname;
+
     @Schema(description = "게시글 생성 시간", example = "2024-01-26T18:40:40.643Z")
     private LocalDateTime createdAt;
 

--- a/app-main/src/main/java/net/causw/app/main/dto/post/PostResponseDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/post/PostResponseDto.java
@@ -34,6 +34,9 @@ public class PostResponseDto {
     @Schema(description = "게시글 작성자 닉네임", example = "푸앙이")
     private String writerNickname;
 
+    @Schema(description = "표시될 게시글 작성자 닉네임", example = "[닉네임/비활성 유저/익명]")
+    private String displayWriterNickname;
+
     @Schema(description = "게시글 작성자의 승인년도", example = "2020")
     private Integer writerAdmissionYear;
 

--- a/app-main/src/main/java/net/causw/app/main/dto/post/PostsResponseDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/post/PostsResponseDto.java
@@ -29,6 +29,9 @@ PostsResponseDto {
     @Schema(description = "게시글 작성자 닉네임", example = "푸앙이")
     private String writerNickname;
 
+    @Schema(description = "표시될 게시글 작성자 닉네임", example = "[닉네임/비활성 유저/익명]")
+    private String displayWriterNickname;
+
     @Schema(description = "게시글 작성자의 승인년도", example = "2020")
     private Integer writerAdmissionYear;
 

--- a/app-main/src/main/java/net/causw/app/main/repository/comment/ChildCommentRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/comment/ChildCommentRepository.java
@@ -17,7 +17,10 @@ public interface ChildCommentRepository extends JpaRepository<ChildComment, Stri
 
     Long countByParentComment_IdAndIsDeletedIsFalse(String parentCommentId);
 
-    @Query("select c from ChildComment c where c.parentComment.id = :parentCommentId order by c.createdAt asc")
+    @Query("SELECT c FROM ChildComment c " +
+            "LEFT JOIN FETCH c.writer w " +
+            "WHERE c.parentComment.id = :parentCommentId " +
+            "ORDER BY c.createdAt ASC")
     List<ChildComment> findByParentComment_Id(@Param("parentCommentId") String parentCommentId);
 
     @Query("SELECT DISTINCT p " +

--- a/app-main/src/main/java/net/causw/app/main/repository/comment/CommentRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/comment/CommentRepository.java
@@ -11,7 +11,12 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, String> {
-    Page<Comment> findByPost_IdOrderByCreatedAt(String postId, Pageable pageable);
+
+    @Query("SELECT c FROM Comment c " +
+            "LEFT JOIN FETCH c.writer w " +
+            "WHERE c.post.id = :postId " +
+            "ORDER BY c.createdAt")
+    Page<Comment> findByPost_IdOrderByCreatedAt(@Param("postId") String postId, Pageable pageable);
 
     Boolean existsByPostIdAndIsDeletedFalse(String postId);
 

--- a/app-main/src/main/java/net/causw/app/main/repository/post/PostRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/post/PostRepository.java
@@ -17,10 +17,19 @@ import java.util.Optional;
 @Repository
 public interface PostRepository extends JpaRepository<Post, String> {
     Page<Post> findAllByBoard_IdAndIsDeletedIsFalseOrderByCreatedAtDesc(String boardId, Pageable pageable);
-    Page<Post> findAllByBoard_IdAndIsDeletedOrderByCreatedAtDesc(String boardId, Pageable pageable, boolean IsDeleted);
-    Page<Post> findAllByBoard_IdOrderByCreatedAtDesc(String boardId, Pageable pageable);
     Optional<Post> findTop1ByBoard_IdAndIsDeletedIsFalseOrderByCreatedAtDesc(String boardId);
-    List<Post> findTop2ByBoard_IdAndIsDeletedOrderByCreatedAtDesc(String boardId, Boolean isDeleted);
+
+    @Query("SELECT p FROM Post p " +
+            "LEFT JOIN FETCH p.writer w " +
+            "WHERE p.board.id = :boardId AND p.isDeleted = :isDeleted " +
+            "ORDER BY p.createdAt DESC")
+    Page<Post> findAllByBoard_IdAndIsDeletedOrderByCreatedAtDesc(@Param("boardId") String boardId, Pageable pageable, @Param("isDeleted") boolean IsDeleted);
+
+    @Query("SELECT p FROM Post p " +
+            "LEFT JOIN FETCH p.writer w " +
+            "WHERE p.board.id = :boardId " +
+            "ORDER BY p.createdAt DESC")
+    Page<Post> findAllByBoard_IdOrderByCreatedAtDesc(@Param("boardId") String boardId, Pageable pageable);
 
     //특정 게시판에서 삭제 여부와 관계없이 title 혹은 content 에 keyword 가 포함된 게시글 검색
     @Query(value = "SELECT * " +


### PR DESCRIPTION
### 🚩 관련사항
탈퇴 사용자 비활성 사용자로 전환
https://www.notion.so/2503d138d33c80bab01eeaef0c36cc41?source=copy_link

### 📢 전달사항
게시글/댓글/대댓글의 작성자가 탈퇴했다면 (state = INACTIVE)
작성자 닉네임이 원래 닉네임이 아니라 '비활성 유저'로 표시됩니다.

만약, 익명을 체크했더라도 (isAnonymous = true) 해당 유저가 탈퇴했다면 역시 '비활성 유저'로 표현됩니다.
따라서 우선순위 : 탈퇴 > 익명 > 기본 입니다.

그러나 익명 처리는 유지하기 위해, `displayWriterNickname`을 response dto에 추가하여
프론트에서 해당 값을 그대로 작성자 닉네임으로 표시할 수 있도록 했습니다.

이런 방식을 통해 탈퇴 복구가 되더라도 state만 ACTIVE로 돌아가면 원래대로 닉네임이 표시되게 됩니다.

또한, N+1 문제 방지를 위해 Repository를 일괄 수정했습니다.
LEFT JOIN을 통해 writer의 정보를 한번에 가져오는 방식으로 수정했습니다.

### 📸 스크린샷

<img width="437" height="365" alt="image" src="https://github.com/user-attachments/assets/b6305fbb-e0f8-4b9e-a30e-de5c6785eb17" />

`/api/v1/boards/main`

<img width="401" height="430" alt="image" src="https://github.com/user-attachments/assets/9e9d6a77-c662-442f-8702-16599c6a986f" />

`/api/v1/comments`

isAnonymous가 true여도 해당 유저가 탈퇴한 유저이기 때문에, '비활성 유저'로 표시되는 것을 확인할 수 있습니다.

### 📃 진행사항
- [x] 게시판 탈퇴 사용자 처리
- [x] 댓글/대댓글 탈퇴 사용자 처리


### ⚙️ 기타사항
프론트에서는 displayWriterNickname을 사용하시기 바랍니다.

개발기간: 4h