### PR TITLE
[BUG] 일부 안드로이드 기기에서 크롤링한 이미지가 보이지 않음

### DIFF
--- a/global/src/main/java/net/causw/global/constant/StaticValue.java
+++ b/global/src/main/java/net/causw/global/constant/StaticValue.java
@@ -106,6 +106,9 @@ public class StaticValue {
 		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Safari/605.1.15",
 		"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 	};
+	// 이미지 URL 정규화 관련 상수
+	public static final List<String> IMAGE_SRC_ATTRIBUTES = List.of("src", "data-src", "data-original", "data-lazy");
+	public static final List<String> REMOVABLE_IMAGE_ATTRIBUTES = List.of("data-src", "data-original", "data-lazy", "srcset");
 
 	// Hash
 	public static final String HASH_ALGORITHM = "SHA-256";


### PR DESCRIPTION
### 🚩 관련사항
#985 


### 📢 전달사항
- 앱은 https:// 주소(보안 연결)로 페이지를 불러옴
- 그런데 페이지 안에 들어 있는 이미지 주소가 http:// (비보안 연결)
- 최신 브라우저/웹뷰(안드로이드 WebView 포함)는 보안 정책상 HTTP 자원 로딩을 차단
- 그래서 이미지가 뜨지 않고, 콘솔에 Mixed Content 에러가 떴음
- 따라서 이미지 관련 html을 정규화해 https로 교체함

### 📸 스크린샷
<img width="1102" height="644" alt="스크린샷 2025-09-23 오후 2 05 04" src="https://github.com/user-attachments/assets/f0cabdc0-87ee-4e81-ad49-a91df481e182" />



### 📃 진행사항
- [x] 이미지 관련 html 정규화 
- [x] 에뮬레이터로 확인 완료


### ⚙️ 기타사항
그리고 에뮬레이터로 디버깅하는 방법 노션에 문서화 해뒀습니다~
https://www.notion.so/2743d138d33c80fe89fae595ea570bed?source=copy_link


개발기간: 2d