### PR TITLE
fix: 경조사 승인 오류 해결

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/service/ceremony/CeremonyService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/ceremony/CeremonyService.java
@@ -151,7 +151,8 @@ public class CeremonyService {
 
         if(updateDto.getTargetCeremonyState() == CeremonyState.ACCEPT){
             Integer writerAdmissionYear = ceremony.getUser().getAdmissionYear();
-            ceremonyNotificationService.sendByAdmissionYear(writerAdmissionYear, ceremony);
+
+            ceremonyNotificationService.sendByAdmissionYear(writerAdmissionYear, updateDto.getCeremonyId());
         }
         else{ // state가 reject, await, close로 바뀌는 경우 (close는 별도 처리)
             ceremony.updateNote(updateDto.getRejectMessage());

--- a/app-main/src/main/java/net/causw/app/main/service/notification/CeremonyNotificationService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/notification/CeremonyNotificationService.java
@@ -9,12 +9,16 @@ import net.causw.app.main.domain.model.entity.notification.CeremonyNotificationS
 import net.causw.app.main.domain.model.entity.notification.Notification;
 import net.causw.app.main.domain.model.entity.notification.NotificationLog;
 import net.causw.app.main.infrastructure.firebase.FcmUtils;
+import net.causw.app.main.repository.ceremony.CeremonyRepository;
 import net.causw.app.main.repository.notification.CeremonyNotificationSettingRepository;
 import net.causw.app.main.repository.notification.NotificationLogRepository;
 import net.causw.app.main.repository.notification.NotificationRepository;
 import net.causw.app.main.domain.model.entity.user.User;
 import net.causw.app.main.dto.notification.CeremonyNotificationDto;
 import net.causw.app.main.domain.model.enums.notification.NoticeType;
+import net.causw.global.constant.MessageUtil;
+import net.causw.global.exception.BadRequestException;
+import net.causw.global.exception.ErrorCode;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,6 +37,7 @@ public class CeremonyNotificationService implements NotificationService {
     private final NotificationRepository notificationRepository;
     private final NotificationLogRepository notificationLogRepository;
     private final FcmUtils fcmUtils;
+    private final CeremonyRepository ceremonyRepository;
 
     @Override
     public void send(User user, String targetToken, String title, String body) {
@@ -59,7 +64,14 @@ public class CeremonyNotificationService implements NotificationService {
 
     @Async("asyncExecutor")
     @Transactional
-    public void sendByAdmissionYear(Integer admissionYear, Ceremony ceremony) {
+    public void sendByAdmissionYear(Integer admissionYear, String ceremonyId) {
+        Ceremony ceremony = ceremonyRepository.findById(ceremonyId).orElseThrow(
+                () -> new BadRequestException(
+                        ErrorCode.ROW_DOES_NOT_EXIST,
+                        MessageUtil.CEREMONY_NOT_FOUND
+                )
+        );
+
         List<CeremonyNotificationSetting> ceremonyNotificationSettings;
 
         if (ceremony.isSetAll()) {

--- a/app-main/src/test/java/net/causw/app/main/service/notification/CeremonyNotificationServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/service/notification/CeremonyNotificationServiceTest.java
@@ -87,7 +87,7 @@ class CeremonyNotificationServiceTest {
         given(ceremonyNotificationSettingRepository.findByAdmissionYearOrSetAll(2023))
                 .willReturn(List.of(CeremonyNotificationSetting.of(Set.of("23", "24"), true, true, mockUser)));
 
-        ceremonyNotificationService.sendByAdmissionYear(2023, mockCeremony);
+        ceremonyNotificationService.sendByAdmissionYear(2023, mockCeremony.getId());
 
         verify(notificationRepository).save(any(Notification.class));
         verify(notificationLogRepository).save(any(NotificationLog.class));
@@ -99,7 +99,7 @@ class CeremonyNotificationServiceTest {
         given(ceremonyNotificationSettingRepository.findByAdmissionYearOrSetAll(2023))
                 .willReturn(List.of());
 
-        ceremonyNotificationService.sendByAdmissionYear(2023, mockCeremony);
+        ceremonyNotificationService.sendByAdmissionYear(2023, mockCeremony.getId());
 
         verify(notificationRepository).save(any(Notification.class));
         verify(notificationLogRepository, never()).save(any(NotificationLog.class));
@@ -117,7 +117,7 @@ class CeremonyNotificationServiceTest {
         given(ceremonyNotificationSettingRepository.findByAdmissionYearOrSetAll(2023))
                 .willReturn(List.of(CeremonyNotificationSetting.of(Set.of("23", "24"), true, true, mockUser)));
 
-        ceremonyNotificationService.sendByAdmissionYear(2023, mockCeremony);
+        ceremonyNotificationService.sendByAdmissionYear(2023, mockCeremony.getId());
 
         verify(firebasePushNotificationService).sendNotification(validToken, "테스트 유저(2023) - 결혼식" , "기간 : 2024-04-15 ~ 2024-04-16");
         verify(notificationLogRepository).save(any(NotificationLog.class));
@@ -148,7 +148,7 @@ class CeremonyNotificationServiceTest {
         }).when(fcmUtils).removeFcmToken(any(User.class), anyString());
 
 
-        ceremonyNotificationService.sendByAdmissionYear(2023, mockCeremony);
+        ceremonyNotificationService.sendByAdmissionYear(2023, mockCeremony.getId());
 
         assertThat(mockUser.getFcmTokens()).doesNotContain(invalidToken);
         assertThat(mockUser.getFcmTokens()).containsExactly("valid-token");


### PR DESCRIPTION
### 🚩 관련사항
#906 
https://www.notion.so/2463d138d33c80a89b1ee20995ada35a?source=copy_link


### 📢 전달사항
경조사 신청 승인이 실패하는 경우가 간헐적으로 발생했음

sendByAdmissionYear는 알림을 전송하는 메소드이기에 통신 시간이 오래 걸릴 것이라 생각해 비동기로 작업했는데,
그로 인해 문제가 발생한 것으로 추정되었음

ceremony 객체를 스레드 사이에서 넘겨서 사용하다보니 문제가 발생한 것으로 확인되어서
ceremonyId를 대신 넘겨서 각 스레드에서 직접 ceremony 객체를 불러와서 사용하는 것으로 방식을 수정함


### 📸 스크린샷
<img width="1460" height="336" alt="image" src="https://github.com/user-attachments/assets/8233b87c-4f5d-423c-99c2-91139418cfb3" />

경조사 신청이 된 모습

<img width="850" height="236" alt="image" src="https://github.com/user-attachments/assets/be2ae58e-03bc-4b02-9b23-3661b6f9b5fc" />

승인 성공

<img width="500" height="855" alt="image" src="https://github.com/user-attachments/assets/86c8a36d-b55e-4759-9ac6-13ceb28276d7" />

알림이 정상적으로 도착했다


### 📃 진행사항
- [x] 로직 개선


### ⚙️ 기타사항
간헐적으로 발생하던 오류라 문제가 완전히 해결되었는지 확인이 어렵습니다.
따라서 QA나 실사용 중 문제가 발생하면 바로 전달해주시기 바랍니다 :)

개발기간: 2h