### PR TITLE
chore: 리프레시 토큰 TTL 7일에서 15일로 연장

### DIFF
--- a/global/src/main/java/net/causw/global/constant/StaticValue.java
+++ b/global/src/main/java/net/causw/global/constant/StaticValue.java
@@ -30,8 +30,8 @@ public class StaticValue {
 	public static final Integer MAX_NUM_EVENT = 10;
 
 	// JWT Token
-	public static final Long JWT_ACCESS_TOKEN_VALID_TIME = 1000L * 60 * 30;    // 30min
-	public static final Long JWT_REFRESH_TOKEN_VALID_TIME = 1000L * 60 * 60 * 24 * 15;   // 7day
+	public static final Long JWT_ACCESS_TOKEN_VALID_TIME = 1000L * 60 * 30;    // 30 min
+	public static final Long JWT_REFRESH_TOKEN_VALID_TIME = 1000L * 60 * 60 * 24 * 15;   // 15 days
 	public static final Integer JWT_ACCESS_THRESHOLD = 60 * 60 * 24;  // 1 day
 
 	// Swagger configuration


### PR DESCRIPTION
### 🚩 배경
재학생 스쿼드 회의에서 로그인 유지 기간 7일이 앱 기준으로 짧다는 의견이 나와 
사용자 편의를 위해 15일로 연장했습니다.


### 📢 주요 변경사항

- 로그인, 사용자 계정 복구 시에 발급되는 리프레시 토큰의 유효 기간이 15일로 연장됩니다.

- 사용자 fcmToken 등록 시 유효 기간이 15일로 연장됩니다.