### PR TITLE
feat: 신고 콘텐츠 목록 & 신고 유저 리스트 페이지 응답 데이터 수정

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/dto/report/ReportedCommentNativeProjection.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/report/ReportedCommentNativeProjection.java
@@ -2,6 +2,8 @@ package net.causw.app.main.dto.report;
 
 import java.time.LocalDateTime;
 
+import net.causw.app.main.domain.model.enums.user.UserState;
+
 /**
  * Native Query 결과를 받기 위한 Projection 인터페이스
  * 댓글과 대댓글 신고를 UNION ALL로 합쳐서 조회할 때 사용
@@ -14,6 +16,7 @@ public interface ReportedCommentNativeProjection {
     String getPostId();
     String getBoardId();
     String getWriterName();
+    UserState getWriterState();
     String getReportReason();
     LocalDateTime getReportCreatedAt();
 }

--- a/app-main/src/main/java/net/causw/app/main/dto/report/ReportedCommentResponseDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/report/ReportedCommentResponseDto.java
@@ -28,6 +28,9 @@ public class ReportedCommentResponseDto {
     
     @Schema(description = "작성자 실명", example = "김철수")
     private final String writerName;
+
+    @Schema(description = "작성자 유저 상태", example = "ACTIVE")
+    private final String writerState;
     
     @Schema(description = "신고 사유 설명", example = "욕설/비하")
     private final String reportReasonDescription;

--- a/app-main/src/main/java/net/causw/app/main/dto/report/ReportedPostNativeProjection.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/report/ReportedPostNativeProjection.java
@@ -2,6 +2,8 @@ package net.causw.app.main.dto.report;
 
 import java.time.LocalDateTime;
 
+import net.causw.app.main.domain.model.enums.user.UserState;
+
 /**
  * Native Query 결과를 받기 위한 Projection 인터페이스
  * 게시글 신고를 조회할 때 사용
@@ -11,6 +13,7 @@ public interface ReportedPostNativeProjection {
     String getPostId();
     String getPostTitle();
     String getWriterName();
+    UserState getWriterState();
     String getReportReason();
     LocalDateTime getReportCreatedAt();
     String getBoardName();

--- a/app-main/src/main/java/net/causw/app/main/dto/report/ReportedPostResponseDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/report/ReportedPostResponseDto.java
@@ -22,7 +22,10 @@ public class ReportedPostResponseDto {
     
     @Schema(description = "작성자 실명", example = "김철수")
     private final String writerName;
-    
+
+    @Schema(description = "작성자 유저 상태", example = "ACTIVE")
+    private final String writerState;
+
     @Schema(description = "신고 사유 설명", example = "낚시/놀람/도배")
     private final String reportReasonDescription;
     

--- a/app-main/src/main/java/net/causw/app/main/dto/report/ReportedUserResponseDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/report/ReportedUserResponseDto.java
@@ -1,5 +1,7 @@
 package net.causw.app.main.dto.report;
 
+import net.causw.app.main.domain.model.enums.user.UserState;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,4 +24,7 @@ public class ReportedUserResponseDto {
     
     @Schema(description = "총 신고 받은 횟수", example = "5")
     private final Integer totalReportCount;
+
+    @Schema(description = "유저 상태", example = "ACTIVE")
+    private final UserState userState;
 }

--- a/app-main/src/main/java/net/causw/app/main/dto/util/dtoMapper/ReportDtoMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/util/dtoMapper/ReportDtoMapper.java
@@ -39,6 +39,7 @@ public interface ReportDtoMapper extends UuidFileToUrlDtoMapper {
     @Mapping(target = "userNickname", source = "nickname")
     @Mapping(target = "totalReportCount", source = "reportCount")
     @Mapping(target = "profileImage", source = "userProfileImage", qualifiedByName = "mapUuidFileToFileUrl")
+    @Mapping(target = "userState", source = "state")
     ReportedUserResponseDto toReportedUserDto(User user);
 
     // Native Query용 description 변환

--- a/app-main/src/main/java/net/causw/app/main/repository/report/ReportRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/report/ReportRepository.java
@@ -54,20 +54,19 @@ public interface ReportRepository extends JpaRepository<Report, String> {
     );
 
     // 신고된 사용자 목록 조회
-    @Query("SELECT u "
-        + "FROM User u "
-        + "WHERE u.reportCount > 0 "
-        + "ORDER BY "
-        + "  CASE u.state "
-        + "    WHEN net.causw.app.main.domain.model.enums.user.UserState.ACTIVE   THEN 0"
-        + "    WHEN net.causw.app.main.domain.model.enums.user.UserState.AWAIT    THEN 1"
-        + "    WHEN net.causw.app.main.domain.model.enums.user.UserState.INACTIVE THEN 2"
-        + "    WHEN net.causw.app.main.domain.model.enums.user.UserState.REJECT   THEN 3"
-        + "    WHEN net.causw.app.main.domain.model.enums.user.UserState.DROP     THEN 4"
-        + "    WHEN net.causw.app.main.domain.model.enums.user.UserState.DELETED  THEN 5"
-        + "    ELSE 99"
-        + "  END,"
-        + "  u.reportCount DESC")
+    @Query("SELECT u FROM User u " +
+        "WHERE u.reportCount > 0 " +
+        "ORDER BY " +
+        "CASE " +
+        "  WHEN u.state = 'ACTIVE' THEN 0 " +
+        "  WHEN u.state = 'AWAIT' THEN 1 " +
+        "  WHEN u.state = 'INACTIVE' THEN 2 " +
+        "  WHEN u.state = 'REJECT' THEN 3 " +
+        "  WHEN u.state = 'DROP' THEN 4 " +
+        "  WHEN u.state = 'DELETED' THEN 5 " +
+        "  ELSE 99 " +
+        "END, " +
+        "u.reportCount DESC")
     Page<User> findReportedUsersByReportCount(Pageable pageable);
 
     // 댓글, 대댓글 신고 목록 조회(메모리 문제를 막기 위해 Native Query와 UNION ALL로 DB 내에서 처리하도록 함)

--- a/app-main/src/main/java/net/causw/app/main/repository/report/ReportRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/report/ReportRepository.java
@@ -54,19 +54,22 @@ public interface ReportRepository extends JpaRepository<Report, String> {
     );
 
     // 신고된 사용자 목록 조회
-    @Query("SELECT u FROM User u " +
-        "WHERE u.reportCount > 0 " +
-        "ORDER BY " +
-        "CASE " +
-        "  WHEN u.state = 'ACTIVE' THEN 0 " +
-        "  WHEN u.state = 'AWAIT' THEN 1 " +
-        "  WHEN u.state = 'INACTIVE' THEN 2 " +
-        "  WHEN u.state = 'REJECT' THEN 3 " +
-        "  WHEN u.state = 'DROP' THEN 4 " +
-        "  WHEN u.state = 'DELETED' THEN 5 " +
-        "  ELSE 99 " +
-        "END, " +
-        "u.reportCount DESC")
+    @Query(value = """
+            SELECT u
+            FROM User u
+            WHERE u.reportCount > 0
+            ORDER BY CASE
+                         WHEN u.state = 'ACTIVE' THEN 0
+                         WHEN u.state = 'AWAIT' THEN 1
+                         WHEN u.state = 'INACTIVE' THEN 2
+                         WHEN u.state = 'REJECT' THEN 3
+                         WHEN u.state = 'DROP' THEN 4
+                         WHEN u.state = 'DELETED' THEN 5
+                         ELSE 99
+                         END,
+                     u.reportCount DESC
+         """
+        )
     Page<User> findReportedUsersByReportCount(Pageable pageable);
 
     // 댓글, 대댓글 신고 목록 조회(메모리 문제를 막기 위해 Native Query와 UNION ALL로 DB 내에서 처리하도록 함)

--- a/app-main/src/main/java/net/causw/app/main/repository/report/ReportRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/report/ReportRepository.java
@@ -53,9 +53,20 @@ public interface ReportRepository extends JpaRepository<Report, String> {
     );
 
     // 신고된 사용자 목록 조회
-    @Query("SELECT u FROM User u " +
-            "WHERE u.reportCount > 0 " +
-            "ORDER BY u.reportCount DESC")
+    @Query("SELECT u "
+        + "FROM User u "
+        + "WHERE u.reportCount > 0 "
+        + "ORDER BY "
+        + "  CASE u.state "
+        + "    WHEN net.causw.app.main.domain.model.enums.user.UserState.ACTIVE   THEN 0"
+        + "    WHEN net.causw.app.main.domain.model.enums.user.UserState.AWAIT    THEN 1"
+        + "    WHEN net.causw.app.main.domain.model.enums.user.UserState.INACTIVE THEN 2"
+        + "    WHEN net.causw.app.main.domain.model.enums.user.UserState.REJECT   THEN 3"
+        + "    WHEN net.causw.app.main.domain.model.enums.user.UserState.DROP     THEN 4"
+        + "    WHEN net.causw.app.main.domain.model.enums.user.UserState.DELETED  THEN 5"
+        + "    ELSE 99"
+        + "  END,"
+        + "  u.reportCount DESC")
     Page<User> findReportedUsersByReportCount(Pageable pageable);
 
     // 댓글, 대댓글 신고 목록 조회(메모리 문제를 막기 위해 Native Query와 UNION ALL로 DB 내에서 처리하도록 함)

--- a/app-main/src/main/java/net/causw/app/main/repository/report/ReportRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/report/ReportRepository.java
@@ -24,6 +24,7 @@ public interface ReportRepository extends JpaRepository<Report, String> {
                 p.id AS postId,
                 p.title AS postTitle,
                 u.name AS writerName,
+                u.state AS writerState,
                 r.report_reason AS reportReason,
                 r.created_at AS reportCreatedAt,
                 b.name AS boardName,
@@ -73,7 +74,7 @@ public interface ReportRepository extends JpaRepository<Report, String> {
     @Query(
             value = """
             SELECT 
-                reportId, contentId, content, postTitle, postId, boardId, writerName, reportReason, reportCreatedAt 
+                reportId, contentId, content, postTitle, postId, boardId, writerName, writerState, reportReason, reportCreatedAt 
             FROM ( 
                 SELECT 
                     r.id AS reportId, 
@@ -83,6 +84,7 @@ public interface ReportRepository extends JpaRepository<Report, String> {
                     p.id AS postId, 
                     p.board_id AS boardId,
                     u.name AS writerName, 
+                    u.state AS writerState,
                     r.report_reason AS reportReason, 
                     r.created_at AS reportCreatedAt
                 FROM tb_report r 
@@ -99,6 +101,7 @@ public interface ReportRepository extends JpaRepository<Report, String> {
                     p.id AS postId, 
                     p.board_id AS boardId,
                     u.name AS writerName, 
+                    u.state AS writerState,
                     r.report_reason AS reportReason, 
                     r.created_at AS reportCreatedAt
                 FROM tb_report r 


### PR DESCRIPTION
### 🚩 관련사항
#927 


### 📢 전달사항
- 신고된 유저 응답 DTO에 유저 상태 필드를 추가하여, 신고된 유저의 상태 정보를 반환하도록 개선합니다.
- 신고된 사용자 목록을 조회할 때, 사용자 상태를 기준으로 우선 정렬한 후 신고 횟수를 기준으로 정렬하도록 변경합니다. 이를 통해 관리자는 활성 상태의 신고된 사용자를 먼저 확인할 수 있습니다.
- 신고된 게시글 및 댓글 조회 시 작성자의 유저 상태 정보를 함께 반환하도록 기능을 추가합니다. 이를 통해 신고된 게시글/댓글을 처리할 때 작성자의 상태를 고려하여 더욱 효과적인 관리가 가능해집니다.

### 📸 스크린샷
<img width="500" height="586" alt="image" src="https://github.com/user-attachments/assets/c2f07081-bd42-4c1b-beb0-88be4cad5632" />

| 기능 | 이미지 | 설명 |
|------|--------|------|
| 신고 유저 리스트 |<img width="1415" height="590" alt="image" src="https://github.com/user-attachments/assets/3837d826-3809-4ebb-9afb-9631bd879cfe" />| userState로 반환 |
| 신고 콘텐츠 목록 (게시물) | <img width="1397" height="499" alt="image" src="https://github.com/user-attachments/assets/cd966db4-9930-4625-9f9d-03de3aceb904" /> | userState로 반환 |
| 신고 콘텐츠 목록 (댓글,대댓글) | <img width="1403" height="511" alt="image" src="https://github.com/user-attachments/assets/302c8ff8-113c-43ac-bcc5-b8e2f7090b4f" /> | userState로 반환 |


### 📃 진행사항
- [x] 신고 콘텐츠 목록에서 신고당한 유저의 현재 상태를 같이 반환해주도록 수정
- [x] 신고 유저 리스트 페이지에서 유저 현재 상태 같이 반환
- [x] 신고 유저 리스트 페이지에서 ACTIVE 유저 우선 정렬

### ⚙️ 기타사항
- comment 테이블이 댓글과 대댓글이 분리되어있는 것때문에 union 이 들어가게 되는데, 이 부분에 대해서 개선이 필요하지 않을까 싶습니다,,!
https://www.notion.so/2513d138d33c80e3a3a7f66ed7977560?source=copy_link

개발기간: 1h