### PR TITLE
fix: 게시판 신청 승인 시 서버 에러 해결

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/service/board/BoardService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/board/BoardService.java
@@ -277,14 +277,6 @@ public class BoardService {
                         MessageUtil.APPLY_NOT_FOUND
                 ));
 
-        // 게시판명 중복 체크
-        if (boardRepository.existsByName(boardApply.getBoardName())) {
-            throw new BadRequestException(
-                    ErrorCode.ROW_ALREADY_EXIST,
-                    MessageUtil.BOARD_NAME_ALREADY_EXISTS
-            );
-        }
-
         if (boardApply.getAcceptStatus() == BoardApplyStatus.ACCEPTED) { // 해당 신청이 이미 승인된 경우
             throw new BadRequestException(
                     ErrorCode.CANNOT_PERFORMED,
@@ -296,6 +288,14 @@ public class BoardService {
             throw new BadRequestException(
                     ErrorCode.CANNOT_PERFORMED,
                     MessageUtil.APPLY_ALREADY_REJECTED
+            );
+        }
+
+        // 게시판명 중복 체크
+        if (boardRepository.existsByName(boardApply.getBoardName())) {
+            throw new BadRequestException(
+                    ErrorCode.ROW_ALREADY_EXIST,
+                    MessageUtil.BOARD_NAME_ALREADY_EXISTS
             );
         }
 


### PR DESCRIPTION
### 🚩 관련사항
#937 
https://www.notion.so/Internal-Server-Error-500-2523d138d33c80d58734dbcb51a15484?source=copy_link 의 1번 이슈

### 📢 전달사항
게시판 신청 승인 API `/api/v1/boards/apply/{applyId}/accept` 에서 승인 시 'Internal Server Error' 발생
로그 확인해보니 DB 수정 시 발생하는 오류로, 게시판 명이 중복되어서 오류가 나는 것이었음

따라서 해당 API에서 중복된 게시판명의 오류 메시지 전송 로직을 추가함

현재 게시판 신청 API `/api/v1/boards/apply` 에서는 이미 게시판명 중복 체크를 하는 로직이 존재하므로,
실 서비스에서는 이런 경우가 발생할 가능성이 없음.


### 📸 스크린샷
<img width="334" height="151" alt="image" src="https://github.com/user-attachments/assets/dd60ac5c-655a-4433-9c00-75861caf75e1" />

이렇게 에러 메시지를 추가함.

<img width="552" height="561" alt="image" src="https://github.com/user-attachments/assets/b7c6c925-d0bd-407d-ad92-41185f187ba9" />

현재 apply 서비스에서도 동일하게 중복 확인을 하고 에러 메시지를 던짐


### 📃 진행사항
- [x] 에러 메시지 추가


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 30m