### PR TITLE
feat: 동문수첩 상세조회 dto에 문자열 정렬 추가

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/mapper/UserInfoMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/mapper/UserInfoMapper.java
@@ -106,13 +106,15 @@ public interface UserInfoMapper extends UuidFileToUrlDtoMapper {
 
 		return socialLinks.stream()
 			.filter(s -> s != null && !s.isBlank())
+			.map(String::trim)
 			.sorted(byDomainThenFullUrl)
 			.toList();
 	}
 
 	private static String extractSortDomainKey(String url) {
 		try {
-			String host = new URI(url).getHost();
+			String urlToParse = (url.contains("://") || url.startsWith("//")) ? url : "https://" + url;
+			String host = new URI(urlToParse).getHost();
 			if (host == null || host.isBlank()) {
 				return url;
 			}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/mapper/UserInfoMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/mapper/UserInfoMapper.java
@@ -1,5 +1,8 @@
 package net.causw.app.main.domain.user.account.service.mapper;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
@@ -28,7 +31,7 @@ public interface UserInfoMapper extends UuidFileToUrlDtoMapper {
 	@Mapping(target = "email", source = "user.email")
 	@Mapping(target = "phoneNumber", source = ".", qualifiedByName = "mapPhoneNumber")
 	@Mapping(target = "isPhoneNumberVisible", source = "phoneNumberVisible")
-	@Mapping(target = "socialLinks", source = "socialLinks")
+	@Mapping(target = "socialLinks", source = "socialLinks", qualifiedByName = "sortSocialLinksByDomain")
 	@Mapping(target = "userTechStack", source = "userTechStack", qualifiedByName = "sortStringsAsc")
 	@Mapping(target = "userCareer", source = "userCareer")
 	@Mapping(target = "userProject", source = "userProject")
@@ -89,5 +92,33 @@ public interface UserInfoMapper extends UuidFileToUrlDtoMapper {
 			.filter(s -> s != null && !s.isBlank())
 			.sorted(String.CASE_INSENSITIVE_ORDER)
 			.toList();
+	}
+
+	@Named("sortSocialLinksByDomain")
+	static List<String> sortSocialLinksByDomain(List<String> socialLinks) {
+		if (socialLinks == null || socialLinks.isEmpty())
+			return List.of();
+
+		// 도메인으로 우선 정렬, 같은 도메인이면 전체 URL로 2차 정렬
+		Comparator<String> byDomainThenFullUrl = Comparator
+			.comparing(UserInfoMapper::extractSortDomainKey, String.CASE_INSENSITIVE_ORDER)
+			.thenComparing(String.CASE_INSENSITIVE_ORDER);
+
+		return socialLinks.stream()
+			.filter(s -> s != null && !s.isBlank())
+			.sorted(byDomainThenFullUrl)
+			.toList();
+	}
+
+	private static String extractSortDomainKey(String url) {
+		try {
+			String host = new URI(url).getHost();
+			if (host == null || host.isBlank()) {
+				return url;
+			}
+			return host.startsWith("www.") ? host.substring(4) : host;
+		} catch (URISyntaxException e) {
+			return url;
+		}
 	}
 }


### PR DESCRIPTION
### 🚩 관련사항
#1202 


### 📢 전달사항
동문수첩 상세조회 dto에서 sns 링크를 내려줄때 정렬 기준이 없어 도메인 기준으로 정렬되도록 매퍼를 수정했습니다.


### 📸 스크린샷
<img width="1920" height="950" alt="image" src="https://github.com/user-attachments/assets/fdea7b3f-6fbc-44a4-b756-e5b97471cd8c" />



### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 