### PR TITLE
feat: 동문수첩 리스트 검색 api 구현

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/controller/UserInfoController.java
+++ b/app-main/src/main/java/net/causw/app/main/controller/UserInfoController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import net.causw.app.main.dto.userInfo.UserInfoResponseDto;
-import net.causw.app.main.dto.userInfo.UserInfoSearchCondition;
+import net.causw.app.main.dto.userInfo.UserInfoSearchConditionDto;
 import net.causw.app.main.dto.userInfo.UserInfoSummaryResponseDto;
 import net.causw.app.main.dto.userInfo.UserInfoUpdateRequestDto;
 import net.causw.app.main.infrastructure.security.userdetails.CustomUserDetails;
@@ -56,9 +56,9 @@ public class UserInfoController {
 	@GetMapping
 	@ResponseStatus(value = HttpStatus.OK)
 	@Operation(summary = "전체 사용자 리스트 검색 및 조회 API", description = "최근 수정된 순서대로 정렬")
-	public Page<UserInfoSummaryResponseDto> userInfoList(
+	public Page<UserInfoSummaryResponseDto> searchUserInfos	(
 		@RequestParam(name = "pageNum", defaultValue = "0") Integer pageNum,
-		@ModelAttribute UserInfoSearchCondition userInfoSearchCondition
+		@ModelAttribute UserInfoSearchConditionDto userInfoSearchCondition
 	) {
 		return searchUserInfoListUseCaseService.execute(userInfoSearchCondition, pageNum);
 	}

--- a/app-main/src/main/java/net/causw/app/main/controller/UserInfoController.java
+++ b/app-main/src/main/java/net/causw/app/main/controller/UserInfoController.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,10 +16,12 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import net.causw.app.main.dto.userInfo.UserInfoResponseDto;
+import net.causw.app.main.dto.userInfo.UserInfoSearchCondition;
 import net.causw.app.main.dto.userInfo.UserInfoSummaryResponseDto;
 import net.causw.app.main.dto.userInfo.UserInfoUpdateRequestDto;
 import net.causw.app.main.infrastructure.security.userdetails.CustomUserDetails;
 import net.causw.app.main.service.userInfo.UserInfoService;
+import net.causw.app.main.service.userInfo.useCase.query.SearchUserInfoListUseCaseService;
 import net.causw.global.exception.BadRequestException;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,6 +37,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserInfoController {
 	private final UserInfoService userInfoService;
+	private final SearchUserInfoListUseCaseService searchUserInfoListUseCaseService;
 
 	/**
 	 *  사용자 고유 id 값으로 사용자 세부정보를 조회하는 API
@@ -51,11 +55,12 @@ public class UserInfoController {
 
 	@GetMapping
 	@ResponseStatus(value = HttpStatus.OK)
-	@Operation(summary = "전체 사용자 리스트 조회 API", description = "최근 수정된 순서대로 정렬")
-	public Page<UserInfoSummaryResponseDto> getAllUserInfos(
-		@RequestParam(name = "pageNum", defaultValue = "0") Integer pageNum
+	@Operation(summary = "전체 사용자 리스트 검색 및 조회 API", description = "최근 수정된 순서대로 정렬")
+	public Page<UserInfoSummaryResponseDto> userInfoList(
+		@RequestParam(name = "pageNum", defaultValue = "0") Integer pageNum,
+		@ModelAttribute UserInfoSearchCondition userInfoSearchCondition
 	) {
-		return userInfoService.getAllUserInfos(pageNum);
+		return searchUserInfoListUseCaseService.execute(userInfoSearchCondition, pageNum);
 	}
 
 	@GetMapping(value = "/me")
@@ -82,15 +87,5 @@ public class UserInfoController {
 		@RequestPart(value = "profileImage", required = false) MultipartFile profileImage
 	) {
 		return userInfoService.update(userDetails.getUser().getId(), userInfoUpdateDto, profileImage);
-	}
-
-	@GetMapping(value = "/search")
-	@ResponseStatus(value = HttpStatus.OK)
-	@Operation(summary = "사용자 세부정보 조건 검색 API")
-	public Page<UserInfoSummaryResponseDto> search(
-		@RequestParam(name = "keyword", defaultValue = "") String keyword,
-		@RequestParam(name = "pageNum", defaultValue = "0") Integer pageNum
-	) {
-		return userInfoService.search(keyword, pageNum);
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/controller/UserInfoController.java
+++ b/app-main/src/main/java/net/causw/app/main/controller/UserInfoController.java
@@ -51,7 +51,7 @@ public class UserInfoController {
 
 	@GetMapping
 	@ResponseStatus(value = HttpStatus.OK)
-	@Operation(summary = "전체 사용자 세부정보 조회 API", description = "최근 수정된 순서대로 정렬")
+	@Operation(summary = "전체 사용자 리스트 조회 API", description = "최근 수정된 순서대로 정렬")
 	public Page<UserInfoSummaryResponseDto> getAllUserInfos(
 		@RequestParam(name = "pageNum", defaultValue = "0") Integer pageNum
 	) {

--- a/app-main/src/main/java/net/causw/app/main/domain/model/entity/user/User.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/entity/user/User.java
@@ -105,17 +105,17 @@ public class User extends BaseEntity {
 	@BatchSize(size = 100)
 	private Set<Role> roles;
 
-	@OneToOne(cascade = {CascadeType.REMOVE, CascadeType.PERSIST}, mappedBy = "user")
+	@OneToOne(cascade = {CascadeType.REMOVE, CascadeType.PERSIST}, mappedBy = "user", fetch = FetchType.LAZY)
 	private UserProfileImage userProfileImage;
 
 	@Column(name = "state", nullable = false)
 	@Enumerated(EnumType.STRING)
 	private UserState state;
 
-	@OneToOne(mappedBy = "user", fetch = FetchType.EAGER)
+	@OneToOne(mappedBy = "user", fetch = FetchType.LAZY)
 	private Locker locker;
 
-	@OneToOne(mappedBy = "user", fetch = FetchType.EAGER)
+	@OneToOne(mappedBy = "user", fetch = FetchType.LAZY)
 	private CeremonyNotificationSetting ceremonyNotificationSetting;
 
 	@OneToMany(mappedBy = "user", fetch = FetchType.LAZY)

--- a/app-main/src/main/java/net/causw/app/main/domain/model/entity/uuidFile/joinEntity/UserProfileImage.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/entity/uuidFile/joinEntity/UserProfileImage.java
@@ -29,7 +29,7 @@ import lombok.Setter;
 public class UserProfileImage extends JoinEntity {
 
 	@Setter(AccessLevel.PUBLIC)
-	@OneToOne(fetch = FetchType.EAGER)
+	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "uuid_file_id", nullable = false, unique = true)
 	public UuidFile uuidFile;
 

--- a/app-main/src/main/java/net/causw/app/main/dto/userInfo/UserInfoSearchCondition.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/userInfo/UserInfoSearchCondition.java
@@ -1,0 +1,13 @@
+package net.causw.app.main.dto.userInfo;
+
+import java.util.List;
+
+import net.causw.app.main.domain.model.enums.userAcademicRecord.AcademicStatus;
+
+public record UserInfoSearchCondition(
+	String keyword,
+	Integer admissionYearStart,
+	Integer admissionYearEnd,
+	List<AcademicStatus> academicStatus
+	) {
+}

--- a/app-main/src/main/java/net/causw/app/main/dto/userInfo/UserInfoSearchConditionDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/userInfo/UserInfoSearchConditionDto.java
@@ -4,10 +4,17 @@ import java.util.List;
 
 import net.causw.app.main.domain.model.enums.userAcademicRecord.AcademicStatus;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record UserInfoSearchConditionDto(
+
+	@Schema(description = "검색어(이름, 직업, 경력)", example = "홍길동")
 	String keyword,
+	@Schema(description = "입학 년도 검색 구간 하방", example = "1990")
 	Integer admissionYearStart,
+	@Schema(description = "입학 년도 검색 구간 상방", example = "2020")
 	Integer admissionYearEnd,
+	@Schema(description = "학적 상태(ENROLLED, LEAVE_OF_ABSENCE, GRADUATED, 그외 등등)", example = "ENROLLED")
 	List<AcademicStatus> academicStatus
 	) {
 }

--- a/app-main/src/main/java/net/causw/app/main/dto/userInfo/UserInfoSearchConditionDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/userInfo/UserInfoSearchConditionDto.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import net.causw.app.main.domain.model.enums.userAcademicRecord.AcademicStatus;
 
-public record UserInfoSearchCondition(
+public record UserInfoSearchConditionDto(
 	String keyword,
 	Integer admissionYearStart,
 	Integer admissionYearEnd,

--- a/app-main/src/main/java/net/causw/app/main/repository/userInfo/UserInfoRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/userInfo/UserInfoRepository.java
@@ -16,18 +16,4 @@ import net.causw.app.main.domain.model.enums.user.UserState;
 public interface UserInfoRepository extends JpaRepository<UserInfo, String> {
 
 	Optional<UserInfo> findByUserId(String userId);
-
-	Page<UserInfo> findAllByUserStateOrderByUpdatedAtDesc(UserState state, Pageable pageable);
-
-	@Query("""
-		SELECT DISTINCT ui FROM UserInfo ui
-		LEFT JOIN ui.userCareer uc
-		WHERE (uc.description LIKE CONCAT('%', :keyword, '%')
-		OR ui.user.name LIKE CONCAT('%', :keyword, '%')
-		OR ui.job LIKE CONCAT('%', :keyword, '%'))
-		AND ui.user.state = :state
-		ORDER BY ui.updatedAt DESC
-		""")
-	Page<UserInfo> findAllByUserStateAndKeywordInNameOrJobOrCareer(@Param("state") UserState state,
-		@Param("keyword") String keyword, Pageable pageable);
 }

--- a/app-main/src/main/java/net/causw/app/main/repository/userInfo/query/UserInfoQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/userInfo/query/UserInfoQueryRepository.java
@@ -1,0 +1,12 @@
+package net.causw.app.main.repository.userInfo.query;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import net.causw.app.main.domain.model.entity.userInfo.UserInfo;
+import net.causw.app.main.dto.userInfo.UserInfoSearchCondition;
+
+public interface UserInfoQueryRepository {
+
+	Page<UserInfo> searchUserInfo(UserInfoSearchCondition userInfoSearchCondition, Pageable pageable);
+}

--- a/app-main/src/main/java/net/causw/app/main/repository/userInfo/query/UserInfoQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/userInfo/query/UserInfoQueryRepository.java
@@ -4,9 +4,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import net.causw.app.main.domain.model.entity.userInfo.UserInfo;
-import net.causw.app.main.dto.userInfo.UserInfoSearchCondition;
+import net.causw.app.main.dto.userInfo.UserInfoSearchConditionDto;
 
 public interface UserInfoQueryRepository {
 
-	Page<UserInfo> searchUserInfo(UserInfoSearchCondition userInfoSearchCondition, Pageable pageable);
+	Page<UserInfo> searchUserInfo(UserInfoSearchConditionDto userInfoSearchCondition, Pageable pageable);
 }

--- a/app-main/src/main/java/net/causw/app/main/repository/userInfo/query/UserInfoQueryRepositoryImpl.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/userInfo/query/UserInfoQueryRepositoryImpl.java
@@ -47,6 +47,7 @@ public class UserInfoQueryRepositoryImpl implements UserInfoQueryRepository {
 			.leftJoin(user.ceremonyNotificationSetting).fetchJoin()
 			.leftJoin(user.locker).fetchJoin()
 			.where(user.state.eq(UserState.ACTIVE))
+			.where(user.academicStatus.ne(AcademicStatus.UNDETERMINED))
 			.where(predicate)
 			.orderBy(userInfo.updatedAt.desc())
 			.offset(pageable.getOffset())

--- a/app-main/src/main/java/net/causw/app/main/repository/userInfo/query/UserInfoQueryRepositoryImpl.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/userInfo/query/UserInfoQueryRepositoryImpl.java
@@ -15,7 +15,7 @@ import net.causw.app.main.domain.model.entity.uuidFile.QUuidFile;
 import net.causw.app.main.domain.model.entity.uuidFile.joinEntity.QUserProfileImage;
 import net.causw.app.main.domain.model.enums.user.UserState;
 import net.causw.app.main.domain.model.enums.userAcademicRecord.AcademicStatus;
-import net.causw.app.main.dto.userInfo.UserInfoSearchCondition;
+import net.causw.app.main.dto.userInfo.UserInfoSearchConditionDto;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.JPAExpressions;
@@ -29,7 +29,7 @@ public class UserInfoQueryRepositoryImpl implements UserInfoQueryRepository {
 	private final JPAQueryFactory jpaQueryFactory;
 
 	@Override
-	public Page<UserInfo> searchUserInfo(UserInfoSearchCondition userInfoSearchCondition, Pageable pageable) {
+	public Page<UserInfo> searchUserInfo(UserInfoSearchConditionDto userInfoSearchCondition, Pageable pageable) {
 		// keyword는 이름, 직업, 경력, like 검색
 		// user, job, user.carrer
 		QUserInfo userInfo = QUserInfo.userInfo;
@@ -71,7 +71,7 @@ public class UserInfoQueryRepositoryImpl implements UserInfoQueryRepository {
 	 * @return 검색 조건 booleanBuilder
 	 */
 	private BooleanBuilder buildSearchPredicate(
-		UserInfoSearchCondition userInfoSearchCondition,
+		UserInfoSearchConditionDto userInfoSearchCondition,
 		QUserInfo userInfo
 	) {
 		BooleanBuilder predicate = new BooleanBuilder();

--- a/app-main/src/main/java/net/causw/app/main/repository/userInfo/query/UserInfoQueryRepositoryImpl.java
+++ b/app-main/src/main/java/net/causw/app/main/repository/userInfo/query/UserInfoQueryRepositoryImpl.java
@@ -1,0 +1,115 @@
+package net.causw.app.main.repository.userInfo.query;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import net.causw.app.main.domain.model.entity.user.QUser;
+import net.causw.app.main.domain.model.entity.userInfo.QUserCareer;
+import net.causw.app.main.domain.model.entity.userInfo.QUserInfo;
+import net.causw.app.main.domain.model.entity.userInfo.UserInfo;
+import net.causw.app.main.domain.model.entity.uuidFile.QUuidFile;
+import net.causw.app.main.domain.model.entity.uuidFile.joinEntity.QUserProfileImage;
+import net.causw.app.main.domain.model.enums.user.UserState;
+import net.causw.app.main.domain.model.enums.userAcademicRecord.AcademicStatus;
+import net.causw.app.main.dto.userInfo.UserInfoSearchCondition;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserInfoQueryRepositoryImpl implements UserInfoQueryRepository {
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public Page<UserInfo> searchUserInfo(UserInfoSearchCondition userInfoSearchCondition, Pageable pageable) {
+		// keyword는 이름, 직업, 경력, like 검색
+		// user, job, user.carrer
+		QUserInfo userInfo = QUserInfo.userInfo;
+		BooleanBuilder predicate = buildSearchPredicate(userInfoSearchCondition, userInfo);
+
+		QUser user = QUser.user;
+		QUserProfileImage userProfileImage = QUserProfileImage.userProfileImage;
+		QUuidFile uuidFile = QUuidFile.uuidFile;
+
+		List<UserInfo> content = jpaQueryFactory
+			.selectFrom(userInfo)
+			.join(userInfo.user, user).fetchJoin()
+			.leftJoin(user.userProfileImage, userProfileImage).fetchJoin()
+			.leftJoin(userProfileImage.uuidFile, uuidFile).fetchJoin()
+			.leftJoin(user.ceremonyNotificationSetting).fetchJoin()
+			.leftJoin(user.locker).fetchJoin()
+			.where(user.state.eq(UserState.ACTIVE))
+			.where(predicate)
+			.orderBy(userInfo.updatedAt.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.distinct()
+			.fetch();
+
+		Long total = jpaQueryFactory
+			.select(userInfo.count())
+			.from(userInfo)
+			.where(predicate)
+			.fetchOne();
+
+		return new PageImpl<>(content, pageable, total != null ? total : 0);
+	}
+
+	/**
+	 * 검색 조건 생성
+	 * (학번, 학적상태 (in), 이름 or 직업 or 커리어,텍스트 검색)
+	 * @param userInfoSearchCondition 검색 조건 dto
+	 * @param userInfo 검색 QueryDSL 엔티티
+	 * @return 검색 조건 booleanBuilder
+	 */
+	private BooleanBuilder buildSearchPredicate(
+		UserInfoSearchCondition userInfoSearchCondition,
+		QUserInfo userInfo
+	) {
+		BooleanBuilder predicate = new BooleanBuilder();
+		String keyword = userInfoSearchCondition.keyword();
+
+		QUserCareer userCareer = QUserCareer.userCareer;
+		if (keyword != null && !keyword.trim().isEmpty()) {
+			BooleanBuilder keywordPredicate = new BooleanBuilder();
+			keywordPredicate.or(userInfo.user.name.containsIgnoreCase(keyword));
+			keywordPredicate.or(userInfo.job.containsIgnoreCase(keyword));
+			keywordPredicate.or(JPAExpressions.selectFrom(userCareer)
+				.where(userCareer.userInfo.eq(userInfo)
+					.and(userCareer.description.containsIgnoreCase(keyword)))
+				.exists());
+
+			predicate.and(keywordPredicate);
+		}
+
+		// 입학 년도 검색
+		Integer admissionYearStart = userInfoSearchCondition.admissionYearStart();
+		Integer admissionYearEnd = userInfoSearchCondition.admissionYearEnd();
+		if (
+			admissionYearStart != null && admissionYearEnd != null
+		) {
+			BooleanBuilder admissionYearPredicate = new BooleanBuilder();
+			admissionYearPredicate.and(userInfo.user.admissionYear.between(admissionYearStart, admissionYearEnd));
+
+			predicate.and(admissionYearPredicate);
+		}
+
+		// 학적 상태
+		List<AcademicStatus> academicStatuses = userInfoSearchCondition.academicStatus();
+		if (academicStatuses != null && !academicStatuses.isEmpty()) {
+			BooleanBuilder academicStatusPredicate = new BooleanBuilder();
+			academicStatusPredicate.and(userInfo.user.academicStatus.in(academicStatuses));
+
+			predicate.and(academicStatusPredicate);
+		}
+		return predicate;
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/service/userInfo/UserInfoService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/userInfo/UserInfoService.java
@@ -1,7 +1,5 @@
 package net.causw.app.main.service.userInfo;
 
-import static net.causw.global.constant.StaticValue.*;
-
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
@@ -23,16 +21,13 @@ import net.causw.app.main.domain.model.enums.user.UserState;
 import net.causw.app.main.dto.user.UserUpdateRequestDto;
 import net.causw.app.main.dto.userInfo.UserCareerDto;
 import net.causw.app.main.dto.userInfo.UserInfoResponseDto;
-import net.causw.app.main.dto.userInfo.UserInfoSearchCondition;
-import net.causw.app.main.dto.userInfo.UserInfoSummaryResponseDto;
+import net.causw.app.main.dto.userInfo.UserInfoSearchConditionDto;
 import net.causw.app.main.dto.userInfo.UserInfoUpdateRequestDto;
 import net.causw.app.main.dto.util.dtoMapper.UserDtoMapper;
 import net.causw.app.main.repository.user.UserRepository;
 import net.causw.app.main.repository.userInfo.UserCareerRepository;
 import net.causw.app.main.repository.userInfo.UserInfoRepository;
 import net.causw.app.main.repository.userInfo.query.UserInfoQueryRepository;
-import net.causw.app.main.repository.userInfo.query.UserInfoQueryRepositoryImpl;
-import net.causw.app.main.service.pageable.PageableFactory;
 import net.causw.app.main.service.user.UserService;
 import net.causw.global.constant.MessageUtil;
 import net.causw.global.exception.BadRequestException;
@@ -46,7 +41,6 @@ public class UserInfoService {
 	private final UserInfoRepository userInfoRepository;
 	private final UserRepository userRepository;
 	private final UserService userService;
-	private final PageableFactory pageableFactory;
 	private final UserCareerRepository userCareerRepository;
 	private final UserInfoQueryRepository userInfoQueryRepository;
 
@@ -148,15 +142,7 @@ public class UserInfoService {
 		}
 	}
 
-	@Transactional(readOnly = true)
-	public Page<UserInfoSummaryResponseDto> search(final String keyword, final Integer pageNum) {
-
-		return userInfoRepository.findAllByUserStateAndKeywordInNameOrJobOrCareer(
-				UserState.ACTIVE, keyword, pageableFactory.create(pageNum, DEFAULT_PAGE_SIZE))
-			.map(UserDtoMapper.INSTANCE::toUserInfoSummaryResponseDto);
-	}
-
-	public Page<UserInfo> searchUserInfo(Pageable pageable, UserInfoSearchCondition userInfoSearchCondition) {
+	public Page<UserInfo> searchUserInfo(Pageable pageable, UserInfoSearchConditionDto userInfoSearchCondition) {
 		return userInfoQueryRepository.searchUserInfo(userInfoSearchCondition, pageable);
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/service/userInfo/UserInfoService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/userInfo/UserInfoService.java
@@ -156,16 +156,16 @@ public class UserInfoService {
 			.map(UserDtoMapper.INSTANCE::toUserInfoSummaryResponseDto);
 	}
 
+	public Page<UserInfo> searchUserInfo(Pageable pageable, UserInfoSearchCondition userInfoSearchCondition) {
+		return userInfoQueryRepository.searchUserInfo(userInfoSearchCondition, pageable);
+	}
+
 	private User findUserById(String userId) {
 		return userRepository.findById(userId)
 			.orElseThrow(() -> new BadRequestException(
 				ErrorCode.ROW_DOES_NOT_EXIST,
 				MessageUtil.USER_NOT_FOUND
 			));
-	}
-
-	public Page<UserInfo> searchUserInfo(Pageable pageable, UserInfoSearchCondition userInfoSearchCondition) {
-		return userInfoQueryRepository.searchUserInfo(userInfoSearchCondition, pageable);
 	}
 
 	private void validateUserCareerDate(UserCareerDto userCareerDto) {

--- a/app-main/src/main/java/net/causw/app/main/service/userInfo/UserInfoService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/userInfo/UserInfoService.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -22,12 +23,15 @@ import net.causw.app.main.domain.model.enums.user.UserState;
 import net.causw.app.main.dto.user.UserUpdateRequestDto;
 import net.causw.app.main.dto.userInfo.UserCareerDto;
 import net.causw.app.main.dto.userInfo.UserInfoResponseDto;
+import net.causw.app.main.dto.userInfo.UserInfoSearchCondition;
 import net.causw.app.main.dto.userInfo.UserInfoSummaryResponseDto;
 import net.causw.app.main.dto.userInfo.UserInfoUpdateRequestDto;
 import net.causw.app.main.dto.util.dtoMapper.UserDtoMapper;
 import net.causw.app.main.repository.user.UserRepository;
 import net.causw.app.main.repository.userInfo.UserCareerRepository;
 import net.causw.app.main.repository.userInfo.UserInfoRepository;
+import net.causw.app.main.repository.userInfo.query.UserInfoQueryRepository;
+import net.causw.app.main.repository.userInfo.query.UserInfoQueryRepositoryImpl;
 import net.causw.app.main.service.pageable.PageableFactory;
 import net.causw.app.main.service.user.UserService;
 import net.causw.global.constant.MessageUtil;
@@ -44,13 +48,7 @@ public class UserInfoService {
 	private final UserService userService;
 	private final PageableFactory pageableFactory;
 	private final UserCareerRepository userCareerRepository;
-
-	@Transactional(readOnly = true)
-	public Page<UserInfoSummaryResponseDto> getAllUserInfos(Integer pageNum) {
-		return userInfoRepository.findAllByUserStateOrderByUpdatedAtDesc(UserState.ACTIVE,
-				pageableFactory.create(pageNum, DEFAULT_PAGE_SIZE))
-			.map(UserDtoMapper.INSTANCE::toUserInfoSummaryResponseDto);
-	}
+	private final UserInfoQueryRepository userInfoQueryRepository;
 
 	@Transactional(readOnly = true)
 	public UserInfoResponseDto getUserInfoByUserId(String userId) {
@@ -152,6 +150,7 @@ public class UserInfoService {
 
 	@Transactional(readOnly = true)
 	public Page<UserInfoSummaryResponseDto> search(final String keyword, final Integer pageNum) {
+
 		return userInfoRepository.findAllByUserStateAndKeywordInNameOrJobOrCareer(
 				UserState.ACTIVE, keyword, pageableFactory.create(pageNum, DEFAULT_PAGE_SIZE))
 			.map(UserDtoMapper.INSTANCE::toUserInfoSummaryResponseDto);
@@ -163,6 +162,10 @@ public class UserInfoService {
 				ErrorCode.ROW_DOES_NOT_EXIST,
 				MessageUtil.USER_NOT_FOUND
 			));
+	}
+
+	public Page<UserInfo> searchUserInfo(Pageable pageable, UserInfoSearchCondition userInfoSearchCondition) {
+		return userInfoQueryRepository.searchUserInfo(userInfoSearchCondition, pageable);
 	}
 
 	private void validateUserCareerDate(UserCareerDto userCareerDto) {

--- a/app-main/src/main/java/net/causw/app/main/service/userInfo/useCase/query/SearchUserInfoListUseCaseService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/userInfo/useCase/query/SearchUserInfoListUseCaseService.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import net.causw.app.main.dto.userInfo.UserInfoSearchCondition;
+import net.causw.app.main.dto.userInfo.UserInfoSearchConditionDto;
 import net.causw.app.main.dto.userInfo.UserInfoSummaryResponseDto;
 import net.causw.app.main.dto.util.dtoMapper.UserDtoMapper;
 import net.causw.app.main.service.pageable.PageableFactory;
@@ -24,7 +24,7 @@ public class SearchUserInfoListUseCaseService {
 	private final PageableFactory pageableFactory;
 	private final UserDtoMapper userDtoMapper;
 
-	public Page<UserInfoSummaryResponseDto> execute(UserInfoSearchCondition userInfoSearchCondition, Integer pageNum) {
+	public Page<UserInfoSummaryResponseDto> execute(UserInfoSearchConditionDto userInfoSearchCondition, Integer pageNum) {
 		Pageable pageable = pageableFactory.create(pageNum, DEFAULT_PAGE_SIZE);
 
 		return userInfoService.searchUserInfo(pageable, userInfoSearchCondition)

--- a/app-main/src/main/java/net/causw/app/main/service/userInfo/useCase/query/SearchUserInfoListUseCaseService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/userInfo/useCase/query/SearchUserInfoListUseCaseService.java
@@ -1,0 +1,33 @@
+package net.causw.app.main.service.userInfo.useCase.query;
+
+import static net.causw.global.constant.StaticValue.*;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import net.causw.app.main.dto.userInfo.UserInfoSearchCondition;
+import net.causw.app.main.dto.userInfo.UserInfoSummaryResponseDto;
+import net.causw.app.main.dto.util.dtoMapper.UserDtoMapper;
+import net.causw.app.main.service.pageable.PageableFactory;
+import net.causw.app.main.service.userInfo.UserInfoService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SearchUserInfoListUseCaseService {
+
+	private final UserInfoService userInfoService;
+	private final PageableFactory pageableFactory;
+	private final UserDtoMapper userDtoMapper;
+
+	public Page<UserInfoSummaryResponseDto> execute(UserInfoSearchCondition userInfoSearchCondition, Integer pageNum) {
+		Pageable pageable = pageableFactory.create(pageNum, DEFAULT_PAGE_SIZE);
+
+		return userInfoService.searchUserInfo(pageable, userInfoSearchCondition)
+			.map(userDtoMapper::toUserInfoSummaryResponseDto);
+	}
+}


### PR DESCRIPTION
### 🚩 관련사항
Close #992 


### 📢 전달사항
전체 사용자 리스트 조회 API에 검색 조건을 추가하여 사용자를 검색하는 기능을 구현했습니다.
- 이름, 직업, 경력에 대한 키워드 검색 기능 추가
- 입학 년도 범위 검색 기능 추가
- 학적 상태 필터링 기능 추가
- 기존 검색 API 제거

- User 엔티티의 Locker, CeremonyNotificationSetting, UserProfileImage 필드에 대해 Lazy Loading을 적용했습니다.

- 기존의 `/api/v1/users-info/search` 엔드포인트를 삭제하고, 해당 기능을 `/api/v1/users-info` 엔드포인트로 합쳤습니다.

- queryDSL을 사용하여 검색 API를 개발했습니다. 참고해주시면 감사하겠습니다.


### 📸 스크린샷
<img width="1421" height="715" alt="image" src="https://github.com/user-attachments/assets/c5c8453e-74ff-4da4-aaa3-e654ac332c71" />



### 📃 진행사항


### ⚙️ 기타사항
- user 리스트를 조회할 경우 쿼리를 통해 확인해보니 `user.locker` 와 `user.ceremonyNotificationSetting` 에 대해서도 계속 쿼리를 요청하고 있어서 n+1 문제가 발생하고 있습니다.
문제는 얘네를 동문수첩 검색 로직상 사용하지 않고 있는데, 쿼리를 하고 있다는 겁니다. 처음에는 이게 eager 로딩 설정이 되어있어서 그런줄 알았는데, lazy 로딩으로 변경한 후에도 계속 해당 속성들에 대한 n+1 문제가 발생합니다.
userInfo.user를 매퍼에서 사용할 때에 모종의 이유로 locker와 ceremonyNotificationSetting 에 대해서도 요청을 하는것 같은데, 일단은 동문수첩 검색시 해당 속성들도 fetchJoin 을 진행하게 하여 n+1 문제는 막았습니다.
정확히 왜 이런 문제가 발생하는 지는 이슈 만들어서 추적해보겠습니다.

개발기간: 