### PR TITLE
feat: ALUMNI_MANAGER 역할 추가 및 queryDSL 도입

### DIFF
--- a/app-main/build.gradle
+++ b/app-main/build.gradle
@@ -10,6 +10,10 @@ plugins {
     id 'org.flywaydb.flyway' version '9.22.3'
 }
 
+ext {
+    queryDslVersion = "6.10.1"
+}
+
 dependencies {
     implementation project(':global')
 
@@ -88,6 +92,13 @@ dependencies {
     implementation 'ch.qos.logback.contrib:logback-json-classic:0.1.5'
     implementation 'ch.qos.logback.contrib:logback-jackson:0.1.5'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+
+    // query-dsl
+    implementation "io.github.openfeign.querydsl:querydsl-core:${queryDslVersion}"
+    implementation "io.github.openfeign.querydsl:querydsl-jpa:${queryDslVersion}"
+    annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:${queryDslVersion}:jpa"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 bootJar {
@@ -111,6 +122,18 @@ test {
         if (!desc.parent) {
             println "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
         }
+    }
+}
+
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile;
+
+tasks.withType(JavaCompile) {
+    options.generatedSourceOutputDirectory = file(querydslDir)
+}
+
+tasks.named("clean") {
+    doLast {
+        delete file(querydslDir)
     }
 }
 

--- a/app-main/src/main/java/net/causw/app/main/controller/UserController.java
+++ b/app-main/src/main/java/net/causw/app/main/controller/UserController.java
@@ -49,6 +49,7 @@ import net.causw.app.main.dto.user.UserUpdateTokenRequestDto;
 import net.causw.app.main.infrastructure.security.userdetails.CustomUserDetails;
 import net.causw.app.main.service.user.UserRoleService;
 import net.causw.app.main.service.user.UserService;
+import net.causw.app.main.service.user.useCase.FindPrivilegedUsersUseCaseService;
 import net.causw.app.main.service.user.useCase.RegisterGraduatedUsersUseCaseService;
 import net.causw.global.exception.BadRequestException;
 import net.causw.global.exception.UnauthorizedException;
@@ -70,6 +71,7 @@ public class UserController {
 	private final UserService userService;
 	private final UserRoleService userRoleService;
 	private final RegisterGraduatedUsersUseCaseService registerGraduatedUsersUseCaseService;
+	private final FindPrivilegedUsersUseCaseService findPrivilegedUsersUseCaseService;
 
 	/**
 	 * 사용자 고유 id 값으로 사용자 정보를 조회하는 API
@@ -238,7 +240,7 @@ public class UserController {
 	public UserPrivilegedResponseDto findPrivilegedUsers(
 		@AuthenticationPrincipal CustomUserDetails userDetails
 	) {
-		return this.userService.findPrivilegedUsers(userDetails.getUser());
+		return findPrivilegedUsersUseCaseService.execute(userDetails.getUser());
 	}
 
 	@GetMapping(value = "/state/{state}")

--- a/app-main/src/main/java/net/causw/app/main/domain/model/entity/notification/CeremonyNotificationSetting.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/entity/notification/CeremonyNotificationSetting.java
@@ -3,6 +3,8 @@ package net.causw.app.main.domain.model.entity.notification;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.hibernate.annotations.BatchSize;
+
 import net.causw.app.main.domain.model.entity.base.BaseEntity;
 import net.causw.app.main.domain.model.entity.user.User;
 
@@ -31,6 +33,7 @@ public class CeremonyNotificationSetting extends BaseEntity {
 	@ElementCollection(fetch = FetchType.EAGER)
 	@CollectionTable(name = "TB_CEREMONY_SUBSCRIBE_YEAR", joinColumns = @JoinColumn(name = "notification_id"))
 	@Column(name = "admission_year")
+	@BatchSize(size = 100)
 	private Set<String> subscribedAdmissionYears = new HashSet<>();
 
 	@Column(name = "is_notification_active", nullable = false)

--- a/app-main/src/main/java/net/causw/app/main/domain/model/entity/user/User.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/entity/user/User.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import org.hibernate.annotations.BatchSize;
+
 import net.causw.app.main.domain.model.entity.base.BaseEntity;
 import net.causw.app.main.domain.model.entity.circle.CircleMember;
 import net.causw.app.main.domain.model.entity.locker.Locker;
@@ -89,9 +91,10 @@ public class User extends BaseEntity {
 	@Column(name = "graduation_type", nullable = true)
 	private GraduationType graduationType;
 
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection(fetch = FetchType.LAZY)
 	@Enumerated(EnumType.STRING)
 	@Column(name = "role", nullable = false)
+	@BatchSize(size = 100)
 	private Set<Role> roles;
 
 	@OneToOne(cascade = {CascadeType.REMOVE, CascadeType.PERSIST}, mappedBy = "user")
@@ -121,7 +124,7 @@ public class User extends BaseEntity {
 	@Builder.Default
 	private Boolean isV2 = true;
 
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection(fetch = FetchType.LAZY)
 	@CollectionTable(
 		name = "tb_user_fcm_token",
 		joinColumns = @JoinColumn(name = "user_id")

--- a/app-main/src/main/java/net/causw/app/main/domain/model/entity/user/User.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/entity/user/User.java
@@ -19,8 +19,8 @@ import net.causw.app.main.domain.model.enums.user.GraduationType;
 import net.causw.app.main.domain.model.enums.user.Role;
 import net.causw.app.main.domain.model.enums.user.UserState;
 import net.causw.app.main.domain.model.enums.userAcademicRecord.AcademicStatus;
-import net.causw.app.main.dto.user.CreateGraduatedUserCommand;
 import net.causw.app.main.dto.user.UserCreateRequestDto;
+import net.causw.app.main.dto.user.CreateGraduatedUserCommand;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;

--- a/app-main/src/main/java/net/causw/app/main/domain/model/entity/user/User.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/entity/user/User.java
@@ -19,8 +19,8 @@ import net.causw.app.main.domain.model.enums.user.GraduationType;
 import net.causw.app.main.domain.model.enums.user.Role;
 import net.causw.app.main.domain.model.enums.user.UserState;
 import net.causw.app.main.domain.model.enums.userAcademicRecord.AcademicStatus;
-import net.causw.app.main.dto.user.UserCreateRequestDto;
 import net.causw.app.main.dto.user.CreateGraduatedUserCommand;
+import net.causw.app.main.dto.user.UserCreateRequestDto;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;

--- a/app-main/src/main/java/net/causw/app/main/domain/model/enums/user/Role.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/enums/user/Role.java
@@ -1,6 +1,7 @@
 package net.causw.app.main.domain.model.enums.user;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.springframework.stereotype.Component;
 
@@ -22,6 +23,7 @@ public enum Role {
 	LEADER_3("LEADER_3", "3학년 대표"),
 	LEADER_4("LEADER_4", "4학년 대표"),
 	LEADER_ALUMNI("LEADER_ALUMNI", "동문회장"),
+	ALUMNI_MANAGER("ALUMNI_MANAGER", "크자회 운영자"),
 	COMMON("COMMON", "일반"),
 	NONE("NONE", "없음"),
 
@@ -48,6 +50,21 @@ public enum Role {
 		return "ROLE_" + value;
 	}
 
+	public static List<Role> getPrivilegedRoles() {
+		return List.of(
+			ADMIN,
+			PRESIDENT,
+			VICE_PRESIDENT,
+			COUNCIL,
+			LEADER_1,
+			LEADER_2,
+			LEADER_3,
+			LEADER_4,
+			LEADER_ALUMNI,
+			ALUMNI_MANAGER
+		);
+	}
+
 	@Component("Role")
 	public static class RoleComponent {
 		public static final Role ADMIN = Role.ADMIN;
@@ -59,6 +76,7 @@ public enum Role {
 		public static final Role LEADER_3 = Role.LEADER_3;
 		public static final Role LEADER_4 = Role.LEADER_4;
 		public static final Role LEADER_ALUMNI = Role.LEADER_ALUMNI;
+		public static final Role ALUMNI_MANAGER = Role.ALUMNI_MANAGER;
 		public static final Role COMMON = Role.COMMON;
 		public static final Role NONE = Role.NONE;
 

--- a/app-main/src/main/java/net/causw/app/main/domain/model/enums/user/RoleGroup.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/enums/user/RoleGroup.java
@@ -27,7 +27,9 @@ public enum RoleGroup {
 		Role.ADMIN,
 		Role.PRESIDENT,
 		Role.VICE_PRESIDENT,
-		Role.LEADER_ALUMNI
+		Role.LEADER_ALUMNI,
+		Role.ALUMNI_MANAGER
+
 	)),
 
 	EXECUTIVES_AND_CIRCLE_LEADER(Set.of( // 집행부 + 동아리장
@@ -52,7 +54,8 @@ public enum RoleGroup {
 		Role.LEADER_2,
 		Role.LEADER_3,
 		Role.LEADER_4,
-		Role.LEADER_ALUMNI
+		Role.LEADER_ALUMNI,
+		Role.ALUMNI_MANAGER
 	));
 
 	private final Set<Role> roles;

--- a/app-main/src/main/java/net/causw/app/main/domain/policy/RolePolicy.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/policy/RolePolicy.java
@@ -26,6 +26,7 @@ public class RolePolicy {
 		entry(LEADER_3, false),
 		entry(LEADER_4, false),
 		entry(LEADER_ALUMNI, true),
+		entry(ALUMNI_MANAGER, false),
 		entry(COMMON, false),
 		entry(NONE, false),
 
@@ -48,6 +49,7 @@ public class RolePolicy {
 		entry(LEADER_3, 4),
 		entry(LEADER_4, 4),
 		entry(LEADER_ALUMNI, 5),
+		entry(ALUMNI_MANAGER, 5),
 		entry(COMMON, 99),
 		entry(NONE, 100),
 
@@ -88,6 +90,7 @@ public class RolePolicy {
 			LEADER_3,
 			LEADER_4,
 			LEADER_ALUMNI,
+			ALUMNI_MANAGER,
 			COMMON
 		),
 
@@ -99,6 +102,7 @@ public class RolePolicy {
 			LEADER_3,
 			LEADER_4,
 			LEADER_ALUMNI,
+			ALUMNI_MANAGER,
 			COMMON
 		)
 	);
@@ -117,7 +121,8 @@ public class RolePolicy {
 			LEADER_2,
 			LEADER_3,
 			LEADER_4,
-			LEADER_ALUMNI
+			LEADER_ALUMNI,
+			ALUMNI_MANAGER
 		),
 
 		PRESIDENT, Set.of(
@@ -127,7 +132,8 @@ public class RolePolicy {
 			LEADER_2,
 			LEADER_3,
 			LEADER_4,
-			LEADER_ALUMNI
+			LEADER_ALUMNI,
+			ALUMNI_MANAGER
 		)
 	);
 

--- a/app-main/src/main/java/net/causw/app/main/dto/user/BatchRegisterResponseDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/user/BatchRegisterResponseDto.java
@@ -2,4 +2,5 @@ package net.causw.app.main.dto.user;
 
 import java.util.List;
 
-public record BatchRegisterResponseDto(Integer successCount, Integer failureCount, List<String> failureMessages) {}
+public record BatchRegisterResponseDto(Integer successCount, Integer failureCount, List<String> failureMessages) {
+}

--- a/app-main/src/main/java/net/causw/app/main/dto/user/CreateGraduatedUserCommand.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/user/CreateGraduatedUserCommand.java
@@ -9,4 +9,5 @@ public record CreateGraduatedUserCommand(
 	String nickname,
 	String major,
 	String phoneNumber
-) {}
+) {
+}

--- a/app-main/src/main/java/net/causw/app/main/dto/user/UserPrivilegedResponseDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/user/UserPrivilegedResponseDto.java
@@ -16,4 +16,5 @@ public class UserPrivilegedResponseDto {
 	private List<UserResponseDto> leaderGradeUsers;
 	private List<UserResponseDto> leaderCircleUsers;
 	private List<UserResponseDto> leaderAlumni;
+	private List<UserResponseDto> alumniManager;
 }

--- a/app-main/src/main/java/net/causw/app/main/dto/util/dtoMapper/UserDtoMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/util/dtoMapper/UserDtoMapper.java
@@ -133,7 +133,9 @@ public interface UserDtoMapper extends UuidFileToUrlDtoMapper {
 		List<UserResponseDto> leaderGrade3,
 		List<UserResponseDto> leaderGrade4,
 		List<UserResponseDto> leaderCircle,
-		List<UserResponseDto> alumni
+		List<UserResponseDto> alumniLeader,
+		List<UserResponseDto> alumniManager
+
 	) {
 		List<UserResponseDto> leaderGrade = new LinkedList<>(leaderGrade1);
 		leaderGrade.addAll(leaderGrade2);
@@ -145,7 +147,8 @@ public interface UserDtoMapper extends UuidFileToUrlDtoMapper {
 			.councilUsers(council)
 			.leaderGradeUsers(leaderGrade)
 			.leaderCircleUsers(leaderCircle)
-			.leaderAlumni(alumni)
+			.leaderAlumni(alumniLeader)
+			.alumniManager(alumniManager)
 			.build();
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/infrastructure/querydsl/QuerydslConfig.java
+++ b/app-main/src/main/java/net/causw/app/main/infrastructure/querydsl/QuerydslConfig.java
@@ -1,0 +1,21 @@
+package net.causw.app.main.infrastructure.querydsl;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/infrastructure/security/userdetails/CustomUserDetailsService.java
+++ b/app-main/src/main/java/net/causw/app/main/infrastructure/security/userdetails/CustomUserDetailsService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 
 import net.causw.app.main.domain.model.entity.user.User;
 import net.causw.app.main.repository.user.UserRepository;
+import net.causw.app.main.repository.user.query.UserQueryRepository;
 import net.causw.global.constant.MessageUtil;
 import net.causw.global.exception.BadRequestException;
 import net.causw.global.exception.ErrorCode;
@@ -17,6 +18,7 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 	private final UserRepository userRepository;
+	private final UserQueryRepository userQueryRepository;
 
 	@Override
 	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
@@ -29,7 +31,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 	}
 
 	public UserDetails loadUserByUserId(String userId) throws UsernameNotFoundException {
-		User user = userRepository.findById(userId)
+		User user = userQueryRepository.findByIdWithRoles(userId)
 			.orElseThrow(() -> new BadRequestException(
 					ErrorCode.ROW_DOES_NOT_EXIST,
 					MessageUtil.LOGIN_USER_NOT_FOUND

--- a/app-main/src/main/java/net/causw/app/main/repository/circle/query/CircleQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/circle/query/CircleQueryRepository.java
@@ -1,0 +1,40 @@
+package net.causw.app.main.repository.circle.query;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import net.causw.app.main.domain.model.entity.circle.Circle;
+import net.causw.app.main.domain.model.entity.circle.QCircle;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CircleQueryRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	// Interface 프로젝션 (더 유연한 방식)
+	public interface CircleLeaderProjection {
+		String getId();
+		String getLeaderId();
+	}
+
+	// Interface 프로젝션 사용 (QueryDSL에서 직접 지원)
+	public List<CircleLeaderProjection> findCircleLeaderProjectionByLeaderIds(List<String> leaderUserIds) {
+		QCircle circle = QCircle.circle;
+
+		return jpaQueryFactory
+			.select(Projections.fields(CircleLeaderProjection.class,
+				circle.id.as("circleId"),
+				circle.leader.id.as("leaderId")
+			))
+			.from(circle)
+			.where(circle.leader.id.in(leaderUserIds))
+			.fetch();
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/repository/circle/query/CircleQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/circle/query/CircleQueryRepository.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Repository;
 import net.causw.app.main.domain.model.entity.circle.Circle;
 import net.causw.app.main.domain.model.entity.circle.QCircle;
 
-import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -18,22 +17,11 @@ public class CircleQueryRepository {
 
 	private final JPAQueryFactory jpaQueryFactory;
 
-	// Interface 프로젝션 (더 유연한 방식)
-	public interface CircleLeaderProjection {
-		String getId();
-		String getLeaderId();
-	}
-
-	// Interface 프로젝션 사용 (QueryDSL에서 직접 지원)
-	public List<CircleLeaderProjection> findCircleLeaderProjectionByLeaderIds(List<String> leaderUserIds) {
+	public List<Circle> findCirclesByLeaderIds(List<String> leaderUserIds) {
 		QCircle circle = QCircle.circle;
 
 		return jpaQueryFactory
-			.select(Projections.fields(CircleLeaderProjection.class,
-				circle.id.as("circleId"),
-				circle.leader.id.as("leaderId")
-			))
-			.from(circle)
+			.selectFrom(circle)
 			.where(circle.leader.id.in(leaderUserIds))
 			.fetch();
 	}

--- a/app-main/src/main/java/net/causw/app/main/repository/user/query/UserQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/user/query/UserQueryRepository.java
@@ -54,4 +54,19 @@ public class UserQueryRepository {
 
 		return Optional.ofNullable(result);
 	}
+
+	public Optional<User> findByEmail(String email) {
+		QUser user = QUser.user;
+
+		User result = jpaQueryFactory.selectFrom(user)
+			.where(user.email.eq(email))
+			.leftJoin(user.roles).fetchJoin()
+			.leftJoin(user.ceremonyNotificationSetting).fetchJoin()
+			.leftJoin(user.locker).fetchJoin()
+			.leftJoin(user.userProfileImage).fetchJoin()
+			.leftJoin(user.userProfileImage.uuidFile).fetchJoin()
+			.fetchOne();
+
+		return Optional.ofNullable(result);
+	}
 }

--- a/app-main/src/main/java/net/causw/app/main/repository/user/query/UserQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/user/query/UserQueryRepository.java
@@ -1,0 +1,62 @@
+package net.causw.app.main.repository.user.query;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Repository;
+
+import net.causw.app.main.domain.model.entity.user.QUser;
+import net.causw.app.main.domain.model.entity.user.User;
+import net.causw.app.main.domain.model.enums.user.Role;
+import net.causw.app.main.domain.model.enums.user.UserState;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserQueryRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	public List<User> findAllActiveUsersByRoles(List<Role> roles) {
+		QUser user = QUser.user;
+
+		BooleanBuilder predicate = new BooleanBuilder();
+
+		for (Role role : roles) {
+			predicate.or(user.roles.contains(role));
+		}
+		predicate.and(user.state.eq(UserState.ACTIVE));
+
+		return jpaQueryFactory.selectFrom(user)
+			.where(predicate)
+			.leftJoin(user.ceremonyNotificationSetting).fetchJoin() // ToOne 관계만 패치 조인
+			.leftJoin(user.ceremonyNotificationSetting.subscribedAdmissionYears).fetchJoin() // ToOne 관계만 패치 조인
+			.leftJoin(user.locker).fetchJoin()
+			.leftJoin(user.userProfileImage).fetchJoin()
+			.leftJoin(user.userProfileImage.uuidFile).fetchJoin()
+			.distinct()
+			.fetch();
+	}
+
+	public Optional<User> findByIdWithRoles(String userId) {
+		QUser user = QUser.user;
+		User result = jpaQueryFactory.selectFrom(user)
+			.where(user.id.eq(userId))
+			.leftJoin(user.roles).fetchJoin()
+			.leftJoin(user.ceremonyNotificationSetting).fetchJoin()
+			.leftJoin(user.ceremonyNotificationSetting.subscribedAdmissionYears).fetchJoin()
+			.leftJoin(user.locker).fetchJoin()
+			.leftJoin(user.userProfileImage).fetchJoin()
+			.leftJoin(user.userProfileImage.uuidFile).fetchJoin()
+			.fetchOne();
+
+		return Optional.ofNullable(result);
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/repository/user/query/UserQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/user/query/UserQueryRepository.java
@@ -49,8 +49,8 @@ public class UserQueryRepository {
 		QUser user = QUser.user;
 		User result = jpaQueryFactory.selectFrom(user)
 			.where(user.id.eq(userId))
+			.leftJoin(user.roles).fetchJoin()
 			.leftJoin(user.ceremonyNotificationSetting).fetchJoin()
-			.leftJoin(user.ceremonyNotificationSetting.subscribedAdmissionYears).fetchJoin()
 			.leftJoin(user.locker).fetchJoin()
 			.leftJoin(user.userProfileImage).fetchJoin()
 			.leftJoin(user.userProfileImage.uuidFile).fetchJoin()

--- a/app-main/src/main/java/net/causw/app/main/repository/user/query/UserQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/user/query/UserQueryRepository.java
@@ -1,10 +1,7 @@
 package net.causw.app.main.repository.user.query;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Repository;
 
@@ -36,8 +33,7 @@ public class UserQueryRepository {
 
 		return jpaQueryFactory.selectFrom(user)
 			.where(predicate)
-			.leftJoin(user.ceremonyNotificationSetting).fetchJoin() // ToOne 관계만 패치 조인
-			.leftJoin(user.ceremonyNotificationSetting.subscribedAdmissionYears).fetchJoin() // ToOne 관계만 패치 조인
+			.leftJoin(user.ceremonyNotificationSetting).fetchJoin()
 			.leftJoin(user.locker).fetchJoin()
 			.leftJoin(user.userProfileImage).fetchJoin()
 			.leftJoin(user.userProfileImage.uuidFile).fetchJoin()

--- a/app-main/src/main/java/net/causw/app/main/repository/user/query/UserQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/user/query/UserQueryRepository.java
@@ -49,7 +49,6 @@ public class UserQueryRepository {
 		QUser user = QUser.user;
 		User result = jpaQueryFactory.selectFrom(user)
 			.where(user.id.eq(userId))
-			.leftJoin(user.roles).fetchJoin()
 			.leftJoin(user.ceremonyNotificationSetting).fetchJoin()
 			.leftJoin(user.ceremonyNotificationSetting.subscribedAdmissionYears).fetchJoin()
 			.leftJoin(user.locker).fetchJoin()

--- a/app-main/src/main/java/net/causw/app/main/service/circle/CircleEntityService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/circle/CircleEntityService.java
@@ -1,0 +1,23 @@
+package net.causw.app.main.service.circle;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import net.causw.app.main.domain.model.entity.circle.Circle;
+import net.causw.app.main.repository.circle.query.CircleQueryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CircleEntityService {
+
+	private final CircleQueryRepository circleQueryRepository;
+
+	public List<Circle> findCirclesByLeaderIds(List<String> leaderUserIds) {
+
+		return circleQueryRepository
+			.findCirclesByLeaderIds(leaderUserIds);
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/service/user/UserEntityService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/user/UserEntityService.java
@@ -1,0 +1,22 @@
+package net.causw.app.main.service.user;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import net.causw.app.main.domain.model.entity.user.User;
+import net.causw.app.main.domain.model.enums.user.Role;
+import net.causw.app.main.repository.user.query.UserQueryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserEntityService {
+
+	private final UserQueryRepository userQueryRepository;
+
+	public List<User> findAllActiveUsersByRoles(List<Role> roles) {
+		return userQueryRepository.findAllActiveUsersByRoles(roles);
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/service/user/UserService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/user/UserService.java
@@ -577,7 +577,8 @@ public class UserService {
 			usersByRole.getOrDefault(Role.LEADER_3, List.of()),
 			usersByRole.getOrDefault(Role.LEADER_4, List.of()),
 			usersByRole.getOrDefault(Role.LEADER_CIRCLE, List.of()),
-			usersByRole.getOrDefault(Role.LEADER_ALUMNI, List.of())
+			usersByRole.getOrDefault(Role.LEADER_ALUMNI, List.of()),
+			usersByRole.getOrDefault(Role.ALUMNI_MANAGER, List.of())
 		);
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/service/user/useCase/FindPrivilegedUsersUseCaseService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/user/useCase/FindPrivilegedUsersUseCaseService.java
@@ -1,0 +1,142 @@
+package net.causw.app.main.service.user.useCase;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import net.causw.app.main.domain.model.entity.circle.Circle;
+import net.causw.app.main.domain.model.entity.user.User;
+import net.causw.app.main.domain.model.enums.user.Role;
+import net.causw.app.main.domain.validation.UserRoleIsNoneValidator;
+import net.causw.app.main.domain.validation.UserRoleValidator;
+import net.causw.app.main.domain.validation.UserStateValidator;
+import net.causw.app.main.domain.validation.ValidatorBucket;
+import net.causw.app.main.dto.user.UserPrivilegedResponseDto;
+import net.causw.app.main.dto.user.UserResponseDto;
+import net.causw.app.main.dto.util.dtoMapper.UserDtoMapper;
+import net.causw.app.main.service.circle.CircleEntityService;
+import net.causw.app.main.service.user.UserEntityService;
+import net.causw.global.constant.MessageUtil;
+import net.causw.global.exception.ErrorCode;
+import net.causw.global.exception.InternalServerException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FindPrivilegedUsersUseCaseService {
+
+	private final CircleEntityService circleEntityService;
+	private final UserEntityService userEntityService;
+
+
+	@Transactional(readOnly = true)
+	public UserPrivilegedResponseDto execute(User requestUser) {
+		validateRequestUser(requestUser);
+
+		List<Role> targetRoles = Role.getPrivilegedRoles();
+		List<User> privilegedUsers = userEntityService.findAllActiveUsersByRoles(targetRoles);
+
+		List<String> leaderUserIds = new ArrayList<>();
+		for (User u : privilegedUsers) {
+			if (u.getRoles().contains(Role.LEADER_CIRCLE)) {
+				leaderUserIds.add(u.getId());
+			}
+		}
+
+		Map<String, List<Circle>> circlesByLeaderId = new HashMap<>();
+		if (!leaderUserIds.isEmpty()) {
+			List<Circle> circles = circleEntityService.findCirclesByLeaderIds(leaderUserIds);
+
+			for (Circle circle : circles) {
+				if (circle.getLeader().isPresent()) {
+					String leaderId = circle.getLeader().get().getId();
+					circlesByLeaderId.computeIfAbsent(leaderId, k -> new ArrayList<>()).add(circle);
+				}
+			}
+
+			validateCircleLeaderUsersWithOutCircle(leaderUserIds, circlesByLeaderId);
+		}
+
+		Map<Role, List<User>> usersByRoleRaw = new EnumMap<>(Role.class);
+		for (User u : privilegedUsers) {
+			for (Role role : u.getRoles()) {
+				usersByRoleRaw.computeIfAbsent(role, k -> new ArrayList<>()).add(u);
+			}
+		}
+
+		Map<Role, List<UserResponseDto>> usersByRole = new EnumMap<>(Role.class);
+		for (Role role : targetRoles) {
+			List<UserResponseDto> dtoList = new ArrayList<>();
+			List<User> roleUsers = usersByRoleRaw.getOrDefault(role, List.of());
+
+			for (User u : roleUsers) {
+				if (role == Role.LEADER_CIRCLE) {
+					List<Circle> userCircles = circlesByLeaderId.getOrDefault(u.getId(), List.of());
+					List<String> circleIds = new ArrayList<>();
+					List<String> circleNames = new ArrayList<>();
+					for (Circle c : userCircles) {
+						circleIds.add(c.getId());
+						circleNames.add(c.getName());
+					}
+					dtoList.add(UserDtoMapper.INSTANCE.toUserResponseDto(u, circleIds, circleNames));
+				} else {
+					dtoList.add(UserDtoMapper.INSTANCE.toUserResponseDto(u, List.of(), List.of()));
+				}
+			}
+
+			usersByRole.put(role, dtoList);
+		}
+
+		return UserDtoMapper.INSTANCE.toUserPrivilegedResponseDto(
+			usersByRole.getOrDefault(Role.PRESIDENT, List.of()),
+			usersByRole.getOrDefault(Role.VICE_PRESIDENT, List.of()),
+			usersByRole.getOrDefault(Role.COUNCIL, List.of()),
+			usersByRole.getOrDefault(Role.LEADER_1, List.of()),
+			usersByRole.getOrDefault(Role.LEADER_2, List.of()),
+			usersByRole.getOrDefault(Role.LEADER_3, List.of()),
+			usersByRole.getOrDefault(Role.LEADER_4, List.of()),
+			usersByRole.getOrDefault(Role.LEADER_CIRCLE, List.of()),
+			usersByRole.getOrDefault(Role.LEADER_ALUMNI, List.of()),
+			usersByRole.getOrDefault(Role.ALUMNI_MANAGER, List.of())
+		);
+	}
+
+
+	private void validateRequestUser(User requester) {
+		Set<Role> roles = requester.getRoles();
+		ValidatorBucket.of()
+			.consistOf(UserStateValidator.of(requester.getState()))
+			.consistOf(UserRoleIsNoneValidator.of(roles))
+			.consistOf(UserRoleValidator.of(roles, Set.of()))
+			.validate();
+	}
+
+	/**
+	 * cirlce 이 존재하지 않는 circleLeader 발견 시 오류 발생
+	 * @param leaderUserIds 동아리 리더 유저 아이디 리스트
+	 */
+	private void validateCircleLeaderUsersWithOutCircle(
+		List<String> leaderUserIds,
+		Map<String, List<Circle>> circlesByLeaderId
+	) {
+		List<String> leadersWithoutCircle = leaderUserIds.stream()
+			.filter(leaderId -> !circlesByLeaderId.containsKey(leaderId) || circlesByLeaderId.get(leaderId).isEmpty())
+			.toList();
+
+		if (!leadersWithoutCircle.isEmpty()) {
+			throw new InternalServerException(
+				ErrorCode.INTERNAL_SERVER,
+				MessageUtil.NO_ASSIGNED_CIRCLE_FOR_LEADER
+			);
+		}
+	}
+
+}

--- a/app-main/src/main/java/net/causw/app/main/service/user/useCase/RegisterGraduatedUsersUseCaseService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/user/useCase/RegisterGraduatedUsersUseCaseService.java
@@ -1,7 +1,21 @@
 package net.causw.app.main.service.user.useCase;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.StreamSupport;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import net.causw.app.main.dto.user.BatchRegisterResponseDto;
 import net.causw.app.main.dto.user.GraduatedUserRegisterRequestDto;
@@ -12,22 +26,8 @@ import net.causw.global.exception.BadRequestException;
 import net.causw.global.exception.ErrorCode;
 import net.causw.global.exception.InternalServerException;
 
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVRecord;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.StreamSupport;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor

--- a/app-main/src/main/resources/db/migration/V20250921152909__ModifyUserRoleField.sql
+++ b/app-main/src/main/resources/db/migration/V20250921152909__ModifyUserRoleField.sql
@@ -1,0 +1,6 @@
+-- Migration: ModifyUserRoleField
+
+alter table user_roles
+    modify role enum ('ADMIN', 'PRESIDENT', 'VICE_PRESIDENT', 'COUNCIL', 'LEADER_1',
+    'LEADER_2', 'LEADER_3', 'LEADER_4', 'LEADER_CIRCLE', 'LEADER_ALUMNI',
+    'COMMON', 'NONE', 'PROFESSOR', 'ALUMNI_MANAGER') not null;


### PR DESCRIPTION
### 🚩 관련사항
#981 


### 📢 전달사항
간만입니다.

- 이번 풀리퀘스트에서는 크자회 운영자 `ALUMNI_MANAGER` role을 추가했습니다.
`ALUMNI_MANAGER` 의 경우 기존 크자회 운영자와 완전히 같은 권한을 가지도록 했습니다.
Role 관련해서 심도깊게 확인해주시면 감사하겠습니다.
제가 놓친 부분이 있을 수도 있어서요..

- queryDSL 을 도입했습니다.
동적 쿼리를 꼭 써야하는 코드들은 아니었습니다만,, 추후 있을 리팩토링에서 n+1 문제를 효과적으로 해결하기 위해서 queryDSL 을 도입하는 것이 불가피하다는 판단이었습니다.
queryDSL 레포지토리를 만드실 때에는 일단은 `repository/query/{Domain이름}QueryRepository` 로 작명하는 것을 임시 원칙으로 하겠습니다. 유념해주세요!

- `/api/v1/users/privileged` 에서 발생하던 n+1 문제를 해결했습니다.
쿼리로그를 처음으로 켜본거 같은데 이 GET 요청 한번 날리는데 1만줄의 쿼리가 발생하더군요,,(format_sql=true여서 그렇긴하지만)
n+1 문제를 해결하면서 겸사겸사 User에 붙어있던 eager 로딩을 제거했습니다.
++) eager 로딩 사용할 때에는 정말 필요할까,,? 라는 생각을 한번 해보는 것도 좋을거 같아요..


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 