### PR TITLE
feat: oauth2 단일 진입점에서 env 쿠키 기반 동적 리다이렉트 지원

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/core/security/OAuth2AuthorizationRequestCookieRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/core/security/OAuth2AuthorizationRequestCookieRepository.java
@@ -1,0 +1,77 @@
+package net.causw.app.main.core.security;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import net.causw.app.main.domain.user.auth.util.OAuthRedirectResolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+/**
+ * OAuth2 AuthorizationRequest 저장소를 감싸서 env 쿠키를 함께 관리하는 리포지토리입니다.
+ * <p>
+ * 기본 저장/조회/삭제는 세션 기반 delegate에 위임하고,
+ * 저장 시점에만 요청 파라미터(env)를 읽어 OAuthRedirectResolver를 통해 쿠키를 설정합니다.
+ */
+public class OAuth2AuthorizationRequestCookieRepository
+	implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+	private final HttpSessionOAuth2AuthorizationRequestRepository delegate = new HttpSessionOAuth2AuthorizationRequestRepository();
+	private final OAuthRedirectResolver oAuthRedirectResolver;
+
+	/**
+	 * 세션에 저장된 OAuth2 AuthorizationRequest를 조회합니다.
+	 *
+	 * @param request 현재 HTTP 요청
+	 * @return 저장된 AuthorizationRequest, 없으면 null
+	 */
+	@Override
+	public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+		return delegate.loadAuthorizationRequest(request);
+	}
+
+	/**
+	 * AuthorizationRequest 저장 전에 env 쿠키를 갱신한 뒤 요청 상태를 저장합니다.
+	 *
+	 * @param authorizationRequest OAuth2 AuthorizationRequest
+	 * @param request 현재 HTTP 요청
+	 * @param response 현재 HTTP 응답
+	 */
+	@Override
+	public void saveAuthorizationRequest(
+		OAuth2AuthorizationRequest authorizationRequest,
+		HttpServletRequest request,
+		HttpServletResponse response) {
+		ResponseCookie envCookie = resolveEnvCookie(request);
+		response.addHeader(HttpHeaders.SET_COOKIE, envCookie.toString());
+		delegate.saveAuthorizationRequest(authorizationRequest, request, response);
+	}
+
+	/**
+	 * 세션에 저장된 OAuth2 AuthorizationRequest를 제거하고 반환합니다.
+	 *
+	 * @param request 현재 HTTP 요청
+	 * @param response 현재 HTTP 응답
+	 * @return 제거된 AuthorizationRequest, 없으면 null
+	 */
+	@Override
+	public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+		HttpServletResponse response) {
+		return delegate.removeAuthorizationRequest(request, response);
+	}
+
+	private ResponseCookie resolveEnvCookie(HttpServletRequest request) {
+		String env = request.getParameter("env");
+		if (oAuthRedirectResolver.isSupportedEnv(env)) {
+			return oAuthRedirectResolver.createEnvCookie(env, request);
+		}
+		return oAuthRedirectResolver.clearEnvCookie(request);
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/core/security/WebSecurityConfig.java
+++ b/app-main/src/main/java/net/causw/app/main/core/security/WebSecurityConfig.java
@@ -39,6 +39,7 @@ public class WebSecurityConfig {
 	private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 	private final CustomAuthorizationManager authorizationManager;
 	private final AppleOAuth2AuthorizationRequestResolver appleOAuth2AuthorizationRequestResolver;
+	private final OAuth2AuthorizationRequestCookieRepository oAuth2AuthorizationRequestCookieRepository;
 	private final CustomOAuth2UserService customOAuth2UserService;
 	private final OAuth2SuccessHandler oAuth2SuccessHandler;
 	private final OAuth2FailureHandler oAuth2FailureHandler;
@@ -71,7 +72,8 @@ public class WebSecurityConfig {
 				.anyRequest().authenticated())
 			.oauth2Login(oauth2 -> oauth2
 				.authorizationEndpoint(authorizationEndpoint -> authorizationEndpoint
-					.authorizationRequestResolver(appleOAuth2AuthorizationRequestResolver))
+					.authorizationRequestResolver(appleOAuth2AuthorizationRequestResolver)
+					.authorizationRequestRepository(oAuth2AuthorizationRequestCookieRepository))
 				.userInfoEndpoint(userInfo -> userInfo
 					.userService(customOAuth2UserService)
 					.oidcUserService(customOAuth2UserService::loadOidcUser))

--- a/app-main/src/main/java/net/causw/app/main/domain/user/auth/handler/OAuth2FailureHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/auth/handler/OAuth2FailureHandler.java
@@ -2,23 +2,26 @@ package net.causw.app.main.domain.user.auth.handler;
 
 import java.io.IOException;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import net.causw.app.main.domain.user.auth.util.OAuthRedirectResolver;
 import net.causw.app.main.shared.exception.BaseRunTimeV2Exception;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 
 @Component
+@RequiredArgsConstructor
 public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
-	@Value("${app.auth.redirect-uri}")
-	private String baseUrl;
+	private final OAuthRedirectResolver oAuthRedirectResolver;
 
 	@Override
 	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
@@ -46,6 +49,10 @@ public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler 
 			errorMessage = "로그인을 취소하셨거나 권한을 제공하지 않으셨습니다.";
 			status = HttpServletResponse.SC_UNAUTHORIZED;
 		}
+
+		String baseUrl = oAuthRedirectResolver.resolveRedirectBase(request);
+		ResponseCookie envCookie = oAuthRedirectResolver.clearEnvCookie(request);
+		response.addHeader(HttpHeaders.SET_COOKIE, envCookie.toString());
 
 		String targetUrl = UriComponentsBuilder.fromUriString(baseUrl)
 			.queryParam("error", errorCode)

--- a/app-main/src/main/java/net/causw/app/main/domain/user/auth/handler/OAuth2SuccessHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/auth/handler/OAuth2SuccessHandler.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Optional;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
@@ -20,6 +19,7 @@ import net.causw.app.main.domain.user.account.enums.user.UserState;
 import net.causw.app.main.domain.user.account.service.implementation.UserReader;
 import net.causw.app.main.domain.user.auth.service.dto.CustomOAuth2User;
 import net.causw.app.main.domain.user.auth.service.implementation.AuthTokenManager;
+import net.causw.app.main.domain.user.auth.util.OAuthRedirectResolver;
 import net.causw.app.main.shared.exception.errorcode.AuthErrorCode;
 import net.causw.global.constant.StaticValue;
 
@@ -37,10 +37,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-	@Value("${app.auth.redirect-uri}")
-	private String baseUrl;
 	private final AuthTokenManager authTokenManager;
 	private final UserReader userReader;
+	private final OAuthRedirectResolver oAuthRedirectResolver;
 
 	/**
 	 * 소셜 로그인 성공 시 호출됩니다.
@@ -69,8 +68,12 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 			.build();
 		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
+		String baseUrl = oAuthRedirectResolver.resolveRedirectBase(request);
+		ResponseCookie envCookie = oAuthRedirectResolver.clearEnvCookie(request);
+		response.addHeader(HttpHeaders.SET_COOKIE, envCookie.toString());
+
 		// 상태에 따른 리다이렉트 경로 결정
-		String targetUrl = determineTargetUrl(user.getState());
+		String targetUrl = determineTargetUrl(user.getState(), baseUrl);
 
 		// 리다이렉트 실행
 		if (response.isCommitted()) {
@@ -135,7 +138,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 	 * @param state 사용자 상태
 	 * @return redirect 대상 URL
 	 */
-	private String determineTargetUrl(UserState state) {
+	private String determineTargetUrl(UserState state, String baseUrl) {
 		// GUEST 상태라면 추가 정보 입력 페이지로, 아니면 메인으로
 		boolean isFirstLogin = (state == UserState.GUEST);
 		return UriComponentsBuilder.fromUriString(baseUrl)

--- a/app-main/src/main/java/net/causw/app/main/domain/user/auth/util/OAuthRedirectResolver.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/auth/util/OAuthRedirectResolver.java
@@ -1,0 +1,142 @@
+package net.causw.app.main.domain.user.auth.util;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+@Component
+/**
+ * OAuth 로그인 전/후 리다이렉트 목적지와 env 쿠키를 관리하는 유틸 컴포넌트입니다.
+ * <p>
+ * 지원하는 env(local/dev)는 짧은 수명의 HttpOnly 쿠키로 저장되고,
+ * 콜백 시 해당 쿠키를 읽어 최종 프론트 리다이렉트 주소를 결정합니다.
+ */
+public class OAuthRedirectResolver {
+	private static final String ENV_COOKIE_NAME = "oauth_env";
+	private static final Duration ENV_COOKIE_TTL = Duration.ofMinutes(3);
+	private static final Set<String> SUPPORTED_ENVS = Set.of("local", "dev");
+
+	@Value("${app.auth.redirect-uri}")
+	private String defaultRedirectUri;
+
+	@Value("${app.auth.redirect-uri-local:}")
+	private String localRedirectUri;
+
+	@Value("${app.auth.redirect-uri-dev:}")
+	private String devRedirectUri;
+
+	/**
+	 * 요청 파라미터로 전달된 env 값이 지원 대상인지 확인합니다.
+	 *
+	 * @param env 프론트에서 전달한 env 값
+	 * @return 지원하는 env(local/dev)면 true
+	 */
+	public boolean isSupportedEnv(String env) {
+		String normalized = normalizeEnv(env);
+		return normalized != null && SUPPORTED_ENVS.contains(normalized);
+	}
+
+	/**
+	 * OAuth 진입 직전에 env 정보를 담은 쿠키를 생성합니다.
+	 *
+	 * @param env 요청 env 값
+	 * @param request 현재 HTTP 요청
+	 * @return 3분 TTL의 env 쿠키
+	 */
+	public ResponseCookie createEnvCookie(String env, HttpServletRequest request) {
+		String normalized = normalizeEnv(env);
+		return buildEnvCookie(normalized, ENV_COOKIE_TTL, request);
+	}
+
+	/**
+	 * 사용이 끝난 env 쿠키를 즉시 만료시키는 쿠키를 생성합니다.
+	 *
+	 * @param request 현재 HTTP 요청
+	 * @return 즉시 만료(max-age=0) 쿠키
+	 */
+	public ResponseCookie clearEnvCookie(HttpServletRequest request) {
+		return buildEnvCookie("", Duration.ZERO, request);
+	}
+
+	/**
+	 * 요청 쿠키에서 env를 읽어 최종 리다이렉트 기준 URL을 반환합니다.
+	 * <p>
+	 * local/dev 전용 URI가 비어 있거나 설정되지 않은 경우 default URI로 fallback 합니다.
+	 *
+	 * @param request 현재 HTTP 요청
+	 * @return 리다이렉트 기준 URL
+	 */
+	public String resolveRedirectBase(HttpServletRequest request) {
+		return resolveRedirectBase(resolveEnv(request).orElse(null));
+	}
+
+	/**
+	 * 요청 쿠키에서 env 값을 추출합니다.
+	 *
+	 * @param request 현재 HTTP 요청
+	 * @return 지원 env가 있으면 Optional 값, 없으면 Optional.empty()
+	 */
+	public Optional<String> resolveEnv(HttpServletRequest request) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies == null) {
+			return Optional.empty();
+		}
+
+		for (Cookie cookie : cookies) {
+			if (ENV_COOKIE_NAME.equals(cookie.getName())) {
+				String normalized = normalizeEnv(cookie.getValue());
+				return isSupportedEnv(normalized) ? Optional.of(normalized) : Optional.empty();
+			}
+		}
+
+		return Optional.empty();
+	}
+
+	private String resolveRedirectBase(String env) {
+		if ("local".equals(env) && hasText(localRedirectUri)) {
+			return localRedirectUri;
+		}
+		if ("dev".equals(env) && hasText(devRedirectUri)) {
+			return devRedirectUri;
+		}
+		return defaultRedirectUri;
+	}
+
+	private ResponseCookie buildEnvCookie(String value, Duration maxAge, HttpServletRequest request) {
+		CookiePolicy policy = CookiePolicy.from(request);
+		return ResponseCookie.from(ENV_COOKIE_NAME, value)
+			.httpOnly(true)
+			.secure(policy.secure())
+			.path("/")
+			.maxAge(maxAge)
+			.sameSite(policy.sameSite())
+			.build();
+	}
+
+	private String normalizeEnv(String env) {
+		if (env == null) {
+			return null;
+		}
+		String normalized = env.trim().toLowerCase();
+		return normalized.isBlank() ? null : normalized;
+	}
+
+	private boolean hasText(String value) {
+		return value != null && !value.isBlank();
+	}
+
+	private record CookiePolicy(boolean secure, String sameSite) {
+		private static CookiePolicy from(HttpServletRequest request) {
+			boolean secure = request.isSecure();
+			String sameSite = secure ? "None" : "Lax";
+			return new CookiePolicy(secure, sameSite);
+		}
+	}
+}

--- a/app-main/src/test/java/net/causw/app/main/core/security/OAuth2AuthorizationRequestCookieRepositoryTest.java
+++ b/app-main/src/test/java/net/causw/app/main/core/security/OAuth2AuthorizationRequestCookieRepositoryTest.java
@@ -1,0 +1,74 @@
+package net.causw.app.main.core.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+import net.causw.app.main.domain.user.auth.util.OAuthRedirectResolver;
+
+class OAuth2AuthorizationRequestCookieRepositoryTest {
+	private final OAuth2AuthorizationRequestCookieRepository repository = new OAuth2AuthorizationRequestCookieRepository(
+		new OAuthRedirectResolver());
+
+	@Test
+	@DisplayName("env가 local이면 oauth_env 쿠키를 저장한다")
+	void saveAuthorizationRequest_WhenLocalEnv_SavesEnvCookie() {
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/oauth2/authorization/kakao");
+		request.setParameter("env", "local");
+		request.setParameter("state", "state-123");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		repository.saveAuthorizationRequest(createAuthorizationRequest(), request, response);
+
+		String setCookie = response.getHeader(HttpHeaders.SET_COOKIE);
+		assertThat(setCookie).contains("oauth_env=local");
+		assertThat(setCookie).contains("Max-Age=180");
+		assertThat(repository.loadAuthorizationRequest(request)).isNotNull();
+	}
+
+	@Test
+	@DisplayName("지원하지 않는 env면 oauth_env 쿠키를 즉시 만료시킨다")
+	void saveAuthorizationRequest_WhenUnsupportedEnv_ExpiresEnvCookie() {
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/oauth2/authorization/kakao");
+		request.setParameter("env", "prod");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		repository.saveAuthorizationRequest(createAuthorizationRequest(), request, response);
+
+		String setCookie = response.getHeader(HttpHeaders.SET_COOKIE);
+		assertThat(setCookie).contains("oauth_env=");
+		assertThat(setCookie).contains("Max-Age=0");
+	}
+
+	@Test
+	@DisplayName("removeAuthorizationRequest는 저장된 OAuth2 요청을 반환하고 제거한다")
+	void removeAuthorizationRequest_RemovesStoredRequest() {
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/oauth2/authorization/kakao");
+		request.setParameter("env", "local");
+		request.setParameter("state", "state-123");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		OAuth2AuthorizationRequest authorizationRequest = createAuthorizationRequest();
+
+		repository.saveAuthorizationRequest(authorizationRequest, request, response);
+		OAuth2AuthorizationRequest removed = repository.removeAuthorizationRequest(request, response);
+
+		assertThat(removed).isNotNull();
+		assertThat(removed.getState()).isEqualTo(authorizationRequest.getState());
+		assertThat(repository.loadAuthorizationRequest(request)).isNull();
+	}
+
+	private OAuth2AuthorizationRequest createAuthorizationRequest() {
+		return OAuth2AuthorizationRequest.authorizationCode()
+			.authorizationUri("https://kauth.kakao.com/oauth/authorize")
+			.clientId("kakao-client")
+			.redirectUri("http://localhost:8080/login/oauth2/code/kakao")
+			.state("state-123")
+			.authorizationRequestUri("https://kauth.kakao.com/oauth/authorize?state=state-123")
+			.build();
+	}
+}

--- a/app-main/src/test/java/net/causw/app/main/infrastructure/security/WebSecurityConfigTest.java
+++ b/app-main/src/test/java/net/causw/app/main/infrastructure/security/WebSecurityConfigTest.java
@@ -32,6 +32,7 @@ import net.causw.app.main.core.security.AppleOAuth2AuthorizationRequestResolver;
 import net.causw.app.main.core.security.CustomAuthenticationEntryPoint;
 import net.causw.app.main.core.security.CustomAuthorizationManager;
 import net.causw.app.main.core.security.JwtTokenProvider;
+import net.causw.app.main.core.security.OAuth2AuthorizationRequestCookieRepository;
 import net.causw.app.main.core.security.SecurityEndpoints;
 import net.causw.app.main.core.security.WebSecurityConfig;
 import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.AcademicStatus;
@@ -56,6 +57,8 @@ public class WebSecurityConfigTest {
 	private JwtTokenProvider jwtTokenProvider;
 	@MockBean
 	private AppleOAuth2AuthorizationRequestResolver appleOAuth2AuthorizationRequestResolver;
+	@MockBean
+	private OAuth2AuthorizationRequestCookieRepository oAuth2AuthorizationRequestCookieRepository;
 	@MockBean
 	private CustomOAuth2UserService customOAuth2UserService;
 	@MockBean


### PR DESCRIPTION
### 🚩 관련사항
관련된 이슈번호 혹은 PR 번호를 기록합니다.
#1087 

### 📢 전달사항
프론트 측 테스트 편의 고려하여 동적 리다이렉트 로직 추가하였습니다.
소셜 로그인 시 쿼리 파라미터로 ?env=local 등으로 설정 시 env에 저장된 프론트 측 로컬/개발 리다이렉트 uri로 이동합니다.
prod 프로필에서는 동적 리다이렉트 불가합니다.

### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- AuthorizationRequestRepository 커스텀으로 /oauth2/authorization 진입 시 env 쿠키 저장
- OAuth 성공/실패 핸들러에서 쿠키 기반 리다이렉트 분기 및 기본 redirect-urifallback 적용
- OAuthRedirectResolver/OAuth2AuthorizationRequestCookieRepository 자바독 및 테스트 추가

### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 