### PR TITLE
[FEATURE] 탈퇴 회원에 대한 회원가입, 복구 처리

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/controller/UserController.java
+++ b/app-main/src/main/java/net/causw/app/main/controller/UserController.java
@@ -273,7 +273,7 @@ public class UserController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserSignInResponseDto.class))),
             @ApiResponse(responseCode = "4000", description = "해당 사용자를 찾을 수 없습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
-            @ApiResponse(responseCode = "4101", description = "잘못된 이메일 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
+            @ApiResponse(responseCode = "4002", description = "복구할 수 없는 계정 상태입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
     })
     public UserSignInResponseDto recoverUser(@Valid @RequestBody UserRecoverRequestDto userRecoverRequestDto) {
         return this.userService.recoverUser(userRecoverRequestDto.getEmail());

--- a/app-main/src/main/java/net/causw/app/main/controller/UserController.java
+++ b/app-main/src/main/java/net/causw/app/main/controller/UserController.java
@@ -263,6 +263,23 @@ public class UserController {
     }
 
     /**
+     * INACTIVE 사용자 계정 복구 컨트롤러
+     * @param userRecoverRequestDto 복구 요청 정보
+     * @return UserSignInResponseDto
+     */
+    @PutMapping(value = "/recover")
+    @ResponseStatus(value = HttpStatus.OK)
+    @Operation(summary = "INACTIVE 사용자 계정 복구 API", description = "탈퇴한 계정을 복구하여 ACTIVE 상태로 변경하고 로그인 토큰을 발급합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserSignInResponseDto.class))),
+            @ApiResponse(responseCode = "4000", description = "해당 사용자를 찾을 수 없습니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class))),
+            @ApiResponse(responseCode = "4101", description = "잘못된 이메일 입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = BadRequestException.class)))
+    })
+    public UserSignInResponseDto recoverUser(@Valid @RequestBody UserRecoverRequestDto userRecoverRequestDto) {
+        return this.userService.recoverUser(userRecoverRequestDto.getEmail());
+    }
+
+    /**
      * 이메일 중복 확인 컨트롤러
      * @param email
      * @return DuplicatedCheckResponseDto

--- a/app-main/src/main/java/net/causw/app/main/dto/user/UserRecoverRequestDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/user/UserRecoverRequestDto.java
@@ -1,0 +1,21 @@
+package net.causw.app.main.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserRecoverRequestDto {
+
+    @Email(message = "이메일 형식에 맞지 않습니다.")
+    @NotBlank(message = "이메일을 입력해 주세요.")
+    @Schema(description = "이메일", example = "yebin@cau.ac.kr")
+    private String email;
+}

--- a/app-main/src/main/java/net/causw/app/main/infrastructure/security/SecurityEndpoints.java
+++ b/app-main/src/main/java/net/causw/app/main/infrastructure/security/SecurityEndpoints.java
@@ -33,6 +33,7 @@ public class SecurityEndpoints {
             of("/h2-console/**"),
             of("/api/v1/users/sign-in", POST),
             of("/api/v1/users/sign-up", POST),
+            of("/api/v1/users/recover", PUT),
             of("/healthy", GET),
             of("/api/v1/users/admissions/apply", POST),
             of("/api/v1/users/{email}/is-duplicated", GET),

--- a/app-main/src/main/java/net/causw/app/main/service/user/UserService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/user/UserService.java
@@ -1646,9 +1646,10 @@ public class UserService {
         user.setState(UserState.ACTIVE);
         
         // 역할을 COMMON으로 설정
-        Set<Role> roles = new HashSet<>();
+        Set<Role> roles = user.getRoles();
+        roles.clear();
         roles.add(Role.COMMON);
-        user.setRoles(roles);
+
 
         userRepository.save(user);
 

--- a/global/src/main/java/net/causw/global/constant/MessageUtil.java
+++ b/global/src/main/java/net/causw/global/constant/MessageUtil.java
@@ -118,7 +118,8 @@ public class MessageUtil {
     public static final String GRANT_ROLE_NOT_ALLOWED = "권한을 부여할 수 없습니다.";
     public static final String DELEGATE_ROLE_NOT_ALLOWED = "권한을 위임할 수 없습니다.";
     public static final String USER_DROPPED_CONTACT_EMAIL = "추방된 계정입니다. 재가입 문의는 caucsedongne@gmail.com으로 연락해주세요";
-    public static final String USER_INACTIVE_CAN_REJOIN = "탈퇴한 계정입니다. 새롭게 회원가입을 진행해주세요";
+    public static final String USER_INACTIVE_CAN_REJOIN = "탈퇴한 계정입니다. 계정 복구를 진행해주세요";
+    public static final String USER_RECOVER_INVALID_STATE = "복구할 수 없는 계정 상태입니다.";
     public static final String USER_DELETED =  "삭제된 계정입니다. 회원가입 페이지에서 새로운 정보로 가입해주세요.";
 
     // Flag


### PR DESCRIPTION
### 🚩 관련사항
#942 

### 📢 전달사항
1. 현재까지 ACTIVE와 DROP에 대해 중복 체크를 하고 있었음
2. INACTIVE인 경우에는 중복체크를 하지 않고, 탈퇴한 사용자와 같은 이메일이나, 같은 전화번호를 쓴 경우에 update처리를 해서 복구로 간주했음.
3. 이때 누군가가 이메일이나, 전화번호를 잘못쳐서 탈퇴한 사용자의 정보를 뺏는다면 문제가 생길 수 있다고 생각함
4. 따라서, 탈퇴한 사용자는 로그인 시에 계정을 복구하시겠습니까? 알림/버튼이 나와서 동의하면 state를 ACTIVE로 변경해 복구하는 방식으로 하자고 이야기가 나옴.

### 수정한 로직
1. INACTIVE인 사용자의 이메일, 닉네임, 학번, 전화번호를 회원가입 시 중복체크에 포함시킴
2. INACTIVE인 경우 로그인했을때 에러를 반환하고, 프론트에서 INACTIVE에러를 받게되면, 모달을 띄움
3. 이후 사용자가 복구하시겠습니까? 라는 질문에 예를 답하면 status는 ACTIVE, Role은 COMMON으로 변경해 복구할 수 있도록 하고 토큰을 발급함



### 📸 스크린샷

<img width="490" height="620" alt="스크린샷 2025-08-19 오후 12 58 44" src="https://github.com/user-attachments/assets/03064224-261e-4d6b-a982-7514391e00e8" />
해주세요.

<img width="587" height="532" alt="스크린샷 2025-08-19 오후 12 58 35" src="https://github.com/user-attachments/assets/66050743-0fec-4d3d-b0d7-0f8311872d31" />

<img width="713" height="707" alt="스크린샷 2025-08-19 오후 12 59 46" src="https://github.com/user-attachments/assets/e9d11f1f-dc81-4363-981a-5554ab84139b" />

<img width="578" height="578" alt="스크린샷 2025-08-19 오후 12 59 51" src="https://github.com/user-attachments/assets/64c38a50-314f-4363-9cb4-40dfa03f836d" />

### 📃 진행사항
- [ ] 회원가입 중복체크 로직에 INACTIVE사용자 포함
- [ ] 사용자가 yes를 누르면, state를 ACTIVE로 변경해 복구하는 API만들기


개발기간: 1d