### PR TITLE
feat: 사용자 접근 가능 게시판 조회 v2 API 추가

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v1/controller/BoardV1Controller.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v1/controller/BoardV1Controller.java
@@ -45,7 +45,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/boards")
-public class BoardController {
+public class BoardV1Controller {
 	private final BoardV1Service boardService;
 
 	@GetMapping

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/controller/BoardController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/controller/BoardController.java
@@ -1,0 +1,37 @@
+package net.causw.app.main.domain.community.board.api.v2.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import net.causw.app.main.domain.community.board.api.v2.dto.response.BoardReadableListResponse;
+import net.causw.app.main.domain.community.board.api.v2.mapper.BoardReadableMapper;
+import net.causw.app.main.domain.community.board.service.v2.BoardService;
+import net.causw.app.main.domain.user.auth.userdetails.CustomUserDetails;
+import net.causw.app.main.shared.dto.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/boards")
+@Tag(name = "Board v2 Public", description = "게시판 조회 API")
+public class BoardController {
+
+	private final BoardService boardService;
+	private final BoardReadableMapper boardReadableMapper;
+
+	@GetMapping("/available")
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(summary = "이용 가능한 게시판 목록", description = "현재 사용자가 이용 가능한 게시판의 id, name 목록을 표시 순서대로 반환합니다.")
+	public ApiResponse<BoardReadableListResponse> getAvailableBoards(
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		return ApiResponse.success(
+			boardReadableMapper.toReadableListResponse(boardService.getReadableBoards(userDetails.getUser().getId())));
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/dto/response/BoardReadableItemResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/dto/response/BoardReadableItemResponse.java
@@ -1,0 +1,10 @@
+package net.causw.app.main.domain.community.board.api.v2.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "읽기 가능한 게시판 한 건")
+public record BoardReadableItemResponse(
+	@Schema(description = "게시판 ID") String id,
+	@Schema(description = "게시판 이름") String name
+) {
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/dto/response/BoardReadableItemResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/dto/response/BoardReadableItemResponse.java
@@ -5,6 +5,5 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "읽기 가능한 게시판 한 건")
 public record BoardReadableItemResponse(
 	@Schema(description = "게시판 ID") String id,
-	@Schema(description = "게시판 이름") String name
-) {
+	@Schema(description = "게시판 이름") String name) {
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/dto/response/BoardReadableListResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/dto/response/BoardReadableListResponse.java
@@ -6,6 +6,5 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "읽기 가능한 게시판 목록 응답")
 public record BoardReadableListResponse(
-	@Schema(description = "읽기 가능한 게시판 목록 (표시 순서)") List<BoardReadableItemResponse> boards
-) {
+	@Schema(description = "읽기 가능한 게시판 목록 (표시 순서)") List<BoardReadableItemResponse> boards) {
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/dto/response/BoardReadableListResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/dto/response/BoardReadableListResponse.java
@@ -1,0 +1,11 @@
+package net.causw.app.main.domain.community.board.api.v2.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "읽기 가능한 게시판 목록 응답")
+public record BoardReadableListResponse(
+	@Schema(description = "읽기 가능한 게시판 목록 (표시 순서)") List<BoardReadableItemResponse> boards
+) {
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/mapper/BoardReadableMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/mapper/BoardReadableMapper.java
@@ -1,0 +1,21 @@
+package net.causw.app.main.domain.community.board.api.v2.mapper;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+
+import net.causw.app.main.domain.community.board.api.v2.dto.response.BoardReadableItemResponse;
+import net.causw.app.main.domain.community.board.api.v2.dto.response.BoardReadableListResponse;
+import net.causw.app.main.domain.community.board.service.v2.dto.BoardReadableItemResult;
+
+@Mapper(componentModel = "spring")
+public interface BoardReadableMapper {
+
+	BoardReadableItemResponse toReadableItemResponse(BoardReadableItemResult result);
+
+	List<BoardReadableItemResponse> toReadableItemResponseList(List<BoardReadableItemResult> results);
+
+	default BoardReadableListResponse toReadableListResponse(List<BoardReadableItemResult> results) {
+		return new BoardReadableListResponse(toReadableItemResponseList(results));
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/repository/BoardQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/repository/BoardQueryRepository.java
@@ -71,17 +71,23 @@ public class BoardQueryRepository {
 	}
 
 	/**
-	 * 게시판 아이디 목록으로 게시판을 조회합니다. 삭제되지 않은 게시판만 조회합니다.
-	 * @param boardIds 게시판 아이디 목록
-	 * @return 게시판 엔티티 목록
+	 * 게시판 ID 목록으로 게시판을 조회합니다. 삭제되지 않은 게시판만 조회하며, 표시 순서(displayOrder) 오름차순으로 반환합니다.
+	 * @param boardIds 게시판 ID 목록
+	 * @return 삭제되지 않은 게시판 엔티티 목록 (displayOrder 오름차순)
 	 */
 	public List<Board> findAllByIdsNotDeleted(List<String> boardIds) {
+		if (boardIds == null || boardIds.isEmpty()) {
+			return List.of();
+		}
 		QBoard board = QBoard.board;
+		QBoardConfig boardConfig = QBoardConfig.boardConfig;
 
 		return jpaQueryFactory
 			.selectFrom(board)
+			.join(boardConfig).on(board.id.eq(boardConfig.boardId))
 			.where(board.id.in(boardIds))
 			.where(notDeleted())
+			.orderBy(boardConfig.displayOrder.asc())
 			.fetch();
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/service/implementation/BoardConfigReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/service/implementation/BoardConfigReader.java
@@ -95,7 +95,7 @@ public class BoardConfigReader {
 	 * 사용자 상태에 따라 접근 가능한 게시판 ID 목록을 조회합니다.
 	 * VISIBLE이고 사용자의 ReadScope에 맞는 게시판만 조회합니다.
 	 *
-	 * @param academicStatus 사용자 상태
+	 * @param academicStatus 사용자 학적 상태
 	 * @return 게시판 ID 목록
 	 */
 	public List<String> getAccessibleBoardIdsByAcademicStatus(AcademicStatus academicStatus) {

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/service/v2/BoardService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/service/v2/BoardService.java
@@ -1,0 +1,43 @@
+package net.causw.app.main.domain.community.board.service.v2;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import net.causw.app.main.domain.community.board.entity.Board;
+import net.causw.app.main.domain.community.board.service.implementation.BoardConfigReader;
+import net.causw.app.main.domain.community.board.service.implementation.BoardReader;
+import net.causw.app.main.domain.community.board.service.v2.dto.BoardReadableItemResult;
+import net.causw.app.main.domain.user.account.service.implementation.UserReader;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BoardService {
+
+	private final BoardReader boardReader;
+	private final BoardConfigReader boardConfigReader;
+	private final UserReader userReader;
+
+	/**
+	 * 특정 사용자가 읽기 가능한 게시판의 id, name 목록을 표시 순서대로 반환합니다.
+	 *
+	 * @param userId 사용자 ID
+	 * @return 읽기 가능한 게시판 목록 (id, name)
+	 */
+	public List<BoardReadableItemResult> getReadableBoards(String userId) {
+		List<String> boardIds = boardConfigReader.getAccessibleBoardIdsByAcademicStatus(
+			userReader.findUserById(userId).getAcademicStatus());
+		if (boardIds.isEmpty()) {
+			return List.of();
+		}
+
+		List<Board> boards = boardReader.findAllByIdsNotDeleted(boardIds);
+		return boards.stream()
+			.map(b -> new BoardReadableItemResult(b.getId(), b.getName()))
+			.toList();
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/service/v2/dto/BoardReadableItemResult.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/service/v2/dto/BoardReadableItemResult.java
@@ -5,6 +5,5 @@ package net.causw.app.main.domain.community.board.service.v2.dto;
  */
 public record BoardReadableItemResult(
 	String id,
-	String name
-) {
+	String name) {
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/service/v2/dto/BoardReadableItemResult.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/service/v2/dto/BoardReadableItemResult.java
@@ -1,0 +1,10 @@
+package net.causw.app.main.domain.community.board.service.v2.dto;
+
+/**
+ * 사용자가 읽기 가능한 게시판 한 건 (id, name).
+ */
+public record BoardReadableItemResult(
+	String id,
+	String name
+) {
+}

--- a/app-main/src/main/resources/db/migration/V20260301120000__AddDisplayOrderIndexToBoardConfig.sql
+++ b/app-main/src/main/resources/db/migration/V20260301120000__AddDisplayOrderIndexToBoardConfig.sql
@@ -1,0 +1,4 @@
+-- Migration: AddDisplayOrderIndexToBoardConfig
+-- 게시판 목록 조회 시 display_order 기준 정렬 성능 개선
+
+CREATE INDEX idx_board_config_display_order ON tb_board_config (display_order);


### PR DESCRIPTION
### 🚩 관련사항
Close #1138


### 📢 전달사항
- 기존 v1 게시판 컨트롤러의 이름을 `BoardV1Controller`로 변경하여 API 버전을 명확히 합니다.
- 새로운 v2 API 엔드포인트 `/api/v2/boards/available`를 추가하여 사용자의 학적 상태에 따라 접근 가능한 게시판 목록을 반환합니다. 게시판 목록은 `displayOrder`를 기준으로 정렬되어 제공됩니다.
- 이를 위해 새로운 서비스 로직, DTO 및 매퍼를 구현합니다.
- 게시판 목록 조회 성능 개선을 위해 `tb_board_config` 테이블의 `display_order` 컬럼에 인덱스를 추가합니다.


### 📸 스크린샷
<img width="1281" height="333" alt="image" src="https://github.com/user-attachments/assets/eb1936ee-08f0-465d-bbc4-a2e2696274ef" />



### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 