### PR TITLE
fix: immutable 리스트를 할당하는거 수정

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/entity/Post.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/entity/Post.java
@@ -154,12 +154,14 @@ public class Post extends BaseEntity {
 		this.title = title;
 		this.content = content;
 		this.form = form;
-		this.postAttachImageList = postAttachImageList;
+		this.postAttachImageList.clear();
+		this.postAttachImageList.addAll(postAttachImageList);
 	}
 
 	public void updateContentAndImages(String content, List<PostAttachImage> postAttachImageList) {
 		this.content = content;
-		this.postAttachImageList = postAttachImageList;
+		this.postAttachImageList.clear();
+		this.postAttachImageList.addAll(postAttachImageList);
 	}
 
 	public void setIsDeleted(Boolean isDeleted) {


### PR DESCRIPTION
### 🚩 관련사항
Closes: #1185


### 📢 전달사항
Stream 에서 toList() 를 하면 불변 리스트가 반환되는데 이를 JPA 엔티티의 필드에 할당하면
Hibernate가 내부적으로 이후 clear()를 호출하기 때문에 여기서 NPE가 터졌습니다.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [x] 수정완


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 