### PR TITLE
fix: 알림 핸들러 트랜잭션 전파 속성 수정 (#1204)

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/AdmissionNotificationHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/AdmissionNotificationHandler.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -47,7 +48,7 @@ public class AdmissionNotificationHandler {
 	 */
 	@Async("asyncExecutor")
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	@Transactional
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void handleRequest(AdmissionRequestedEvent event) {
 		// ID로 요청자 조회
 		User requester = userReader.findUserById(event.requesterId());

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/CeremonyNotificationHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/CeremonyNotificationHandler.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -51,7 +52,7 @@ public class CeremonyNotificationHandler {
 	 */
 	@Async("asyncExecutor")
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	@Transactional
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void handle(CeremonyNotificationEvent event) {
 		Ceremony ceremony = ceremonyReader.findById(event.ceremonyId())
 			.orElseThrow(CeremonyErrorCode.CEREMONY_NOT_FOUND::toBaseException);

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/CommentNotificationHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/CommentNotificationHandler.java
@@ -2,6 +2,7 @@ package net.causw.app.main.domain.notification.notification.service.handler;
 
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -110,7 +111,7 @@ public class CommentNotificationHandler {
 	 */
 	@Async("asyncExecutor")
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	@Transactional
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void handleChildComment(CommentChildCommentCreatedEvent event) {
 		// ID로 댓글·대댓글 조회
 		Comment comment = commentReader.getComment(event.commentId());

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/LikePostNotificationHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/LikePostNotificationHandler.java
@@ -2,6 +2,7 @@ package net.causw.app.main.domain.notification.notification.service.handler;
 
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -45,7 +46,7 @@ public class LikePostNotificationHandler {
 	 */
 	@Async("asyncExecutor")
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	@Transactional
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void handle(PostLikedEvent event) {
 		// ID로 게시글·좋아요 누른 유저 조회
 		Post post = postReader.findById(event.postId());

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/OfficialPostNotificationHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/OfficialPostNotificationHandler.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -40,7 +41,7 @@ public class OfficialPostNotificationHandler {
 
 	@Async("asyncExecutor")
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	@Transactional
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void handle(OfficialPostEvent event) {
 		// ID로 게시판·게시글 조회
 		Board board = boardReader.getById(event.boardId());


### PR DESCRIPTION
@Async 및 @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)이 적용된 핸들러에서 새로운 트랜잭션을 시작하도록 Propagation.REQUIRES_NEW를 추가했습니다. 이를 통해 메인 트랜잭션 종료 후 비동기 로직이 정상적으로 데이터베이스 작업을 수행할 수 있도록 보장합니다.

### 🚩 관련사항
관련된 이슈번호 혹은 PR 번호를 기록합니다.


### 📢 전달사항
어떤 버그나 오류가 발생했는지,
무슨 이유로 코드를 생성하거나 변경했는지,
어떤 부분을 집중적으로 봐줘야하는지 등
내용을 상세히 적어주세요.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 