### PR TITLE
hotfix : 운영계 DB phoneNumber Null 이슈 해결

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/dto/util/dtoMapper/UserDtoMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/util/dtoMapper/UserDtoMapper.java
@@ -17,6 +17,7 @@ import net.causw.app.main.dto.userInfo.UserCareerDto;
 import net.causw.app.main.dto.userInfo.UserInfoResponseDto;
 import net.causw.app.main.dto.userInfo.UserInfoSummaryResponseDto;
 import net.causw.app.main.dto.util.dtoMapper.custom.UuidFileToUrlDtoMapper;
+import net.causw.global.constant.StaticValue;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -236,8 +237,8 @@ public interface UserDtoMapper extends UuidFileToUrlDtoMapper {
         if (phoneNumber == null) {
             return null;
         }
-        if (phoneNumber.startsWith("temp-")) {
-            return "전화번호 없음";
+        if (phoneNumber.startsWith(StaticValue.TEMP_PHONE_NUMBER_PREFIX)) {
+            return StaticValue.NO_PHONE_NUMBER_MESSAGE;
         }
         return phoneNumber;
     }

--- a/app-main/src/main/java/net/causw/app/main/dto/util/dtoMapper/UserDtoMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/util/dtoMapper/UserDtoMapper.java
@@ -48,7 +48,7 @@ public interface UserDtoMapper extends UuidFileToUrlDtoMapper {
     @Mapping(target = "currentCompletedSemester", source = "user.currentCompletedSemester")
     @Mapping(target = "graduationYear", source = "user.graduationYear")
     @Mapping(target = "graduationType", source = "user.graduationType")
-    @Mapping(target = "phoneNumber", source = "user.phoneNumber")
+    @Mapping(target = "phoneNumber", source = "user.phoneNumber", qualifiedByName = "maskPhoneNumber")
     @Mapping(target = "rejectionOrDropReason", source = "user.rejectionOrDropReason")
     @Mapping(target = "createdAt", source = "user.createdAt")
     @Mapping(target = "updatedAt", source = "user.updatedAt")
@@ -69,7 +69,7 @@ public interface UserDtoMapper extends UuidFileToUrlDtoMapper {
     @Mapping(target = "currentCompletedSemester", source = "user.currentCompletedSemester")
     @Mapping(target = "graduationYear", source = "user.graduationYear")
     @Mapping(target = "graduationType", source = "user.graduationType")
-    @Mapping(target = "phoneNumber", source = "user.phoneNumber")
+    @Mapping(target = "phoneNumber", source = "user.phoneNumber", qualifiedByName = "maskPhoneNumber")
     @Mapping(target = "rejectionOrDropReason", source = "user.rejectionOrDropReason")
     @Mapping(target = "createdAt", source = "user.createdAt")
     @Mapping(target = "updatedAt", source = "user.updatedAt")
@@ -213,7 +213,7 @@ public interface UserDtoMapper extends UuidFileToUrlDtoMapper {
     @Mapping(target = "userId", source = "userInfo.user.id")
     @Mapping(target = "name", source = "userInfo.user.name")
     @Mapping(target = "email", source = "userInfo.user.email")
-    @Mapping(target = "phoneNumber", source = "userInfo.user.phoneNumber")
+    @Mapping(target = "phoneNumber", source = "userInfo.user.phoneNumber", qualifiedByName = "maskPhoneNumber")
     @Mapping(target = "admissionYear", source = "userInfo.user.admissionYear")
     @Mapping(target = "profileImageUrl", source = "userInfo.user.userProfileImage", qualifiedByName = "mapUuidFileToFileUrl")
     @Mapping(target = "major", source = "userInfo.user.major")
@@ -229,4 +229,18 @@ public interface UserDtoMapper extends UuidFileToUrlDtoMapper {
     @Mapping(target = "instagramLink", source = "userInfo.instagramLink")
     @Mapping(target = "isPhoneNumberVisible", source = "userInfo.isPhoneNumberVisible")
     UserInfoResponseDto toUserInfoResponseDto(UserInfo userInfo);
+
+    //TODO : 운영계 반영 성공시 삭제
+    @Named("maskPhoneNumber")
+    default String maskPhoneNumber(String phoneNumber) {
+        if (phoneNumber == null) {
+            return null;
+        }
+        if (phoneNumber.startsWith("temp-")) {
+            return "전화번호 없음";
+        }
+        return phoneNumber;
+    }
+
+
 }

--- a/global/src/main/java/net/causw/global/constant/StaticValue.java
+++ b/global/src/main/java/net/causw/global/constant/StaticValue.java
@@ -106,4 +106,8 @@ public class StaticValue {
     // nickname
     public static final String INACTIVE_USER_NICKNAME = "비활성 유저";
     public static final String ANONYMOUS_USER_NICKNAME = "익명";
+
+    //Temp Prefix
+    public static final String NO_PHONE_NUMBER_MESSAGE = "전화번호 없음";
+    public static final String TEMP_PHONE_NUMBER_PREFIX = "temp-";
 }


### PR DESCRIPTION
### 🚩 관련사항
#930 
https://www.notion.so/2513d138d33c807abedce69139d30b13?source=copy_link

### 📢 전달사항

1. 현재 운영계에 전화번호가 없는 사용자가 존재하지만 개발과정에서 phoneNumber는 nullable = false인 상태가 되었습니다.
2. DB마이그레이션에 대한 대책으로 전화번호가 없는 사용자에 대해서 임의로 'temp-' prefix를 붙여 전화번호를 저장합니다.
3. 'temp-' prefix를 기준으로 '전화번호 없음'을 반환합니다.

- 해당 코드는 임시 코드로 'temp-' prefix가 DB에서 사라진다면 삭제해야 합니다.
- 동문수첩 이외에 전화번호를 사용하는 곳은 학생회비 관리 부분이 있지만 당장의 우선순위가 아니라고 판단해 동문수첩에만 임시 적용하였습니다.


### 📸 스크린샷
<img width="1440" height="585" alt="image" src="https://github.com/user-attachments/assets/6f46b263-59af-4046-9c76-70ecd790d0de" />



### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 