### PR TITLE
[BUG] 회원 정보 수정 시 전화번호 수정란이 없지만 전화번호 형식 에러 뜸

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/dto/user/UserUpdateRequestDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/user/UserUpdateRequestDto.java
@@ -20,7 +20,6 @@ public class UserUpdateRequestDto {
     private String nickname;
 
     @Schema(description = "전화번호", example = "010-1234-5678", requiredMode = Schema.RequiredMode.REQUIRED)
-    @Pattern(regexp = "^01(?:0|1|[6-9])-(\\d{3}|\\d{4})-\\d{4}$", message = "전화번호 형식에 맞지 않습니다.")
     private String phoneNumber;
 
 }

--- a/app-main/src/main/java/net/causw/app/main/service/user/UserService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/user/UserService.java
@@ -808,7 +808,7 @@ public class UserService {
             }
         }
 
-        srcUser.update(userUpdateRequestDto.getNickname(), userProfileImage,userUpdateRequestDto.getPhoneNumber());
+        srcUser.update(userUpdateRequestDto.getNickname(), userProfileImage, userUpdateRequestDto.getPhoneNumber());
 
         User updatedUser = userRepository.save(srcUser);
 

--- a/app-main/src/main/java/net/causw/app/main/service/userInfo/UserInfoService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/userInfo/UserInfoService.java
@@ -4,6 +4,8 @@ import static net.causw.global.constant.StaticValue.DEFAULT_PAGE_SIZE;
 
 import net.causw.app.main.domain.event.InitialAcademicCertificationEvent;
 import net.causw.app.main.domain.model.enums.user.UserState;
+import net.causw.app.main.domain.validation.PhoneNumberFormatValidator;
+import net.causw.app.main.domain.validation.ValidatorBucket;
 import org.springframework.context.event.EventListener;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -104,6 +106,9 @@ public class UserInfoService {
         .nickname(user.getNickname())
         .phoneNumber(phoneNumber == null ? user.getPhoneNumber() : phoneNumber)
         .build();
+
+    ValidatorBucket validatorBucket = ValidatorBucket.of();
+    validatorBucket.consistOf(PhoneNumberFormatValidator.of(phoneNumber));
 
     userService.update(user, userUpdateRequestDto, profileImage); // 실패시 user, userInfo 전부 rollback
 

--- a/app-main/src/main/java/net/causw/app/main/service/userInfo/UserInfoService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/userInfo/UserInfoService.java
@@ -107,8 +107,11 @@ public class UserInfoService {
         .phoneNumber(phoneNumber == null ? user.getPhoneNumber() : phoneNumber)
         .build();
 
-    ValidatorBucket validatorBucket = ValidatorBucket.of();
-    validatorBucket.consistOf(PhoneNumberFormatValidator.of(phoneNumber));
+    if (phoneNumber != null) {
+      ValidatorBucket.of()
+              .consistOf(PhoneNumberFormatValidator.of(phoneNumber))
+              .validate();
+    }
 
     userService.update(user, userUpdateRequestDto, profileImage); // 실패시 user, userInfo 전부 rollback
 


### PR DESCRIPTION
### 🚩 관련사항
#941 


### 📢 전달사항
@pattern으로 형식 검사하고 있었는데, 이걸 지웠음
그리고 userInfo/me에서는 전화번호 수정을 할 때 형식검사를 진행해야하므로 Validator로 형식검사함
다른 곳에서 UserUpdateRequestDto를 쓰고 있기 때문에 dto에서 전화번호를 제외하지 않았음.

### 📸 스크린샷
<img width="1413" height="898" alt="스크린샷 2025-08-19 오전 2 18 46" src="https://github.com/user-attachments/assets/fd7e8dd2-d55b-48ae-b27d-36c1e63d8e6e" />

<img width="633" height="934" alt="스크린샷 2025-08-19 오전 2 16 27" src="https://github.com/user-attachments/assets/1d2e1fd4-1c2a-4183-a70f-7cdf8b220df2" />

<img width="1519" height="903" alt="스크린샷 2025-08-19 오전 2 19 00" src="https://github.com/user-attachments/assets/c9d4f975-5f02-4168-b653-79aa1819f2ae" />


<img width="1514" height="900" alt="스크린샷 2025-08-19 오전 2 21 38" src="https://github.com/user-attachments/assets/0dce3125-cf35-45c5-ae05-18215e9031a6" />

개발기간: 1d