### PR TITLE
fix: 동문수첩의 전화번호 중복 체크 대상에 탈퇴 유저 추가

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/service/userInfo/UserInfoService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/userInfo/UserInfoService.java
@@ -83,15 +83,10 @@ public class UserInfoService {
     public UserInfoResponseDto update(String userId, UserInfoUpdateRequestDto request, MultipartFile profileImage) {
         User user = findUserById(userId);
 
-        String phoneNumber = request.getPhoneNumber();
-        if (phoneNumber != null) {
-            validatePhoneNumberDuplication(phoneNumber, user);
-        }
-
         // 사용자 정보 갱신(전화번호, 프로필 이미지)
         final UserUpdateRequestDto userUpdateRequestDto = UserUpdateRequestDto.builder()
                 .nickname(user.getNickname())
-                .phoneNumber(phoneNumber == null ? user.getPhoneNumber() : phoneNumber)
+                .phoneNumber(request.getPhoneNumber() == null ? user.getPhoneNumber() : request.getPhoneNumber())
                 .build();
 
         userService.update(user, userUpdateRequestDto, profileImage); // 실패시 user, userInfo 전부 rollback
@@ -190,23 +185,5 @@ public class UserInfoService {
                     MessageUtil.INVALID_CAREER_DATE
             );
         }
-    }
-
-    private void validatePhoneNumberDuplication(String phoneNumber, User user) {
-        userRepository.findByPhoneNumber(phoneNumber)
-                .ifPresent(foundUser -> {
-                    if (foundUser.getId().equals(user.getId())) return;
-
-                    if (foundUser.getState() == UserState.ACTIVE || foundUser.getState() == UserState.INACTIVE) {
-                        throw new BadRequestException(
-                                ErrorCode.ROW_ALREADY_EXIST,
-                                MessageUtil.PHONE_NUMBER_ALREADY_EXIST);
-
-                    } else if (foundUser.getState() == UserState.DROP) {
-                        throw new BadRequestException(
-                                ErrorCode.ROW_ALREADY_EXIST,
-                                MessageUtil.DROPPED_USER_PHONE_NUMBER);
-                    }
-                });
     }
 }

--- a/app-main/src/main/java/net/causw/app/main/service/userInfo/UserInfoService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/userInfo/UserInfoService.java
@@ -85,10 +85,6 @@ public class UserInfoService {
 
         String phoneNumber = request.getPhoneNumber();
         if (phoneNumber != null) {
-            ValidatorBucket.of()
-                    .consistOf(PhoneNumberFormatValidator.of(phoneNumber))
-                    .validate();
-
             validatePhoneNumberDuplication(phoneNumber, user);
         }
 

--- a/app-main/src/main/java/net/causw/app/main/service/userInfo/UserInfoService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/userInfo/UserInfoService.java
@@ -88,7 +88,7 @@ public class UserInfoService {
               .ifPresent(foundUser -> {
                 if (foundUser.getId().equals(user.getId())) return;
 
-                if (foundUser.getState() == UserState.ACTIVE) {
+                if (foundUser.getState() == UserState.ACTIVE || foundUser.getState() == UserState.INACTIVE) {
                   throw new BadRequestException(
                       ErrorCode.ROW_ALREADY_EXIST,
                       MessageUtil.PHONE_NUMBER_ALREADY_EXIST);

--- a/app-main/src/test/java/net/causw/app/main/service/userInfo/UserInfoServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/service/userInfo/UserInfoServiceTest.java
@@ -153,30 +153,6 @@ class UserInfoServiceTest {
     }
 
     @Test
-    @DisplayName("중복된 전화번호 입력시 예외 발생")
-    void duplicatedPhoneNumberThrowsException() {
-      // given
-      String duplicatedPhoneNumber = "010-0000-0000";
-
-      certifiedUser.setPhoneNumber(duplicatedPhoneNumber);
-
-      User foundUser = ObjectFixtures.getCertifiedUserWithId("foundUserId");
-      foundUser.setPhoneNumber(duplicatedPhoneNumber);
-
-      UserInfoUpdateRequestDto updateRequestDto = UserInfoUpdateRequestDto.builder()
-          .phoneNumber(duplicatedPhoneNumber)
-          .isPhoneNumberVisible(true)
-          .build();
-
-      given(userRepository.findByPhoneNumber(duplicatedPhoneNumber)).willReturn(Optional.of(foundUser));
-
-      // when & then
-      assertThatThrownBy(() -> userInfoService.update(certifiedUser.getId(), updateRequestDto, profileImage))
-          .isInstanceOf(BadRequestException.class)
-          .extracting("errorCode").isEqualTo(ErrorCode.ROW_ALREADY_EXIST);
-    }
-
-    @Test
     @DisplayName("사용자 정보 갱신 실패시 세부정보 갱신도 함께 실패")
     void userServiceUpdateFailedThenUserInfoServiceUpdateFailed() {
       // given

--- a/global/src/main/java/net/causw/global/constant/MessageUtil.java
+++ b/global/src/main/java/net/causw/global/constant/MessageUtil.java
@@ -113,7 +113,6 @@ public class MessageUtil {
     public static final String USER_ADMISSION_MUST_HAVE_IMAGE = "입학 증빙 사진은 필수 입니다.";
     public static final String STUDENT_ID_ALREADY_EXIST = "이미 존재하는 학번입니다.";
     public static final String PHONE_NUMBER_ALREADY_EXIST = "이미 존재하는 전화번호입니다.";
-    public static final String DROPPED_USER_PHONE_NUMBER = "추방된 계정의 전화번호입니다. 재가입 문의는 caucsedongne@gmail.com으로 연락해주세요.";
     public static final String INVALID_USER_APPLICATION_USER_STATE = "사용자 인증을 할 수 없는 상태의 사용자입니다(AWAIT / REJECT 상태만 인증 가능합니다).";
     public static final String GRANT_ROLE_NOT_ALLOWED = "권한을 부여할 수 없습니다.";
     public static final String DELEGATE_ROLE_NOT_ALLOWED = "권한을 위임할 수 없습니다.";


### PR DESCRIPTION
### 🚩 관련사항
[탈퇴 회원에 대한 회원가입, 복구 처리](https://www.notion.so/2533d138d33c804bbddfd6126159617c)

### 📢 전달사항
동문수첩 수정시 닉네임, 전화번호는 user의 필드이므로 userService의 update로 변경합니다.
따라서 닉네임, 전화번호의 중복 체크도 userService로 통합합니다.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 