### PR TITLE
refactor: 졸업생 일괄 등록 기능에 학과/학부명 상수화 반영 및 예외처리

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/model/entity/user/User.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/entity/user/User.java
@@ -183,7 +183,7 @@ public class User extends BaseEntity {
 			.build();
 	}
 
-	public static User createGraduatedUser(
+	public static User createGraduate(
 		GraduatedUserCommand graduatedUserCommand,
 		String encodedPassword
 	) {
@@ -198,14 +198,13 @@ public class User extends BaseEntity {
 			.graduationYear(graduatedUserCommand.graduationYear())
 			.nickname(graduatedUserCommand.nickname())
 			.department(graduatedUserCommand.department())
-
 			.academicStatus(AcademicStatus.GRADUATED)
 			.phoneNumber(graduatedUserCommand.phoneNumber())
 			.isV2(true)
 			.build();
 	}
 
-	public void update(String nickname, UserProfileImage userProfileImage, String phoneNumber) {
+	public void updateProfile(String nickname, UserProfileImage userProfileImage, String phoneNumber) {
 		this.nickname = nickname;
 		this.userProfileImage = userProfileImage;
 		if (phoneNumber != null && !NO_PHONE_NUMBER_MESSAGE.equals(phoneNumber)) {
@@ -213,13 +212,10 @@ public class User extends BaseEntity {
 		}
 	}
 
-	public void updateRejectionOrDropReason(String reason) {
-		this.rejectionOrDropReason = reason;
-	}
-
-	public void updateUser(
+	public void updateDetails(
 		String email, String name, String phoneNumber, String encodedPassword,
-		String studentId, Integer admissionYear, String nickname
+		String studentId, Integer admissionYear, String nickname,
+		String major, Department department
 	) {
 		this.email = email;
 		this.name = name;
@@ -228,36 +224,21 @@ public class User extends BaseEntity {
 		this.studentId = studentId;
 		this.admissionYear = admissionYear;
 		this.nickname = nickname;
+		this.major = major;
+		this.department = department;
 	}
 
-	public void updateAwaitOrRejectedUser(UserCreateRequestDto userCreateRequestDto, String encodedPassword) {
-		updateUser(
-			userCreateRequestDto.getEmail(),
-			userCreateRequestDto.getName(),
-			userCreateRequestDto.getPhoneNumber(),
-			encodedPassword,
-			userCreateRequestDto.getStudentId(),
-			userCreateRequestDto.getAdmissionYear(),
-			userCreateRequestDto.getNickname()
-		);
-		this.major = userCreateRequestDto.getMajor();
-		this.department = userCreateRequestDto.getDepartment();
+	public void updateRejectionOrDropReason(String reason) {
+		this.rejectionOrDropReason = reason;
+	}
+
+	public void markAsAwait() {
 		this.state = UserState.AWAIT;
 		this.rejectionOrDropReason = null; // 거절 사유 초기화
 	}
 
-	public void updateGraduatedUser(GraduatedUserCommand graduatedUserCommand, String encodedPassword) {
-		updateUser(
-			graduatedUserCommand.email(),
-			graduatedUserCommand.name(),
-			graduatedUserCommand.phoneNumber(),
-			encodedPassword,
-			graduatedUserCommand.studentId(),
-			graduatedUserCommand.admissionYear(),
-			graduatedUserCommand.nickname()
-		);
-		this.graduationYear = graduatedUserCommand.graduationYear();
-		this.department = graduatedUserCommand.department();
+	public void markAsCertifiedGraduate(Integer graduationYear) {
+		this.graduationYear = graduationYear;
 		this.state = UserState.ACTIVE;
 		this.roles = Set.of(Role.COMMON);
 		this.academicStatus = AcademicStatus.GRADUATED;

--- a/app-main/src/main/java/net/causw/app/main/domain/model/entity/user/User.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/entity/user/User.java
@@ -21,7 +21,7 @@ import net.causw.app.main.domain.model.enums.user.Role;
 import net.causw.app.main.domain.model.enums.user.UserState;
 import net.causw.app.main.domain.model.enums.userAcademicRecord.AcademicStatus;
 import net.causw.app.main.domain.resolver.DepartmentResolver;
-import net.causw.app.main.dto.user.CreateGraduatedUserCommand;
+import net.causw.app.main.dto.user.GraduatedUserCommand;
 import net.causw.app.main.dto.user.UserCreateRequestDto;
 
 import jakarta.persistence.CascadeType;
@@ -184,23 +184,23 @@ public class User extends BaseEntity {
 	}
 
 	public static User createGraduatedUser(
-		CreateGraduatedUserCommand createGraduatedUserCommand,
+		GraduatedUserCommand graduatedUserCommand,
 		String encodedPassword
 	) {
 		return User.builder()
-			.email(createGraduatedUserCommand.email())
-			.name(createGraduatedUserCommand.name())
+			.email(graduatedUserCommand.email())
+			.name(graduatedUserCommand.name())
 			.roles(Set.of(Role.COMMON))
 			.state(UserState.ACTIVE)
 			.password(encodedPassword)
-			.studentId(createGraduatedUserCommand.studentId())
-			.admissionYear(createGraduatedUserCommand.admissionYear())
-			.graduationYear(createGraduatedUserCommand.graduationYear())
-			.nickname(createGraduatedUserCommand.nickname())
-			.department(createGraduatedUserCommand.department())
+			.studentId(graduatedUserCommand.studentId())
+			.admissionYear(graduatedUserCommand.admissionYear())
+			.graduationYear(graduatedUserCommand.graduationYear())
+			.nickname(graduatedUserCommand.nickname())
+			.department(graduatedUserCommand.department())
 
 			.academicStatus(AcademicStatus.GRADUATED)
-			.phoneNumber(createGraduatedUserCommand.phoneNumber())
+			.phoneNumber(graduatedUserCommand.phoneNumber())
 			.isV2(true)
 			.build();
 	}
@@ -217,16 +217,50 @@ public class User extends BaseEntity {
 		this.rejectionOrDropReason = reason;
 	}
 
-	public void updateInfo(UserCreateRequestDto userCreateRequestDto, String encodedPassword) {
-		this.email = userCreateRequestDto.getEmail();
-		this.name = userCreateRequestDto.getName();
-		this.nickname = userCreateRequestDto.getNickname();
-		this.phoneNumber = userCreateRequestDto.getPhoneNumber();
-		this.studentId = userCreateRequestDto.getStudentId();
-		this.admissionYear = userCreateRequestDto.getAdmissionYear();
-		this.major = userCreateRequestDto.getMajor();
+	public void updateUser(
+		String email, String name, String phoneNumber, String encodedPassword,
+		String studentId, Integer admissionYear, String nickname
+	) {
+		this.email = email;
+		this.name = name;
+		this.phoneNumber = phoneNumber;
 		this.password = encodedPassword;
+		this.studentId = studentId;
+		this.admissionYear = admissionYear;
+		this.nickname = nickname;
+	}
+
+	public void updateAwaitOrRejectedUser(UserCreateRequestDto userCreateRequestDto, String encodedPassword) {
+		updateUser(
+			userCreateRequestDto.getEmail(),
+			userCreateRequestDto.getName(),
+			userCreateRequestDto.getPhoneNumber(),
+			encodedPassword,
+			userCreateRequestDto.getStudentId(),
+			userCreateRequestDto.getAdmissionYear(),
+			userCreateRequestDto.getNickname()
+		);
+		this.major = userCreateRequestDto.getMajor();
+		this.department = userCreateRequestDto.getDepartment();
 		this.state = UserState.AWAIT;
+		this.rejectionOrDropReason = null; // 거절 사유 초기화
+	}
+
+	public void updateGraduatedUser(GraduatedUserCommand graduatedUserCommand, String encodedPassword) {
+		updateUser(
+			graduatedUserCommand.email(),
+			graduatedUserCommand.name(),
+			graduatedUserCommand.phoneNumber(),
+			encodedPassword,
+			graduatedUserCommand.studentId(),
+			graduatedUserCommand.admissionYear(),
+			graduatedUserCommand.nickname()
+		);
+		this.graduationYear = graduatedUserCommand.graduationYear();
+		this.department = graduatedUserCommand.department();
+		this.state = UserState.ACTIVE;
+		this.roles = Set.of(Role.COMMON);
+		this.academicStatus = AcademicStatus.GRADUATED;
 		this.rejectionOrDropReason = null; // 거절 사유 초기화
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/model/entity/user/User.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/model/entity/user/User.java
@@ -173,7 +173,7 @@ public class User extends BaseEntity {
 			.nickname(userCreateRequestDto.getNickname())
 			.major(userCreateRequestDto.getMajor())
 			.department(
-				DepartmentResolver.resolveByAdmissionYearOrRequest(
+				DepartmentResolver.resolveByAdmissionYearOrDepartment(
 					userCreateRequestDto.getAdmissionYear(),
 					userCreateRequestDto.getDepartment()
 				))
@@ -197,7 +197,7 @@ public class User extends BaseEntity {
 			.admissionYear(createGraduatedUserCommand.admissionYear())
 			.graduationYear(createGraduatedUserCommand.graduationYear())
 			.nickname(createGraduatedUserCommand.nickname())
-			.major(createGraduatedUserCommand.major())
+			.department(createGraduatedUserCommand.department())
 
 			.academicStatus(AcademicStatus.GRADUATED)
 			.phoneNumber(createGraduatedUserCommand.phoneNumber())

--- a/app-main/src/main/java/net/causw/app/main/domain/resolver/DepartmentResolver.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/resolver/DepartmentResolver.java
@@ -22,20 +22,29 @@ public class DepartmentResolver {
 		new DepartmentPeriod(Department.DEPT_OF_CS, StaticValue.CAU_SW_START_YEAR, 1992)
 	);
 
-	public static Department resolveByAdmissionYearOrRequest(Integer admissionYear, Department request) {
-		// AI 학과 개설 이후 입학생은 학과/학부 선택 필수
-		if (admissionYear >= StaticValue.CAU_AI_START_YEAR) {
-			if (request == null) {
-				throw new BadRequestException(
-					ErrorCode.INVALID_REQUEST_DEPARTMENT,
-					MessageUtil.DEPARTMENT_EXPLICITLY_REQUIRED
-				);
-			}
-			return request;
+	public static Department resolveByAdmissionYearOrDepartmentName(Integer admissionYear, String departmentName) {
+		// AI 학과 개설 이전 입학생은 입학년도로 학과/학부 결정
+		if (admissionYear < StaticValue.CAU_AI_START_YEAR) {
+			return resolveByAdmissionYear(admissionYear);
 		}
 
+		return Department.of(departmentName);
+	}
+
+	public static Department resolveByAdmissionYearOrDepartment(Integer admissionYear, Department request) {
 		// AI 학과 개설 이전 입학생은 입학년도로 학과/학부 결정
-		return resolveByAdmissionYear(admissionYear);
+		if (admissionYear < StaticValue.CAU_AI_START_YEAR) {
+			return resolveByAdmissionYear(admissionYear);
+		}
+
+		// AI 학과 개설 이후 입학생은 학과/학부 선택 필수
+		if (request == null) {
+			throw new BadRequestException(
+				ErrorCode.INVALID_REQUEST_DEPARTMENT,
+				MessageUtil.DEPARTMENT_EXPLICITLY_REQUIRED
+			);
+		}
+		return request;
 	}
 
 	public static Department resolveByAdmissionYear(int admissionYear) {

--- a/app-main/src/main/java/net/causw/app/main/dto/user/CreateGraduatedUserCommand.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/user/CreateGraduatedUserCommand.java
@@ -1,5 +1,7 @@
 package net.causw.app.main.dto.user;
 
+import net.causw.app.main.domain.model.enums.user.Department;
+
 public record CreateGraduatedUserCommand(
 	String email,
 	String name,
@@ -7,7 +9,7 @@ public record CreateGraduatedUserCommand(
 	Integer admissionYear,
 	Integer graduationYear,
 	String nickname,
-	String major,
+	Department department,
 	String phoneNumber
 ) {
 }

--- a/app-main/src/main/java/net/causw/app/main/dto/user/GraduatedUserCommand.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/user/GraduatedUserCommand.java
@@ -2,7 +2,7 @@ package net.causw.app.main.dto.user;
 
 import net.causw.app.main.domain.model.enums.user.Department;
 
-public record CreateGraduatedUserCommand(
+public record GraduatedUserCommand(
 	String email,
 	String name,
 	String studentId,

--- a/app-main/src/main/java/net/causw/app/main/dto/user/GraduatedUserRegisterRequestDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/user/GraduatedUserRegisterRequestDto.java
@@ -31,7 +31,7 @@ public record GraduatedUserRegisterRequestDto(
 	@Pattern(regexp = "^01(?:0|1|[6-9])-(\\d{3}|\\d{4})-\\d{4}$", message = "전화번호 형식에 맞지 않습니다.")
 	String phoneNumber,
 
-	@NotBlank
+	@NotNull
 	Department department,
 
 	String studentId

--- a/app-main/src/main/java/net/causw/app/main/dto/user/GraduatedUserRegisterRequestDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/user/GraduatedUserRegisterRequestDto.java
@@ -36,8 +36,8 @@ public record GraduatedUserRegisterRequestDto(
 
 	String studentId
 ) {
-	public CreateGraduatedUserCommand toCreateGraduatedUserCommand() {
-		return new CreateGraduatedUserCommand(
+	public GraduatedUserCommand toGraduatedUserCommand() {
+		return new GraduatedUserCommand(
 			this.email,
 			this.name,
 			this.studentId,

--- a/app-main/src/main/java/net/causw/app/main/dto/user/GraduatedUserRegisterRequestDto.java
+++ b/app-main/src/main/java/net/causw/app/main/dto/user/GraduatedUserRegisterRequestDto.java
@@ -1,5 +1,7 @@
 package net.causw.app.main.dto.user;
 
+import net.causw.app.main.domain.model.enums.user.Department;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -30,7 +32,7 @@ public record GraduatedUserRegisterRequestDto(
 	String phoneNumber,
 
 	@NotBlank
-	String major,
+	Department department,
 
 	String studentId
 ) {
@@ -42,7 +44,7 @@ public record GraduatedUserRegisterRequestDto(
 			this.admissionYear,
 			this.graduationYear,
 			this.nickname,
-			this.major,
+			this.department,
 			this.phoneNumber
 		);
 	}

--- a/app-main/src/main/java/net/causw/app/main/service/user/UserService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/user/UserService.java
@@ -612,7 +612,18 @@ public class UserService {
 			//AWAIT, REJECT인 경우 정보 업데이트 진행
 			if (state == UserState.AWAIT || state == UserState.REJECT) {
 				validateUniqueness(dto.getNickname(), dto.getPhoneNumber(), dto.getStudentId(), user);
-				user.updateAwaitOrRejectedUser(dto, passwordEncoder.encode(dto.getPassword()));
+				user.updateDetails(
+					dto.getEmail(),
+					dto.getName(),
+					dto.getPhoneNumber(),
+					passwordEncoder.encode(dto.getPassword()),
+					dto.getStudentId(),
+					dto.getAdmissionYear(),
+					dto.getNickname(),
+					dto.getMajor(),
+					dto.getDepartment()
+				);
+				user.markAsAwait();
 				validateUser(dto, user);
 				userRepository.save(user);
 				return UserDtoMapper.INSTANCE.toUserResponseDto(user, null, null);
@@ -646,7 +657,18 @@ public class UserService {
 					}
 				});
 				validateUniqueness(dto.getNickname(), dto.getPhoneNumber(), dto.getStudentId(), ghostuser);
-				ghostuser.updateAwaitOrRejectedUser(dto, passwordEncoder.encode(dto.getPassword()));
+				ghostuser.updateDetails(
+					dto.getEmail(),
+					dto.getName(),
+					dto.getPhoneNumber(),
+					passwordEncoder.encode(dto.getPassword()),
+					dto.getStudentId(),
+					dto.getAdmissionYear(),
+					dto.getNickname(),
+					dto.getMajor(),
+					dto.getDepartment()
+				);
+				ghostuser.markAsAwait();
 				validateUser(dto, ghostuser);
 				userRepository.save(ghostuser);
 				return UserDtoMapper.INSTANCE.toUserResponseDto(ghostuser, null, null);
@@ -683,7 +705,6 @@ public class UserService {
 	 */
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void registerGraduatedUser(GraduatedUserRegisterRequestDto dto) {
-		GraduatedUserCommand command = dto.toGraduatedUserCommand();
 		String encodedPassword = passwordEncoder.encode(dto.password());
 
 		User registeredUser = userRepository.findByEmail(dto.email())
@@ -692,12 +713,23 @@ public class UserService {
 				if (user.getState() == UserState.AWAIT || user.getState() == UserState.REJECT) {
 					validateEmailUniqueness(dto.email(), user);
 					validateUniqueness(dto.nickname(), dto.phoneNumber(), dto.studentId(), user);
-					user.updateGraduatedUser(command, encodedPassword);
+
+					user.updateDetails(
+						dto.email(),
+						dto.name(),
+						dto.phoneNumber(),
+						encodedPassword,
+						dto.studentId(),
+						dto.admissionYear(),
+						dto.nickname(),
+						null,
+						dto.department()
+					);
+					user.markAsCertifiedGraduate(dto.graduationYear());
 					return user;
 
 				} else if (user.getAcademicStatus() == AcademicStatus.UNDETERMINED) {
-					user.setAcademicStatus(AcademicStatus.GRADUATED);
-					user.setGraduationYear(dto.graduationYear());
+					user.markAsCertifiedGraduate(dto.graduationYear());
 					return user;
 
 				} else { // 이미 인증된 계정이 존재하는 경우
@@ -710,7 +742,7 @@ public class UserService {
 			.orElseGet(() -> {
 				validateEmailUniqueness(dto.email(), null);
 				validateUniqueness(dto.nickname(), dto.phoneNumber(), dto.studentId(), null);
-				return userRepository.save(User.createGraduatedUser(command, encodedPassword));
+				return userRepository.save(User.createGraduate(dto.toGraduatedUserCommand(), encodedPassword));
 			});
 
 		eventPublisher.publishEvent(new CertifiedUserCreatedEvent(registeredUser.getId()));
@@ -901,7 +933,7 @@ public class UserService {
 			}
 		}
 
-		srcUser.update(userUpdateRequestDto.getNickname(), userProfileImage, userUpdateRequestDto.getPhoneNumber());
+		srcUser.updateProfile(userUpdateRequestDto.getNickname(), userProfileImage, userUpdateRequestDto.getPhoneNumber());
 
 		User updatedUser = userRepository.save(srcUser);
 

--- a/app-main/src/main/java/net/causw/app/main/service/user/UserService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/user/UserService.java
@@ -697,6 +697,7 @@ public class UserService {
 
 				} else if (user.getAcademicStatus() == AcademicStatus.UNDETERMINED) {
 					user.setAcademicStatus(AcademicStatus.GRADUATED);
+					user.setGraduationYear(dto.graduationYear());
 					return user;
 
 				} else { // 이미 인증된 계정이 존재하는 경우

--- a/app-main/src/main/java/net/causw/app/main/service/user/useCase/RegisterGraduatedUsersUseCaseService.java
+++ b/app-main/src/main/java/net/causw/app/main/service/user/useCase/RegisterGraduatedUsersUseCaseService.java
@@ -17,6 +17,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import net.causw.app.main.domain.model.enums.user.Department;
+import net.causw.app.main.domain.resolver.DepartmentResolver;
 import net.causw.app.main.dto.user.BatchRegisterResponseDto;
 import net.causw.app.main.dto.user.GraduatedUserRegisterRequestDto;
 import net.causw.app.main.service.user.UserService;
@@ -41,7 +43,7 @@ public class RegisterGraduatedUsersUseCaseService {
 	private static final int GRADUATION_YEAR_COLUMN = 5;
 	private static final int EMAIL_COLUMN = 6;
 	private static final int PHONE_NUMBER_COLUMN = 7;
-	private static final int MAJOR_COLUMN = 8;
+	private static final int DEPARTMENT_COLUMN = 8;
 	private static final int STUDENT_ID_COLUMN = 9;
 
 	private final UserService userService;
@@ -148,16 +150,28 @@ public class RegisterGraduatedUsersUseCaseService {
 			);
 		}
 
+		String name = record.get(NAME_COLUMN).trim();
+		String tempNickname = "user-" + UUID.randomUUID().toString().substring(0, 8);
+		String email = record.get(EMAIL_COLUMN).trim();
+		Integer admissionYear = Integer.parseInt(record.get(ADMISSION_YEAR_COLUMN).trim());
+		Integer graduationYear = Integer.parseInt(record.get(GRADUATION_YEAR_COLUMN).trim());
+		Department department = DepartmentResolver.resolveByAdmissionYearOrDepartmentName(
+			admissionYear,
+			record.get(DEPARTMENT_COLUMN).trim()
+		);
+		String phoneNumber = record.get(PHONE_NUMBER_COLUMN).trim();
+		String studentId = record.get(STUDENT_ID_COLUMN).trim();
+
 		return new GraduatedUserRegisterRequestDto(
-			record.get(NAME_COLUMN).trim(),
-			"user-" + UUID.randomUUID().toString().substring(0, 8), // 임시 닉네임
-			Integer.parseInt(record.get(ADMISSION_YEAR_COLUMN).trim()),
-			Integer.parseInt(record.get(GRADUATION_YEAR_COLUMN).trim()),
-			record.get(EMAIL_COLUMN).trim(),
-			record.get(EMAIL_COLUMN).trim(), // 임시 비밀번호
-			record.get(PHONE_NUMBER_COLUMN).trim(),
-			record.get(MAJOR_COLUMN).trim(),
-			record.get(STUDENT_ID_COLUMN).trim().isEmpty() ? null : record.get(9).trim()
+			name,
+			tempNickname,
+			admissionYear,
+			graduationYear,
+			email,
+			email, // 임시 비밀번호
+			phoneNumber,
+			department,
+			studentId.isEmpty() ? null : studentId // 학번 입력 선택적
 		);
 	}
 }

--- a/global/src/main/java/net/causw/global/constant/MessageUtil.java
+++ b/global/src/main/java/net/causw/global/constant/MessageUtil.java
@@ -113,6 +113,7 @@ public class MessageUtil {
 	public static final String EMAIL_ALREADY_EXIST = "이미 존재하는 이메일입니다.";
 	public static final String EMAIL_INVALID = "잘못된 이메일입니다.";
 	public static final String USER_ALREADY_APPLY = "이미 신청한 사용자 입니다.";
+	public static final String USER_ALREADY_REGISTERD = "이미 등록된 사용자입니다.";
 	public static final String NO_APPLICATION = "신청서를 작성하지 않았습니다.";
 	public static final String CONCURRENT_JOB_IMPOSSIBLE = "겸직이 불가합니다.";
 	public static final String NICKNAME_ALREADY_EXIST = "이미 존재하는 닉네임입니다.";


### PR DESCRIPTION
### 🚩 관련사항
close #988 


### 📢 전달사항
회원 등록 구글폼 응답에 포함된 입학년도 값으로 운영계 회원 일괄 등록 전에 학과/학부명 상수화 반영했습니다.
이미 가입 신청된 경우, 가입 신청 승인된 경우, 학적 인증된 경우에 따른 예외처리도 추가헸습니다.

로컬에서 운영계 DB 데이터로 테스트했을 때 일괄 등록이 정상적으로 이루어졌고,
등록된 계정으로 여러 기능 테스트한 결과 정상 동작했습니다.
- 게시글, 동문수첩 조회
- 댓글, 글, 경조사, 게시글 좋아요, 게시글 찜 생성 
- 동문수첩, 회원정보, 비밀번호 수정
- 경조사 알림 및 게시글 알림 수신


### 📸 스크린샷
<img width="587" height="289" alt="Screenshot from 2025-09-28 21-30-42" src="https://github.com/user-attachments/assets/0878805f-e117-4bde-9b55-bf27213f9c5c" />
<img width="587" height="289" alt="Screenshot from 2025-09-28 21-30-48" src="https://github.com/user-attachments/assets/f95b4543-9311-4401-a731-4b1c81173621" />
<img width="216" height="457" alt="Screenshot from 2025-09-28 21-31-19" src="https://github.com/user-attachments/assets/7df16dc3-82ed-4929-a2d5-6e7d58670e9a" />
<img width="726" height="245" alt="Screenshot from 2025-09-28 21-32-04" src="https://github.com/user-attachments/assets/08212ed7-110d-4a25-bd5c-cbc98ccc6a19" />
<img width="593" height="580" alt="Screenshot from 2025-09-28 21-32-45" src="https://github.com/user-attachments/assets/edff7b24-b09a-4ea1-b450-a15d837be675" />
<img width="593" height="694" alt="Screenshot from 2025-09-28 21-34-02" src="https://github.com/user-attachments/assets/b4c7572c-618e-44ef-bdf2-0230ec289aa3" />
<img width="776" height="687" alt="Screenshot from 2025-09-28 21-41-59" src="https://github.com/user-attachments/assets/50203002-df45-434c-be09-c9852ba833bf" />



### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 