### PR TITLE
feat: 이용약관 동의 및 개인 동의 여부 조회 api

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/user/UserRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/user/UserRepository.java
@@ -42,7 +42,7 @@ public interface UserRepository extends JpaRepository<User, String> {
 
 	List<User> findAllByState(UserState state);
 
-	List<User> findAllByDeletedAtBefore(LocalDateTime deletedAt);
+List<User> findAllByDeletedAtBefore(LocalDateTime deletedAt);
 
 	Optional<User> findByStudentIdAndName(String studentId, String name);
 

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/user/UserRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/user/UserRepository.java
@@ -42,7 +42,7 @@ public interface UserRepository extends JpaRepository<User, String> {
 
 	List<User> findAllByState(UserState state);
 
-List<User> findAllByDeletedAtBefore(LocalDateTime deletedAt);
+	List<User> findAllByDeletedAtBefore(LocalDateTime deletedAt);
 
 	Optional<User> findByStudentIdAndName(String studentId, String name);
 

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/api/v2/controller/TermsController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/api/v2/controller/TermsController.java
@@ -2,16 +2,25 @@ package net.causw.app.main.domain.user.terms.api.v2.controller;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import net.causw.app.main.domain.user.auth.userdetails.CustomUserDetails;
+import net.causw.app.main.domain.user.terms.api.v2.dto.request.TermsAgreementRequestDto;
 import net.causw.app.main.domain.user.terms.api.v2.dto.response.TermsResponseDto;
+import net.causw.app.main.domain.user.terms.api.v2.dto.response.UserTermsAgreementStatusResponseDto;
 import net.causw.app.main.domain.user.terms.service.v2.TermsService;
 import net.causw.app.main.shared.dto.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "Terms V2", description = "이용약관 API V2")
@@ -27,5 +36,24 @@ public class TermsController {
 	public ApiResponse<List<TermsResponseDto>> getTerms() {
 		return ApiResponse.success(
 			termsService.getTerms().stream().map(TermsResponseDto::from).toList());
+	}
+
+	@Operation(summary = "나의 약관 동의 상태 조회 V2", description = "현재 로그인한 유저의 약관 동의/미동의 현황을 조회합니다.")
+	@GetMapping("/agreement-status")
+	public ApiResponse<UserTermsAgreementStatusResponseDto> getAgreementStatus(
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		return ApiResponse.success(
+			UserTermsAgreementStatusResponseDto.from(
+				termsService.getAgreementStatus(userDetails.getUser())));
+	}
+
+	@Operation(summary = "약관 동의 처리 V2", description = "지정한 약관에 동의 처리합니다. 전체 약관이 모두 포함되어야 합니다.")
+	@PostMapping("/agreements")
+	@ResponseStatus(HttpStatus.CREATED)
+	public ApiResponse<Void> agreeToTerms(
+		@Valid @RequestBody TermsAgreementRequestDto request,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		termsService.agreeToTerms(userDetails.getUser(), request.termsIds());
+		return ApiResponse.success();
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/api/v2/dto/request/TermsAgreementRequestDto.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/api/v2/dto/request/TermsAgreementRequestDto.java
@@ -1,0 +1,11 @@
+package net.causw.app.main.domain.user.terms.api.v2.dto.request;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+
+public record TermsAgreementRequestDto(
+	@NotEmpty
+	@Schema(description = "동의할 약관 ID 목록") List<String> termsIds) {
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/api/v2/dto/request/TermsAgreementRequestDto.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/api/v2/dto/request/TermsAgreementRequestDto.java
@@ -6,6 +6,5 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 
 public record TermsAgreementRequestDto(
-	@NotEmpty
-	@Schema(description = "동의할 약관 ID 목록") List<String> termsIds) {
+	@NotEmpty @Schema(description = "동의할 약관 ID 목록") List<String> termsIds) {
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/api/v2/dto/response/AgreedTermsResponseDto.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/api/v2/dto/response/AgreedTermsResponseDto.java
@@ -1,0 +1,18 @@
+package net.causw.app.main.domain.user.terms.api.v2.dto.response;
+
+import java.time.LocalDateTime;
+
+import net.causw.app.main.domain.user.terms.entity.TermsType;
+import net.causw.app.main.domain.user.terms.service.v2.dto.AgreedTermsInfo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AgreedTermsResponseDto(
+	@Schema(description = "약관 종류") TermsType type,
+	@Schema(description = "동의한 버전") int version,
+	@Schema(description = "동의 일시") LocalDateTime agreedAt) {
+
+	public static AgreedTermsResponseDto from(AgreedTermsInfo info) {
+		return new AgreedTermsResponseDto(info.type(), info.version(), info.agreedAt());
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/api/v2/dto/response/UnagreedTermsResponseDto.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/api/v2/dto/response/UnagreedTermsResponseDto.java
@@ -1,0 +1,29 @@
+package net.causw.app.main.domain.user.terms.api.v2.dto.response;
+
+import java.time.LocalDate;
+
+import net.causw.app.main.domain.user.terms.entity.TermsType;
+import net.causw.app.main.domain.user.terms.service.v2.dto.UnagreedTermsInfo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UnagreedTermsResponseDto(
+	@Schema(description = "약관 ID") String termsId,
+	@Schema(description = "제목") String title,
+	@Schema(description = "약관 종류") TermsType type,
+	@Schema(description = "필수 동의 여부") boolean isRequired,
+	@Schema(description = "버전") int version,
+	@Schema(description = "시행일") LocalDate effectiveDate,
+	@Schema(description = "내용") String content) {
+
+	public static UnagreedTermsResponseDto from(UnagreedTermsInfo info) {
+		return new UnagreedTermsResponseDto(
+			info.termsId(),
+			info.title(),
+			info.type(),
+			info.isRequired(),
+			info.version(),
+			info.effectiveDate(),
+			info.content());
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/api/v2/dto/response/UserTermsAgreementStatusResponseDto.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/api/v2/dto/response/UserTermsAgreementStatusResponseDto.java
@@ -1,0 +1,20 @@
+package net.causw.app.main.domain.user.terms.api.v2.dto.response;
+
+import java.util.List;
+
+import net.causw.app.main.domain.user.terms.service.v2.dto.UserTermsAgreementStatusInfo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UserTermsAgreementStatusResponseDto(
+	@Schema(description = "동의 완료 약관 목록") List<AgreedTermsResponseDto> agreedTerms,
+	@Schema(description = "미동의 약관 목록") List<UnagreedTermsResponseDto> unagreedTerms,
+	@Schema(description = "전체 약관 동의 여부") boolean hasAllRequiredAgreements) {
+
+	public static UserTermsAgreementStatusResponseDto from(UserTermsAgreementStatusInfo info) {
+		return new UserTermsAgreementStatusResponseDto(
+			info.agreedTerms().stream().map(AgreedTermsResponseDto::from).toList(),
+			info.unagreedTerms().stream().map(UnagreedTermsResponseDto::from).toList(),
+			info.hasAllRequiredAgreements());
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/entity/UserTermsAgreement.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/entity/UserTermsAgreement.java
@@ -1,0 +1,48 @@
+package net.causw.app.main.domain.user.terms.entity;
+
+import java.time.LocalDateTime;
+
+import net.causw.app.main.domain.user.account.entity.user.User;
+import net.causw.app.main.shared.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Builder(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "tb_user_terms_agreement",
+	uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "terms_id"}))
+public class UserTermsAgreement extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "terms_id", nullable = false)
+	private Terms terms;
+
+	@Column(name = "agreed_at", nullable = false)
+	private LocalDateTime agreedAt;
+
+	public static UserTermsAgreement of(User user, Terms terms) {
+		return UserTermsAgreement.builder()
+			.user(user)
+			.terms(terms)
+			.agreedAt(LocalDateTime.now())
+			.build();
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/entity/UserTermsAgreement.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/entity/UserTermsAgreement.java
@@ -23,8 +23,7 @@ import lombok.NoArgsConstructor;
 @Builder(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Table(name = "tb_user_terms_agreement",
-	uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "terms_id"}))
+@Table(name = "tb_user_terms_agreement", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "terms_id"}))
 public class UserTermsAgreement extends BaseEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/repository/UserTermsAgreementRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/repository/UserTermsAgreementRepository.java
@@ -1,0 +1,18 @@
+package net.causw.app.main.domain.user.terms.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import net.causw.app.main.domain.user.account.entity.user.User;
+import net.causw.app.main.domain.user.terms.entity.Terms;
+import net.causw.app.main.domain.user.terms.entity.UserTermsAgreement;
+
+@Repository
+public interface UserTermsAgreementRepository extends JpaRepository<UserTermsAgreement, String> {
+
+	List<UserTermsAgreement> findByUser(User user);
+
+	boolean existsByUserAndTerms(User user, Terms terms);
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/repository/UserTermsAgreementRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/repository/UserTermsAgreementRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import net.causw.app.main.domain.user.account.entity.user.User;
-import net.causw.app.main.domain.user.terms.entity.Terms;
 import net.causw.app.main.domain.user.terms.entity.UserTermsAgreement;
 
 @Repository
@@ -14,5 +13,5 @@ public interface UserTermsAgreementRepository extends JpaRepository<UserTermsAgr
 
 	List<UserTermsAgreement> findByUser(User user);
 
-	boolean existsByUserAndTerms(User user, Terms terms);
+	List<UserTermsAgreement> findByUserAndTerms_IdIn(User user, List<String> termsIds);
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/service/implementation/TermsReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/service/implementation/TermsReader.java
@@ -1,0 +1,30 @@
+package net.causw.app.main.domain.user.terms.service.implementation;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import net.causw.app.main.domain.user.terms.entity.Terms;
+import net.causw.app.main.domain.user.terms.repository.TermsRepository;
+import net.causw.app.main.shared.exception.errorcode.TermsErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TermsReader {
+
+	private final TermsRepository termsRepository;
+
+	public List<Terms> findLatestVersionPerType() {
+		List<Terms> result = termsRepository.findLatestVersionPerType();
+		if (result.isEmpty()) {
+			throw TermsErrorCode.TERMS_NOT_FOUND.toBaseException();
+		}
+		return result;
+	}
+
+	public List<Terms> findAllById(List<String> ids) {
+		return termsRepository.findAllById(ids);
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/service/implementation/UserTermsAgreementReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/service/implementation/UserTermsAgreementReader.java
@@ -1,0 +1,26 @@
+package net.causw.app.main.domain.user.terms.service.implementation;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import net.causw.app.main.domain.user.account.entity.user.User;
+import net.causw.app.main.domain.user.terms.entity.UserTermsAgreement;
+import net.causw.app.main.domain.user.terms.repository.UserTermsAgreementRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UserTermsAgreementReader {
+
+	private final UserTermsAgreementRepository userTermsAgreementRepository;
+
+	public List<UserTermsAgreement> findByUser(User user) {
+		return userTermsAgreementRepository.findByUser(user);
+	}
+
+	public List<UserTermsAgreement> findByUserAndTermsIdIn(User user, List<String> termsIds) {
+		return userTermsAgreementRepository.findByUserAndTerms_IdIn(user, termsIds);
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/service/implementation/UserTermsAgreementWriter.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/service/implementation/UserTermsAgreementWriter.java
@@ -1,0 +1,21 @@
+package net.causw.app.main.domain.user.terms.service.implementation;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import net.causw.app.main.domain.user.terms.entity.UserTermsAgreement;
+import net.causw.app.main.domain.user.terms.repository.UserTermsAgreementRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UserTermsAgreementWriter {
+
+	private final UserTermsAgreementRepository userTermsAgreementRepository;
+
+	public void saveAll(List<UserTermsAgreement> agreements) {
+		userTermsAgreementRepository.saveAll(agreements);
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/service/v2/TermsService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/service/v2/TermsService.java
@@ -1,12 +1,21 @@
 package net.causw.app.main.domain.user.terms.service.v2;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import net.causw.app.main.domain.user.account.entity.user.User;
+import net.causw.app.main.domain.user.terms.entity.Terms;
+import net.causw.app.main.domain.user.terms.entity.UserTermsAgreement;
 import net.causw.app.main.domain.user.terms.repository.TermsRepository;
+import net.causw.app.main.domain.user.terms.repository.UserTermsAgreementRepository;
+import net.causw.app.main.domain.user.terms.service.v2.dto.AgreedTermsInfo;
 import net.causw.app.main.domain.user.terms.service.v2.dto.TermsInfo;
+import net.causw.app.main.domain.user.terms.service.v2.dto.UnagreedTermsInfo;
+import net.causw.app.main.domain.user.terms.service.v2.dto.UserTermsAgreementStatusInfo;
 import net.causw.app.main.shared.exception.errorcode.TermsErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -17,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class TermsService {
 
 	private final TermsRepository termsRepository;
+	private final UserTermsAgreementRepository userTermsAgreementRepository;
 
 	public List<TermsInfo> getTerms() {
 		List<TermsInfo> result = termsRepository.findLatestVersionPerType()
@@ -27,5 +37,61 @@ public class TermsService {
 			throw TermsErrorCode.TERMS_NOT_FOUND.toBaseException();
 		}
 		return result;
+	}
+
+	public UserTermsAgreementStatusInfo getAgreementStatus(User user) {
+		List<Terms> latestTerms = termsRepository.findLatestVersionPerType();
+		if (latestTerms.isEmpty()) {
+			throw TermsErrorCode.TERMS_NOT_FOUND.toBaseException();
+		}
+
+		Set<String> latestTermsIds = latestTerms.stream()
+			.map(Terms::getId)
+			.collect(Collectors.toSet());
+
+		List<UserTermsAgreement> userAgreements = userTermsAgreementRepository.findByUser(user)
+			.stream()
+			.filter(uta -> latestTermsIds.contains(uta.getTerms().getId()))
+			.toList();
+
+		Set<String> agreedTermsIds = userAgreements.stream()
+			.map(uta -> uta.getTerms().getId())
+			.collect(Collectors.toSet());
+
+		List<AgreedTermsInfo> agreedTerms = userAgreements.stream()
+			.map(uta -> new AgreedTermsInfo(
+				uta.getTerms().getType(),
+				uta.getTerms().getVersion(),
+				uta.getAgreedAt()))
+			.toList();
+
+		List<UnagreedTermsInfo> unagreedTerms = latestTerms.stream()
+			.filter(t -> !agreedTermsIds.contains(t.getId()))
+			.map(UnagreedTermsInfo::from)
+			.toList();
+
+		boolean hasAllRequiredAgreements = agreedTermsIds.containsAll(latestTermsIds);
+
+		return new UserTermsAgreementStatusInfo(agreedTerms, unagreedTerms, hasAllRequiredAgreements);
+	}
+
+	@Transactional
+	public void agreeToTerms(User user, List<String> termsIds) {
+		List<Terms> latestTerms = termsRepository.findLatestVersionPerType();
+
+		Set<String> latestTermsIds = latestTerms.stream()
+			.map(Terms::getId)
+			.collect(Collectors.toSet());
+
+		if (!Set.copyOf(termsIds).containsAll(latestTermsIds)) {
+			throw TermsErrorCode.NOT_ALL_TERMS_AGREED.toBaseException();
+		}
+
+		List<Terms> termsToAgree = termsRepository.findAllById(termsIds);
+		for (Terms terms : termsToAgree) {
+			if (!userTermsAgreementRepository.existsByUserAndTerms(user, terms)) {
+				userTermsAgreementRepository.save(UserTermsAgreement.of(user, terms));
+			}
+		}
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/service/v2/TermsService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/service/v2/TermsService.java
@@ -10,8 +10,9 @@ import org.springframework.transaction.annotation.Transactional;
 import net.causw.app.main.domain.user.account.entity.user.User;
 import net.causw.app.main.domain.user.terms.entity.Terms;
 import net.causw.app.main.domain.user.terms.entity.UserTermsAgreement;
-import net.causw.app.main.domain.user.terms.repository.TermsRepository;
-import net.causw.app.main.domain.user.terms.repository.UserTermsAgreementRepository;
+import net.causw.app.main.domain.user.terms.service.implementation.TermsReader;
+import net.causw.app.main.domain.user.terms.service.implementation.UserTermsAgreementReader;
+import net.causw.app.main.domain.user.terms.service.implementation.UserTermsAgreementWriter;
 import net.causw.app.main.domain.user.terms.service.v2.dto.AgreedTermsInfo;
 import net.causw.app.main.domain.user.terms.service.v2.dto.TermsInfo;
 import net.causw.app.main.domain.user.terms.service.v2.dto.UnagreedTermsInfo;
@@ -25,31 +26,25 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class TermsService {
 
-	private final TermsRepository termsRepository;
-	private final UserTermsAgreementRepository userTermsAgreementRepository;
+	private final TermsReader termsReader;
+	private final UserTermsAgreementReader userTermsAgreementReader;
+	private final UserTermsAgreementWriter userTermsAgreementWriter;
 
 	public List<TermsInfo> getTerms() {
-		List<TermsInfo> result = termsRepository.findLatestVersionPerType()
+		return termsReader.findLatestVersionPerType()
 			.stream()
 			.map(TermsInfo::from)
 			.toList();
-		if (result.isEmpty()) {
-			throw TermsErrorCode.TERMS_NOT_FOUND.toBaseException();
-		}
-		return result;
 	}
 
 	public UserTermsAgreementStatusInfo getAgreementStatus(User user) {
-		List<Terms> latestTerms = termsRepository.findLatestVersionPerType();
-		if (latestTerms.isEmpty()) {
-			throw TermsErrorCode.TERMS_NOT_FOUND.toBaseException();
-		}
+		List<Terms> latestTerms = termsReader.findLatestVersionPerType();
 
 		Set<String> latestTermsIds = latestTerms.stream()
 			.map(Terms::getId)
 			.collect(Collectors.toSet());
 
-		List<UserTermsAgreement> userAgreements = userTermsAgreementRepository.findByUser(user)
+		List<UserTermsAgreement> userAgreements = userTermsAgreementReader.findByUser(user)
 			.stream()
 			.filter(uta -> latestTermsIds.contains(uta.getTerms().getId()))
 			.toList();
@@ -72,12 +67,12 @@ public class TermsService {
 
 		boolean hasAllRequiredAgreements = agreedTermsIds.containsAll(latestTermsIds);
 
-		return new UserTermsAgreementStatusInfo(agreedTerms, unagreedTerms, hasAllRequiredAgreements);
+		return UserTermsAgreementStatusInfo.of(agreedTerms, unagreedTerms, hasAllRequiredAgreements);
 	}
 
 	@Transactional
 	public void agreeToTerms(User user, List<String> termsIds) {
-		List<Terms> latestTerms = termsRepository.findLatestVersionPerType();
+		List<Terms> latestTerms = termsReader.findLatestVersionPerType();
 
 		Set<String> latestTermsIds = latestTerms.stream()
 			.map(Terms::getId)
@@ -87,11 +82,17 @@ public class TermsService {
 			throw TermsErrorCode.NOT_ALL_TERMS_AGREED.toBaseException();
 		}
 
-		List<Terms> termsToAgree = termsRepository.findAllById(termsIds);
-		for (Terms terms : termsToAgree) {
-			if (!userTermsAgreementRepository.existsByUserAndTerms(user, terms)) {
-				userTermsAgreementRepository.save(UserTermsAgreement.of(user, terms));
-			}
-		}
+		Set<String> alreadyAgreedIds = userTermsAgreementReader.findByUserAndTermsIdIn(user, termsIds)
+			.stream()
+			.map(uta -> uta.getTerms().getId())
+			.collect(Collectors.toSet());
+
+		List<Terms> termsToAgree = termsReader.findAllById(termsIds);
+		List<UserTermsAgreement> newAgreements = termsToAgree.stream()
+			.filter(terms -> !alreadyAgreedIds.contains(terms.getId()))
+			.map(terms -> UserTermsAgreement.of(user, terms))
+			.toList();
+
+		userTermsAgreementWriter.saveAll(newAgreements);
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/service/v2/dto/AgreedTermsInfo.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/service/v2/dto/AgreedTermsInfo.java
@@ -1,0 +1,11 @@
+package net.causw.app.main.domain.user.terms.service.v2.dto;
+
+import java.time.LocalDateTime;
+
+import net.causw.app.main.domain.user.terms.entity.TermsType;
+
+public record AgreedTermsInfo(
+	TermsType type,
+	int version,
+	LocalDateTime agreedAt) {
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/service/v2/dto/UnagreedTermsInfo.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/service/v2/dto/UnagreedTermsInfo.java
@@ -1,0 +1,27 @@
+package net.causw.app.main.domain.user.terms.service.v2.dto;
+
+import java.time.LocalDate;
+
+import net.causw.app.main.domain.user.terms.entity.Terms;
+import net.causw.app.main.domain.user.terms.entity.TermsType;
+
+public record UnagreedTermsInfo(
+	String termsId,
+	String title,
+	TermsType type,
+	boolean isRequired,
+	int version,
+	LocalDate effectiveDate,
+	String content) {
+
+	public static UnagreedTermsInfo from(Terms terms) {
+		return new UnagreedTermsInfo(
+			terms.getId(),
+			terms.getTitle(),
+			terms.getType(),
+			terms.isRequired(),
+			terms.getVersion(),
+			terms.getEffectiveDate(),
+			terms.getContent());
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/service/v2/dto/UserTermsAgreementStatusInfo.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/service/v2/dto/UserTermsAgreementStatusInfo.java
@@ -1,0 +1,9 @@
+package net.causw.app.main.domain.user.terms.service.v2.dto;
+
+import java.util.List;
+
+public record UserTermsAgreementStatusInfo(
+	List<AgreedTermsInfo> agreedTerms,
+	List<UnagreedTermsInfo> unagreedTerms,
+	boolean hasAllRequiredAgreements) {
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/service/v2/dto/UserTermsAgreementStatusInfo.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/service/v2/dto/UserTermsAgreementStatusInfo.java
@@ -6,4 +6,11 @@ public record UserTermsAgreementStatusInfo(
 	List<AgreedTermsInfo> agreedTerms,
 	List<UnagreedTermsInfo> unagreedTerms,
 	boolean hasAllRequiredAgreements) {
+
+	public static UserTermsAgreementStatusInfo of(
+		List<AgreedTermsInfo> agreedTerms,
+		List<UnagreedTermsInfo> unagreedTerms,
+		boolean hasAllRequiredAgreements) {
+		return new UserTermsAgreementStatusInfo(agreedTerms, unagreedTerms, hasAllRequiredAgreements);
+	}
 }

--- a/app-main/src/main/java/net/causw/app/main/shared/exception/errorcode/TermsErrorCode.java
+++ b/app-main/src/main/java/net/causw/app/main/shared/exception/errorcode/TermsErrorCode.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public enum TermsErrorCode implements BaseResponseCode {
-	TERMS_NOT_FOUND(HttpStatus.NOT_FOUND, "TERMS_404_001", "해당 이용약관을 찾을 수 없습니다.");
+	TERMS_NOT_FOUND(HttpStatus.NOT_FOUND, "TERMS_404_001", "해당 이용약관을 찾을 수 없습니다."),
+	NOT_ALL_TERMS_AGREED(HttpStatus.BAD_REQUEST, "TERMS_400_001", "전체 약관에 모두 동의해야 합니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/app-main/src/main/resources/db/migration/V20260309120000__CreateUserTermsAgreementTable.sql
+++ b/app-main/src/main/resources/db/migration/V20260309120000__CreateUserTermsAgreementTable.sql
@@ -1,0 +1,11 @@
+CREATE TABLE tb_user_terms_agreement (
+    id         VARCHAR(255) NOT NULL PRIMARY KEY,
+    user_id    VARCHAR(255) NOT NULL,
+    terms_id   VARCHAR(255) NOT NULL,
+    agreed_at  DATETIME(6)  NOT NULL,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    UNIQUE KEY uq_user_terms_agreement (user_id, terms_id),
+    CONSTRAINT fk_uta_user  FOREIGN KEY (user_id)  REFERENCES tb_user(id),
+    CONSTRAINT fk_uta_terms FOREIGN KEY (terms_id) REFERENCES tb_terms(id)
+);


### PR DESCRIPTION
### 🚩 관련사항
#1163 


### 📢 전달사항
1. 이용약관 동의 api
이용약관을 불러와서 동의 시키는 방식이고 전체 약관이 전부 필수인점 고려해서 진행했습니다
2. 개인 동의 여부 조회 api가 추가되었습니다. 


### 📸 스크린샷
<img width="383" height="395" alt="image" src="https://github.com/user-attachments/assets/cd937174-13ea-4b61-87bf-e5b006108366" />



### 📃 진행사항
- [ ] 이용약관 동의 api
- [ ] 동의 여부 조회 api

### ⚙️ 기타사항
단순이용약관 동의 api와 동의 여부 조회 api 개발은 완료 하였으나 조회api의 경우 개인이 동의를 하였는지 확인하는 용도로 진행하였으나 해당 방향을 말씀하셨던건지 정확하지 않아 해당 조회 api 파트가 목적에 맞는지확인 한번 부탁드립니다..ㅜ 
NOT_ALL_TERMS_AGREED(는 전체 약관이 현재 필수라는 점에 넣은 요소입니다

상세 조회를 위한 이용약관 내용은 조회시 한번에 내려주고 있습니다 분리필요가 있지 않다 생각해 같이 내렸는데 분리하는 것이 낫다면 말씀해주세요!
개발기간: 