### PR TITLE
chore: D-n PR 알림을 상태 기준으로 변경

### DIFF
--- a/.github/workflows/d-day-labeler.yml
+++ b/.github/workflows/d-day-labeler.yml
@@ -13,41 +13,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Step A: 업데이트 전 상태 스냅샷
-      - name: Snapshot BEFORE d-day update
-        id: before
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pulls = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: "open",
-              base: "dev"
-            });
-
-            const before = {};
-            for (const pr of pulls.data) {
-              const d = pr.labels.find(l => /^D-\d+$/.test(l.name));
-              if (d) before[pr.number] = d.name;
-            }
-
-            return before;
-
-      # Step B: D-n 라벨 업데이트
+      # Step A: D-n 라벨 업데이트
       - name: Update D-n Labels
         uses: naver/d-day-labeler@latest
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Step C: 업데이트 후 상태 + diff 판단
-      - name: Detect D-2→D-1 / D-1→D-0
+      # Step B: 현재 D-1 / D-0 PR 감지 (상태 기준)
+      - name: Detect D-1 / D-0 PRs
         id: detect
         uses: actions/github-script@v7
         with:
           script: |
-            const before = JSON.parse(`${{ steps.before.outputs.result }}`);
-
             const pulls = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -58,28 +35,24 @@ jobs:
             const notify = [];
 
             for (const pr of pulls.data) {
-              const afterLabel = pr.labels.find(l => /^D-\d+$/.test(l.name));
-              if (!afterLabel) continue;
+              const dLabel = pr.labels.find(l => /^D-\d+$/.test(l.name));
+              if (!dLabel) continue;
 
-              const after = afterLabel.name;
-              const prev = before[pr.number];
+              const label = dLabel.name;
 
-              if (
-                (prev === "D-2" && after === "D-1") ||
-                (prev === "D-1" && after === "D-0")
-              ) {
+              if (label === "D-1" || label === "D-0") {
                 notify.push({
                   number: pr.number,
                   title: pr.title,
                   url: pr.html_url,
-                  prefix: after === "D-0" ? "🚨 [D-0]" : "⏳ [D-1]"
+                  prefix: label === "D-0" ? "🚨 [D-0]" : "⏳ [D-1]"
                 });
               }
             }
 
             return notify;
 
-      # Discord 알림
+      # Step C: Discord 알림
       - name: Send Discord notification
         if: ${{ steps.detect.outputs.result != '[]' }}
         env:


### PR DESCRIPTION
### 🚩 관련사항
close #1090 


### 📢 전달사항
기존에는 D-2 → D-1, D-1 → D-0으로 라벨이 변경된 경우에만 디스코드 알림이 전송되었습니다.
요구사항 변경에 따라 현재 상태가 D-1 또는 D-0인 모든 PR에 대해 매일 알림이 전송되도록 수정하였습니다.

주요 변경 사항:
- diff 기반 비교 로직 제거


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [x] diff 비교 로직 제거
- [x] 테스트용 리포지토리에서 Discord 알림 정상 동작 확인


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 