### PR TITLE
fix: WebSecurityConfigTest의 ClientRegistrationRepository MockBean 누락 수정

### DIFF
--- a/app-main/src/test/java/net/causw/app/main/infrastructure/security/WebSecurityConfigTest.java
+++ b/app-main/src/test/java/net/causw/app/main/infrastructure/security/WebSecurityConfigTest.java
@@ -23,6 +23,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -62,6 +63,8 @@ public class WebSecurityConfigTest {
 	private OAuth2SuccessHandler oAuth2SuccessHandler;
 	@MockBean
 	private OAuth2FailureHandler oAuth2FailureHandler;
+	@MockBean
+	private ClientRegistrationRepository clientRegistrationRepository;
 
 	@Nested
 	@DisplayName("AuthorizeHttpRequests 테스트")


### PR DESCRIPTION
### 🚩 관련사항
관련된 이슈번호 혹은 PR 번호를 기록합니다.
https://github.com/CAUCSE/CAUSW_backend/actions/runs/22570714165

### 📢 전달사항
dev 서버 배포 후 main test 실패
- WebSecurityConfigTest의 빈 생성 오류로 인한 것으로 확인하였고, 수정하였습니다.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 