### PR TITLE
fix: 학적 상태 비고에 따옴표를 포함하하지 않고 저장, 반환하도록 수정

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/controller/UserAcademicRecordApplicationController.java
+++ b/app-main/src/main/java/net/causw/app/main/controller/UserAcademicRecordApplicationController.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import net.causw.app.main.dto.semester.CurrentSemesterResponseDto;
+import net.causw.app.main.dto.user.UserAcademicStatusNoteUpdateDto;
 import net.causw.app.main.dto.userAcademicRecordApplication.*;
 import net.causw.app.main.service.semester.SemesterService;
 import net.causw.app.main.service.userAcademicRecord.UserAcademicRecordApplicationService;
@@ -100,7 +101,7 @@ public class UserAcademicRecordApplicationController {
     /**
      * 유저 학적 정보 노트 변경
      * @param userId
-     * @param note
+     * @param userAcademicStatusNoteUpdateDto
      * @return Void
      */
     @PutMapping("/record/{userId}")
@@ -110,9 +111,9 @@ public class UserAcademicRecordApplicationController {
             description = "유저 학적 정보 노트를 변경합니다.")
     public UserAcademicRecordInfoResponseDto updateUserAcademicRecordNote(
             @PathVariable("userId") String userId,
-            @RequestBody String note
-    ) {
-        return userAcademicRecordApplicationService.updateUserAcademicRecordNote(userId, note);
+            @RequestBody UserAcademicStatusNoteUpdateDto userAcademicStatusNoteUpdateDto
+            ) {
+        return userAcademicRecordApplicationService.updateUserAcademicRecordNote(userId, userAcademicStatusNoteUpdateDto);
     }
 
     /**

--- a/app-main/src/main/java/net/causw/app/main/dto/user/UserAcademicStatusNoteUpdateDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/user/UserAcademicStatusNoteUpdateDto.java
@@ -1,0 +1,17 @@
+package net.causw.app.main.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserAcademicStatusNoteUpdateDto {
+
+    @Schema(description = "사용자 학적 상태에 대한 비고", example = "비고입니다.")
+    private String note;
+}

--- a/app-main/src/main/java/net/causw/app/main/dto/userAcademicRecordApplication/UserAcademicRecordInfoResponseDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/userAcademicRecordApplication/UserAcademicRecordInfoResponseDto.java
@@ -4,11 +4,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 import net.causw.app.main.domain.model.enums.userAcademicRecord.AcademicStatus;
 
 import java.util.List;
 
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 public class UserAcademicRecordInfoResponseDto {

--- a/app-main/src/main/java/net/causw/app/main/service/userAcademicRecord/UserAcademicRecordApplicationService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/userAcademicRecord/UserAcademicRecordApplicationService.java
@@ -374,17 +374,10 @@ public class UserAcademicRecordApplicationService {
     }
 
     private UserAcademicRecordInfoResponseDto getUserAcademicRecordInfoResponseDto(User user) {
-        UserAcademicRecordInfoResponseDto responseDto = toUserAcademicRecordInfoResponseDto(
+        return toUserAcademicRecordInfoResponseDto(
                 user,
                 getUserAcademicRecordLogList(user)
         );
-
-        // 따옴표 제거
-        if (responseDto.getNote() != null) {
-            responseDto.setNote(responseDto.getNote().replaceAll("^\"|\"$", ""));
-        }
-
-        return responseDto;
     }
 
     private List<UserAcademicRecordLog> getUserAcademicRecordLogList(User user) {
@@ -476,12 +469,19 @@ public class UserAcademicRecordApplicationService {
     }
 
     private UserAcademicRecordInfoResponseDto toUserAcademicRecordInfoResponseDto(User user, List<UserAcademicRecordLog> userAcademicRecordLogList) {
-        return UserAcademicRecordDtoMapper.INSTANCE.toUserAcademicRecordInfoResponseDto(
+        UserAcademicRecordInfoResponseDto responseDto = UserAcademicRecordDtoMapper.INSTANCE.toUserAcademicRecordInfoResponseDto(
                 user,
                 userAcademicRecordLogList.stream()
                         .map(this::toUserAcademicRecordApplicationResponseDto)
                         .toList()
         );
+
+        // 따옴표 제거
+        if (responseDto.getNote() != null) {
+            responseDto.setNote(responseDto.getNote().replaceAll("^\"|\"$", ""));
+        }
+
+        return responseDto;
     }
 
     private UserAcademicRecordApplicationResponseDto toUserAcademicRecordApplicationResponseDto(UserAcademicRecordLog userAcademicRecordLog) {

--- a/app-main/src/main/java/net/causw/app/main/service/userAcademicRecord/UserAcademicRecordApplicationService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/userAcademicRecord/UserAcademicRecordApplicationService.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import net.causw.app.main.domain.event.AcademicStatusChangeEvent;
 import net.causw.app.main.domain.event.InitialAcademicCertificationEvent;
+import net.causw.app.main.dto.user.UserAcademicStatusNoteUpdateDto;
 import net.causw.app.main.repository.notification.CeremonyNotificationSettingRepository;
 import net.causw.app.main.repository.user.UserRepository;
 import net.causw.app.main.repository.userAcademicRecord.UserAcademicRecordApplicationRepository;
@@ -106,10 +107,10 @@ public class UserAcademicRecordApplicationService {
     }
 
     @Transactional
-    public UserAcademicRecordInfoResponseDto updateUserAcademicRecordNote(String userId, String note) {
+    public UserAcademicRecordInfoResponseDto updateUserAcademicRecordNote(String userId, UserAcademicStatusNoteUpdateDto userAcademicStatusNoteUpdateDto) {
         User user = getUser(userId);
 
-        user.setAcademicStatusNote(note);
+        user.setAcademicStatusNote(userAcademicStatusNoteUpdateDto.getNote());
 
         userRepository.save(user);
 

--- a/app-main/src/main/java/net/causw/app/main/service/userAcademicRecord/UserAcademicRecordApplicationService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/userAcademicRecord/UserAcademicRecordApplicationService.java
@@ -374,10 +374,17 @@ public class UserAcademicRecordApplicationService {
     }
 
     private UserAcademicRecordInfoResponseDto getUserAcademicRecordInfoResponseDto(User user) {
-        return toUserAcademicRecordInfoResponseDto(
+        UserAcademicRecordInfoResponseDto responseDto = toUserAcademicRecordInfoResponseDto(
                 user,
                 getUserAcademicRecordLogList(user)
         );
+
+        // 따옴표 제거
+        if (responseDto.getNote() != null) {
+            responseDto.setNote(responseDto.getNote().replaceAll("^\"|\"$", ""));
+        }
+
+        return responseDto;
     }
 
     private List<UserAcademicRecordLog> getUserAcademicRecordLogList(User user) {


### PR DESCRIPTION
### 🚩 관련사항
[비고 따옴표 포함되어 오는 이슈](https://www.notion.so/2523d138d33c801d97badfeb630191c9)


### 📢 전달사항
@RequestBody String으로 직접 비고 내용을 받아와서 따옴표가 파싱되지 않고 그대로 저장되고 있었습니다.
DTO로 비고 내용을 받아와 저장하도록 변경하고, 응답 DTO 반환 전 따옴표를 제거합니다.


### 📸 스크린샷
- 비고 갱신시 따옴표 없이 DB에 저장
<img width="953" height="901" alt="Screenshot from 2025-08-19 17-58-24" src="https://github.com/user-attachments/assets/78e77002-43db-4115-94eb-fe12ec5a0b5a" />
<img width="961" height="149" alt="Screenshot from 2025-08-19 17-59-17" src="https://github.com/user-attachments/assets/993c611c-88e2-4a4d-91e2-720c0ef680f2" />
- 따옴표 포함하는 비고의 따옴표 제거후 반환
<img width="1285" height="840" alt="Screenshot from 2025-08-19 18-00-21" src="https://github.com/user-attachments/assets/82ff5df0-0fc9-404f-88a9-0d796161b677" />

### 📃 진행사항
- [ ] 프론트에서 PUT "/users/academic-record/record/{userId}"의 request body 수정


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 1h