### PR TITLE
fix: 추방, 삭제된 유저도 비활성 유저 처리

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/service/post/PostService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/post/PostService.java
@@ -1208,7 +1208,9 @@ public class PostService {
 
     // 화면에 표시할 작성자 닉네임 설정 (닉네임 / 비활성 유저 / 익명)
     public String getDisplayWriterNickname(User writer, Boolean isAnonymous, String originalNickname) {
-        if (writer != null && writer.getState() == UserState.INACTIVE) {
+        if (writer != null && (writer.getState() == UserState.INACTIVE
+                || writer.getState() == UserState.DROP
+                || writer.getState() == UserState.DELETED)) {
             return StaticValue.INACTIVE_USER_NICKNAME;
         } else if (Boolean.TRUE.equals(isAnonymous)) {
             return StaticValue.ANONYMOUS_USER_NICKNAME;


### PR DESCRIPTION
### 🚩 관련사항
#933 
https://www.notion.so/2503d138d33c8067b2f7e06dc8c4ca3c?source=copy_link


### 📢 전달사항
우선 추방 (DROP), 삭제 (DELETED)된 유저도 모두 '비활성 유저'로 뜨도록 처리했습니다.

찜한 게시글, 좋아요 누른 게시글 쪽도 응답을 바꾸려고 보니
이미 전에 수정한 부분과 같은 DTO를 쓰고 있어서 프론트 적용이 되면 동일하게 적용될 것으로 보입니다.


### 📸 스크린샷
<img width="500" height="470" alt="image" src="https://github.com/user-attachments/assets/055b02d3-bd13-4ff3-b9eb-8f226d791fd8" />
<img width="500" height="461" alt="image" src="https://github.com/user-attachments/assets/4d375c4d-f0e1-40fb-9bcd-ee4cecc85249" />

모두 UserPostsResponseDto을 Response로 사용하는데

<img width="350" height="465" alt="image" src="https://github.com/user-attachments/assets/c4e3f099-e0f6-4e29-8505-da64ccdabc32" />

<img width="500" height="658" alt="image" src="https://github.com/user-attachments/assets/f4749219-2890-42d2-a121-ad67eba88af4" />

이미 displayWriterNickname이 적용되어 있습니다. (전에 수정한 부분)


### 📃 진행사항
- [x] 추방, 삭제된 유저 비활성 유저 처리


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 10m