### PR TITLE
feat: 미처리 경조사 수 조회 api 구현

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/api/v2/controller/CeremonyAdminController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/api/v2/controller/CeremonyAdminController.java
@@ -18,6 +18,7 @@ import net.causw.app.main.domain.community.ceremony.api.v2.dto.request.CeremonyA
 import net.causw.app.main.domain.community.ceremony.api.v2.dto.request.CeremonyRejectRequest;
 import net.causw.app.main.domain.community.ceremony.api.v2.dto.response.CeremonyAdminListResponse;
 import net.causw.app.main.domain.community.ceremony.api.v2.dto.response.CeremonyDetailResponse;
+import net.causw.app.main.domain.community.ceremony.api.v2.dto.response.CeremonyPendingCountResponse;
 import net.causw.app.main.domain.community.ceremony.api.v2.mapper.CeremonyAdminListMapper;
 import net.causw.app.main.domain.community.ceremony.api.v2.mapper.CeremonyDtoMapper;
 import net.causw.app.main.domain.community.ceremony.service.CeremonyAdminService;
@@ -54,6 +55,14 @@ public class CeremonyAdminController {
 		Page<CeremonyAdminListResult> result = ceremonyAdminService.getCeremonyList(condition, pageable);
 		Page<CeremonyAdminListResponse> response = result.map(ceremonyDtoMapper::toAdminListResponse);
 		return ApiResponse.success(PageResponse.from(response));
+	}
+
+	@GetMapping("/pending-count")
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(summary = "미처리 경조사수 조회", description = "대기 중인 경조사 수를 조회합니다.")
+	public ApiResponse<CeremonyPendingCountResponse> getPendingCeremonyCount() {
+		long count = ceremonyAdminService.getPendingCeremonyCount();
+		return ApiResponse.success(new CeremonyPendingCountResponse(count));
 	}
 
 	@GetMapping("/{ceremonyId}")

--- a/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/api/v2/controller/CeremonyAdminController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/api/v2/controller/CeremonyAdminController.java
@@ -60,8 +60,8 @@ public class CeremonyAdminController {
 	@GetMapping("/pending-count")
 	@ResponseStatus(HttpStatus.OK)
 	@Operation(summary = "미처리 경조사수 조회", description = "대기 중인 경조사 수를 조회합니다.")
-	public ApiResponse<CeremonyPendingCountResponse> getPendingCeremonyCount() {
-		long count = ceremonyAdminService.getPendingCeremonyCount();
+	public ApiResponse<CeremonyPendingCountResponse> getPendingCount() {
+		long count = ceremonyAdminService.getPendingCount();
 		return ApiResponse.success(new CeremonyPendingCountResponse(count));
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/api/v2/dto/response/CeremonyPendingCountResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/api/v2/dto/response/CeremonyPendingCountResponse.java
@@ -1,0 +1,8 @@
+package net.causw.app.main.domain.community.ceremony.api.v2.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "미처리 경조사 수 응답")
+public record CeremonyPendingCountResponse(
+	@Schema(description = "대기 상태인 경조사 수", example = "5") long pendingCount) {
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/repository/CeremonyRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/repository/CeremonyRepository.java
@@ -11,4 +11,6 @@ public interface CeremonyRepository extends JpaRepository<Ceremony, String> {
 
 	Page<Ceremony> findByUser_IdAndCeremonyStateOrderByStartDateDescStartTimeDesc(String userId,
 		CeremonyState ceremonyState, Pageable pageable);
+
+	long countByCeremonyState(CeremonyState ceremonyState);
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/service/CeremonyAdminService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/service/CeremonyAdminService.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import net.causw.app.main.domain.community.ceremony.entity.Ceremony;
-import net.causw.app.main.domain.community.ceremony.enums.CeremonyState;
 import net.causw.app.main.domain.community.ceremony.service.dto.request.CeremonyAdminListCondition;
 import net.causw.app.main.domain.community.ceremony.service.dto.response.CeremonyAdminListResult;
 import net.causw.app.main.domain.community.ceremony.service.dto.response.CeremonyDetailResult;
@@ -35,7 +34,7 @@ public class CeremonyAdminService {
 	}
 
 	public long getPendingCount() {
-		return ceremonyReader.countByCeremonyState(CeremonyState.AWAIT);
+		return ceremonyReader.countAwaitCeremony();
 	}
 
 	public CeremonyDetailResult getCeremonyDetail(String ceremonyId) {

--- a/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/service/CeremonyAdminService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/service/CeremonyAdminService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import net.causw.app.main.domain.community.ceremony.entity.Ceremony;
+import net.causw.app.main.domain.community.ceremony.enums.CeremonyState;
 import net.causw.app.main.domain.community.ceremony.service.dto.request.CeremonyAdminListCondition;
 import net.causw.app.main.domain.community.ceremony.service.dto.response.CeremonyAdminListResult;
 import net.causw.app.main.domain.community.ceremony.service.dto.response.CeremonyDetailResult;
@@ -31,6 +32,10 @@ public class CeremonyAdminService {
 		Page<Ceremony> ceremonies = ceremonyReader.findAllForAdmin(
 			condition.fromDate(), condition.toDate(), condition.state(), pageable);
 		return ceremonies.map(ceremonyMapper::toAdminListResult);
+	}
+
+	public long getPendingCeremonyCount() {
+		return ceremonyReader.countByCeremonyState(CeremonyState.AWAIT);
 	}
 
 	public CeremonyDetailResult getCeremonyDetail(String ceremonyId) {

--- a/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/service/CeremonyAdminService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/service/CeremonyAdminService.java
@@ -34,7 +34,7 @@ public class CeremonyAdminService {
 		return ceremonies.map(ceremonyMapper::toAdminListResult);
 	}
 
-	public long getPendingCeremonyCount() {
+	public long getPendingCount() {
 		return ceremonyReader.countByCeremonyState(CeremonyState.AWAIT);
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/service/implementation/CeremonyReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/service/implementation/CeremonyReader.java
@@ -53,4 +53,8 @@ public class CeremonyReader {
 		Pageable pageable) {
 		return ceremonyQueryRepository.findAllForAdmin(fromDate, toDate, state, pageable);
 	}
+
+	public long countByCeremonyState(CeremonyState ceremonyState) {
+		return ceremonyRepository.countByCeremonyState(ceremonyState);
+	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/service/implementation/CeremonyReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/service/implementation/CeremonyReader.java
@@ -54,7 +54,7 @@ public class CeremonyReader {
 		return ceremonyQueryRepository.findAllForAdmin(fromDate, toDate, state, pageable);
 	}
 
-	public long countByCeremonyState(CeremonyState ceremonyState) {
-		return ceremonyRepository.countByCeremonyState(ceremonyState);
+	public long countAwaitCeremony() {
+		return ceremonyRepository.countByCeremonyState(CeremonyState.AWAIT);
 	}
 }


### PR DESCRIPTION
### 🚩 관련사항
issue #1197 


### 📢 전달사항
- 관리자 대시보드에 표시할 미처리된 경조사 수를 조회하는 api를 구현했습니다.
- 상태가 `AWAIT(대기)`인 경조사를 미처리로 분류하여 값을 반환합니다 

### 📸 스크린샷
<img width="1972" height="1125" alt="image" src="https://github.com/user-attachments/assets/2ec042e0-c1ba-46fb-88b3-25c812c2c62f" />



### 📃 진행사항
- [x] 미처리 경조사 수 조회 api 구현
- 


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 2026.03.30