### PR TITLE
chore: MySQL connector, flyway 버전 업그레이드

### DIFF
--- a/app-main/build.gradle
+++ b/app-main/build.gradle
@@ -1,13 +1,13 @@
 buildscript {
     dependencies {
-        classpath 'org.flywaydb:flyway-mysql:9.22.3'
-        classpath 'com.mysql:mysql-connector-j:8.1.0'
+        classpath 'org.flywaydb:flyway-mysql:11.15.0'
+        classpath 'com.mysql:mysql-connector-j:8.4.0'
     }
 }
 
 plugins {
     id 'org.springframework.boot' version '3.2.0'
-    id 'org.flywaydb.flyway' version '9.22.3'
+    id 'org.flywaydb.flyway' version '11.15.0'
 }
 
 ext {
@@ -31,7 +31,7 @@ dependencies {
 
     implementation 'org.jsoup:jsoup:1.18.1'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
-    implementation 'com.mysql:mysql-connector-j:8.1.0'
+    implementation 'com.mysql:mysql-connector-j:8.4.0'
 
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
@@ -85,8 +85,8 @@ dependencies {
     implementation 'com.google.firebase:firebase-admin:9.2.0'
 
     // Flyway
-    implementation 'org.flywaydb:flyway-core:9.22.3'
-    implementation 'org.flywaydb:flyway-mysql:9.22.3'
+    implementation 'org.flywaydb:flyway-core:11.15.0'
+    implementation 'org.flywaydb:flyway-mysql:11.15.0'
 
     // logback json 형식 관련
     implementation 'ch.qos.logback.contrib:logback-json-classic:0.1.5'


### PR DESCRIPTION
### 🚩 관련사항
DB 버전 업그레이드

### 📢 전달사항
RDS MySQL 버전을 8.4로 업그레이드 하기 앞서 jdbc 드라이버와 flyway의 버전을 최신으로 업데이트합니다.
로컬에서 버전 업그레이드 후 덤프 데이터로 애플리케이션과 flyway가 정상 동작함을 확인했고,
MySQL 공식 upgrade checker utility를 사용해 사전 호환성 검사를 마쳤습니다.
머지후에 개발용 DB 업그레이드를 진행할 예정입니다.

### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
Workbench가 지원하는 가장 최신 버전이 8.0까지라 서버 업그레이드후 일부 기능이 동작하지 않을 수 있다고 합니다.
앞으로는 Datagrip이나 다른 도구를 사용할 것을 권장합니다.

개발기간: 