### PR TITLE
feat: v1 알림, v2 알림 분별되어 노출되도록 수정

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/enums/NoticeType.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/enums/NoticeType.java
@@ -1,5 +1,7 @@
 package net.causw.app.main.domain.notification.notification.enums;
 
+import java.util.List;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -22,4 +24,6 @@ public enum NoticeType {
 
 	private final String title;
 	private final String type;
+
+	public static final List<NoticeType> V1_TYPES = List.of(POST, COMMENT, CEREMONY, BOARD, ADMISSION);
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/repository/NotificationLogQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/repository/NotificationLogQueryRepository.java
@@ -25,7 +25,7 @@ public class NotificationLogQueryRepository {
 	/**
 	 * 알림 로그 ID와 유저 ID로 알림 로그 조회
 	 */
-	public Optional<NotificationLog> findByIdAndUserId(String id, String userId) {
+	public Optional<NotificationLog> findNotificationLogByIdAndUserId(String id, String userId) {
 		QNotificationLog nl = QNotificationLog.notificationLog;
 
 		return Optional.ofNullable(
@@ -40,7 +40,7 @@ public class NotificationLogQueryRepository {
 	/**
 	 * 유저 ID와 읽음 여부로 최근 7일간의 알림 로그 조회 (notification JOIN FETCH) (v1 알림 제외)
 	 */
-	public List<NotificationLog> findRecentNotifications(String userId, boolean isRead, LocalDateTime sevenDaysAgo) {
+	public List<NotificationLog> findNotificationLogByUserIdAndIsRead(String userId, boolean isRead, LocalDateTime sevenDaysAgo) {
 		QNotificationLog nl = QNotificationLog.notificationLog;
 		QNotification n = QNotification.notification;
 
@@ -57,23 +57,45 @@ public class NotificationLogQueryRepository {
 	}
 
 	/**
-	 * 유저 ID로 읽지 않은 V2 알림 로그 조회 (페이징)  (v1 알림 제외)
+	 * 유저 ID로 가장 최근의 읽지 않은 알림 로그 단건 조회 (v1 알림 제외)
 	 */
-	public List<NotificationLog> findByUserIdAndIsReadFalse(String userId, Pageable pageable) {
+	public Optional<NotificationLog> findLatestUnreadByUserId(String userId) {
 		QNotificationLog nl = QNotificationLog.notificationLog;
 		QNotification n = QNotification.notification;
 
-		return jpaQueryFactory
-			.selectFrom(nl)
+		return Optional.ofNullable(
+			jpaQueryFactory
+				.selectFrom(nl)
+				.join(nl.notification, n).fetchJoin()
+				.where(
+					nl.user.id.eq(userId),
+					nl.isRead.isFalse(),
+					n.noticeType.notIn(NoticeType.V1_TYPES))
+				.orderBy(nl.createdAt.desc())
+				.fetchFirst()
+		);
+	}
+
+	/**
+	 * 유저 ID로 최근 7일간의 읽지 않은 알림 개수를 카운트 (v1 알림 제외)
+	 */
+	public long countRecentUnread(String userId, LocalDateTime sevenDaysAgo) {
+		QNotificationLog nl = QNotificationLog.notificationLog;
+		QNotification n = QNotification.notification;
+
+		Long count = jpaQueryFactory
+			.select(nl.count())
+			.from(nl)
 			.join(nl.notification, n)
 			.where(
 				nl.user.id.eq(userId),
 				nl.isRead.isFalse(),
+				nl.createdAt.goe(sevenDaysAgo),
 				n.noticeType.notIn(NoticeType.V1_TYPES))
-			.orderBy(nl.createdAt.desc())
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.fetch();
+			.fetchOne();
+
+		// npe 방지 위해 null 체크 후 0L 반환
+		return count != null ? count : 0L;
 	}
 
 	/**
@@ -81,18 +103,18 @@ public class NotificationLogQueryRepository {
 	 */
 	public List<NotificationLog> findRecentUnreadLogsUpToLimit(String userId, LocalDateTime sevenDaysAgo,
 		Pageable pageable) {
-		QNotificationLog nl = QNotificationLog.notificationLog;
-		QNotification n = QNotification.notification;
+		QNotificationLog notificationLog = QNotificationLog.notificationLog;
+		QNotification notification = QNotification.notification;
 
 		return jpaQueryFactory
-			.selectFrom(nl)
-			.join(nl.notification, n)
+			.selectFrom(notificationLog)
+			.join(notificationLog.notification, notification).fetchJoin()
 			.where(
-				nl.user.id.eq(userId),
-				nl.isRead.isFalse(),
-				nl.createdAt.goe(sevenDaysAgo),
-				n.noticeType.notIn(NoticeType.V1_TYPES))
-			.orderBy(nl.createdAt.desc())
+				notificationLog.user.id.eq(userId),
+				notificationLog.isRead.isFalse(),
+				notificationLog.createdAt.goe(sevenDaysAgo),
+					notification.noticeType.notIn(NoticeType.V1_TYPES))
+			.orderBy(notificationLog.createdAt.desc())
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.fetch();

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/repository/NotificationLogQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/repository/NotificationLogQueryRepository.java
@@ -1,0 +1,101 @@
+package net.causw.app.main.domain.notification.notification.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import net.causw.app.main.domain.notification.notification.entity.NotificationLog;
+import net.causw.app.main.domain.notification.notification.entity.QNotification;
+import net.causw.app.main.domain.notification.notification.entity.QNotificationLog;
+import net.causw.app.main.domain.notification.notification.enums.NoticeType;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationLogQueryRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	/**
+	 * 알림 로그 ID와 유저 ID로 알림 로그 조회
+	 */
+	public Optional<NotificationLog> findByIdAndUserId(String id, String userId) {
+		QNotificationLog nl = QNotificationLog.notificationLog;
+
+		return Optional.ofNullable(
+			jpaQueryFactory
+				.selectFrom(nl)
+				.where(
+					nl.id.eq(id),
+					nl.user.id.eq(userId))
+				.fetchOne()
+		);
+	}
+
+	/**
+	 * 유저 ID와 읽음 여부로 최근 7일간의 알림 로그 조회 (notification JOIN FETCH) (v1 알림 제외)
+	 */
+	public List<NotificationLog> findRecentNotifications(String userId, boolean isRead, LocalDateTime sevenDaysAgo) {
+		QNotificationLog nl = QNotificationLog.notificationLog;
+		QNotification n = QNotification.notification;
+
+		return jpaQueryFactory
+			.selectFrom(nl)
+			.join(nl.notification, n).fetchJoin()
+			.where(
+				nl.user.id.eq(userId),
+				nl.isRead.eq(isRead),
+				nl.createdAt.goe(sevenDaysAgo),
+				n.noticeType.notIn(NoticeType.V1_TYPES))
+			.orderBy(nl.createdAt.desc())
+			.fetch();
+	}
+
+	/**
+	 * 유저 ID로 읽지 않은 V2 알림 로그 조회 (페이징)  (v1 알림 제외)
+	 */
+	public List<NotificationLog> findByUserIdAndIsReadFalse(String userId, Pageable pageable) {
+		QNotificationLog nl = QNotificationLog.notificationLog;
+		QNotification n = QNotification.notification;
+
+		return jpaQueryFactory
+			.selectFrom(nl)
+			.join(nl.notification, n)
+			.where(
+				nl.user.id.eq(userId),
+				nl.isRead.isFalse(),
+				n.noticeType.notIn(NoticeType.V1_TYPES))
+			.orderBy(nl.createdAt.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+	}
+
+	/**
+	 * 유저 ID로 최근 7일간의 읽지 않은 알림 로그를 최대 N개까지 조회 (v1 알림 제외)
+	 */
+	public List<NotificationLog> findRecentUnreadLogsUpToLimit(String userId, LocalDateTime sevenDaysAgo,
+		Pageable pageable) {
+		QNotificationLog nl = QNotificationLog.notificationLog;
+		QNotification n = QNotification.notification;
+
+		return jpaQueryFactory
+			.selectFrom(nl)
+			.join(nl.notification, n)
+			.where(
+				nl.user.id.eq(userId),
+				nl.isRead.isFalse(),
+				nl.createdAt.goe(sevenDaysAgo),
+				n.noticeType.notIn(NoticeType.V1_TYPES))
+			.orderBy(nl.createdAt.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/repository/NotificationLogQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/repository/NotificationLogQueryRepository.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import net.causw.app.main.domain.notification.notification.entity.NotificationLog;
@@ -96,27 +95,5 @@ public class NotificationLogQueryRepository {
 
 		// npe 방지 위해 null 체크 후 0L 반환
 		return count != null ? count : 0L;
-	}
-
-	/**
-	 * 유저 ID로 최근 7일간의 읽지 않은 알림 로그를 최대 N개까지 조회 (v1 알림 제외)
-	 */
-	public List<NotificationLog> findRecentUnreadLogsUpToLimit(String userId, LocalDateTime sevenDaysAgo,
-		Pageable pageable) {
-		QNotificationLog notificationLog = QNotificationLog.notificationLog;
-		QNotification notification = QNotification.notification;
-
-		return jpaQueryFactory
-			.selectFrom(notificationLog)
-			.join(notificationLog.notification, notification).fetchJoin()
-			.where(
-				notificationLog.user.id.eq(userId),
-				notificationLog.isRead.isFalse(),
-				notificationLog.createdAt.goe(sevenDaysAgo),
-				notification.noticeType.notIn(NoticeType.V1_TYPES))
-			.orderBy(notificationLog.createdAt.desc())
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.fetch();
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/repository/NotificationLogQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/repository/NotificationLogQueryRepository.java
@@ -40,7 +40,8 @@ public class NotificationLogQueryRepository {
 	/**
 	 * 유저 ID와 읽음 여부로 최근 7일간의 알림 로그 조회 (notification JOIN FETCH) (v1 알림 제외)
 	 */
-	public List<NotificationLog> findNotificationLogByUserIdAndIsRead(String userId, boolean isRead, LocalDateTime sevenDaysAgo) {
+	public List<NotificationLog> findNotificationLogByUserIdAndIsRead(String userId, boolean isRead,
+		LocalDateTime sevenDaysAgo) {
 		QNotificationLog nl = QNotificationLog.notificationLog;
 		QNotification n = QNotification.notification;
 
@@ -72,8 +73,7 @@ public class NotificationLogQueryRepository {
 					nl.isRead.isFalse(),
 					n.noticeType.notIn(NoticeType.V1_TYPES))
 				.orderBy(nl.createdAt.desc())
-				.fetchFirst()
-		);
+				.fetchFirst());
 	}
 
 	/**
@@ -113,7 +113,7 @@ public class NotificationLogQueryRepository {
 				notificationLog.user.id.eq(userId),
 				notificationLog.isRead.isFalse(),
 				notificationLog.createdAt.goe(sevenDaysAgo),
-					notification.noticeType.notIn(NoticeType.V1_TYPES))
+				notification.noticeType.notIn(NoticeType.V1_TYPES))
 			.orderBy(notificationLog.createdAt.desc())
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/repository/NotificationLogQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/repository/NotificationLogQueryRepository.java
@@ -34,8 +34,7 @@ public class NotificationLogQueryRepository {
 				.where(
 					nl.id.eq(id),
 					nl.user.id.eq(userId))
-				.fetchOne()
-		);
+				.fetchOne());
 	}
 
 	/**

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/repository/NotificationLogRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/repository/NotificationLogRepository.java
@@ -18,17 +18,6 @@ public interface NotificationLogRepository extends JpaRepository<NotificationLog
 
 	@Query("SELECT nl FROM NotificationLog nl " +
 		"JOIN FETCH nl.notification n " +
-		"WHERE nl.user.id = :userId " +
-		"AND nl.isRead = :isRead " +
-		"AND nl.createdAt >= :sevenDaysAgo " +
-		"ORDER BY nl.createdAt DESC")
-	List<NotificationLog> findRecentNotifications(
-		@Param("userId") String userId,
-		@Param("isRead") boolean isRead,
-		@Param("sevenDaysAgo") LocalDateTime sevenDaysAgo);
-
-	@Query("SELECT nl FROM NotificationLog nl " +
-		"JOIN FETCH nl.notification n " +
 		"WHERE nl.user = :user " +
 		"AND n.noticeType IN :types " +
 		"ORDER BY nl.createdAt DESC")
@@ -44,28 +33,6 @@ public interface NotificationLogRepository extends JpaRepository<NotificationLog
 	List<NotificationLog> findByUserAndIsReadFalseNotificationTypes(@Param("user") User user,
 		@Param("types") List<NoticeType> types, Pageable pageable);
 
-	@Query("SELECT nl FROM NotificationLog nl " +
-		"WHERE nl.user.id = :userId " +
-		"AND nl.isRead = false " +
-		"ORDER BY nl.createdAt DESC")
-	List<NotificationLog> findByUserIdAndIsReadFalseNotification(@Param("userId") String userId, Pageable pageable);
-
 	Optional<NotificationLog> findByIdAndUser(String id, User user);
-
-	Optional<NotificationLog> findByIdAndUserId(String id, String userId);
-
-	@Query("SELECT nl FROM NotificationLog nl " +
-		"WHERE nl.user.id = :userId " +
-		"AND nl.isRead = false " +
-		"AND nl.createdAt >= :sevenDaysAgo")
-	List<NotificationLog> findRecentUnreadLogsUpToLimit(
-		@Param("userId") String userId,
-		@Param("sevenDaysAgo") LocalDateTime sevenDaysAgo,
-		Pageable pageable);
-
-	@Query("SELECT nl FROM NotificationLog nl " +
-		"WHERE nl.user = :user " +
-		"AND nl.isRead = false")
-	List<NotificationLog> findUnreadLogsUpToLimit(@Param("user") User user, Pageable pageable);
 
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/repository/NotificationLogRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/repository/NotificationLogRepository.java
@@ -1,6 +1,5 @@
 package net.causw.app.main.domain.notification.notification.repository;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/NotificationLogService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/NotificationLogService.java
@@ -52,16 +52,13 @@ public class NotificationLogService {
 	}
 
 	/**
-	 * 유저 ID로 최근 7일간의 읽지 않은 알림 로그를 최대 20개까지 조회하여 개수를 반환합니다.
+	 * 유저 ID로 최근 7일간의 읽지 않은 알림 개수를 반환합니다. (최대 MAX_NOTIFICATION_COUNT)
 	 * @param userId 유저 ID
-	 * @return 읽지 않은 알림 로그 개수, 최대 10개까지 카운팅하여 반환 (20개 이상인 경우 20으로 반환)
+	 * @return 읽지 않은 알림 개수 (최대 MAX_NOTIFICATION_COUNT)
 	 */
 	@Transactional(readOnly = true)
 	public NotificationCountResult getNotificationLogCount(String userId) {
-		List<NotificationLog> unreadNotificationLogs = notificationLogReader.findUnreadUpToLimit(userId,
-			LocalDateTime.now());
-
-		return new NotificationCountResult(unreadNotificationLogs.size());
+		return new NotificationCountResult(notificationLogReader.countUnreadUpToLimit(userId, LocalDateTime.now()));
 	}
 
 	/**

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/implementation/NotificationLogReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/implementation/NotificationLogReader.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 import org.springframework.stereotype.Component;
 
 import net.causw.app.main.domain.notification.notification.entity.NotificationLog;
-import net.causw.app.main.domain.notification.notification.repository.NotificationLogRepository;
+import net.causw.app.main.domain.notification.notification.repository.NotificationLogQueryRepository;
 import net.causw.app.main.shared.pageable.PageableFactory;
 import net.causw.global.constant.StaticValue;
 
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class NotificationLogReader {
-	private final NotificationLogRepository notificationLogRepository;
+	private final NotificationLogQueryRepository notificationLogQueryRepository;
 	private final PageableFactory pageableFactory;
 
 	/**
@@ -26,11 +26,11 @@ public class NotificationLogReader {
 	 * @return 알림 로그 Optional
 	 */
 	public Optional<NotificationLog> findByIdAndUserId(String id, String userId) {
-		return notificationLogRepository.findByIdAndUserId(id, userId);
+		return notificationLogQueryRepository.findByIdAndUserId(id, userId);
 	}
 
 	/**
-	 * 유저 ID와 읽음 여부로 최근 7일간의 알림 로그 조회
+	 * 유저 ID와 읽음 여부로 최근 7일간의 알림 로그 조회 (V1 타입 제외)
 	 * @param userId 유저 ID
 	 * @param isRead 읽음 여부
 	 * @param currentTime 현재 시간
@@ -39,24 +39,23 @@ public class NotificationLogReader {
 	public List<NotificationLog> getNotificationList(String userId, boolean isRead, LocalDateTime currentTime) {
 		LocalDateTime sevenDaysAgo = currentTime.minusDays(7);
 
-		return notificationLogRepository.findRecentNotifications(userId, isRead, sevenDaysAgo);
+		return notificationLogQueryRepository.findRecentNotifications(userId, isRead, sevenDaysAgo);
 	}
 
 	/**
-	 * 유저 ID로 가장 최근의 읽지 않은 알림 로그 조회
+	 * 유저 ID로 가장 최근의 읽지 않은 알림 로그 조회 (V1 타입제외)
 	 * @param userId 유저 ID
 	 * @return 알림 로그 Optional
 	 */
 	public Optional<NotificationLog> getLatestUnread(String userId) {
-
-		List<NotificationLog> notificationLog = notificationLogRepository.findByUserIdAndIsReadFalseNotification(
+		List<NotificationLog> notificationLog = notificationLogQueryRepository.findByUserIdAndIsReadFalse(
 			userId, pageableFactory.create(0, StaticValue.HOME_NOTIFICATION_PAGE_SIZE));
 
 		return notificationLog.stream().findFirst();
 	}
 
 	/**
-	 * 유저 ID로 최근 7일간의 읽지 않은 알림 로그를 최대 20개까지 조회
+	 * 유저 ID로 최근 7일간의 읽지 않은 알림 로그를 최대 20개까지 조회 (V1 타입제외)
 	 * @param userId 유저 ID
 	 * @param currentTime 현재 시간
 	 * @return 알림 로그 리스트
@@ -64,7 +63,7 @@ public class NotificationLogReader {
 	public List<NotificationLog> findUnreadUpToLimit(String userId, LocalDateTime currentTime) {
 		LocalDateTime sevenDaysAgo = currentTime.minusDays(7);
 
-		return notificationLogRepository.findRecentUnreadLogsUpToLimit(
+		return notificationLogQueryRepository.findRecentUnreadLogsUpToLimit(
 			userId, sevenDaysAgo, pageableFactory.create(0, StaticValue.MAX_NOTIFICATION_COUNT));
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/implementation/NotificationLogReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/implementation/NotificationLogReader.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Component;
 
 import net.causw.app.main.domain.notification.notification.entity.NotificationLog;
 import net.causw.app.main.domain.notification.notification.repository.NotificationLogQueryRepository;
-import net.causw.app.main.shared.pageable.PageableFactory;
 import net.causw.global.constant.StaticValue;
 
 import lombok.RequiredArgsConstructor;
@@ -17,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class NotificationLogReader {
 	private final NotificationLogQueryRepository notificationLogQueryRepository;
-	private final PageableFactory pageableFactory;
 
 	/**
 	 * 알림 로그 ID와 유저 ID로 알림 로그 조회
@@ -26,7 +24,7 @@ public class NotificationLogReader {
 	 * @return 알림 로그 Optional
 	 */
 	public Optional<NotificationLog> findByIdAndUserId(String id, String userId) {
-		return notificationLogQueryRepository.findByIdAndUserId(id, userId);
+		return notificationLogQueryRepository.findNotificationLogByIdAndUserId(id, userId);
 	}
 
 	/**
@@ -39,31 +37,28 @@ public class NotificationLogReader {
 	public List<NotificationLog> getNotificationList(String userId, boolean isRead, LocalDateTime currentTime) {
 		LocalDateTime sevenDaysAgo = currentTime.minusDays(7);
 
-		return notificationLogQueryRepository.findRecentNotifications(userId, isRead, sevenDaysAgo);
+		return notificationLogQueryRepository.findNotificationLogByUserIdAndIsRead(userId, isRead, sevenDaysAgo);
 	}
 
 	/**
-	 * 유저 ID로 가장 최근의 읽지 않은 알림 로그 조회 (V1 타입제외)
+	 * 유저 ID로 가장 최근의 읽지 않은 알림 로그 조회 (V1 타입 제외)
 	 * @param userId 유저 ID
 	 * @return 알림 로그 Optional
 	 */
 	public Optional<NotificationLog> getLatestUnread(String userId) {
-		List<NotificationLog> notificationLog = notificationLogQueryRepository.findByUserIdAndIsReadFalse(
-			userId, pageableFactory.create(0, StaticValue.HOME_NOTIFICATION_PAGE_SIZE));
-
-		return notificationLog.stream().findFirst();
+		return notificationLogQueryRepository.findLatestUnreadByUserId(userId);
 	}
 
 	/**
-	 * 유저 ID로 최근 7일간의 읽지 않은 알림 로그를 최대 20개까지 조회 (V1 타입제외)
+	 * 유저 ID로 최근 7일간의 읽지 않은 알림 개수를 카운트 (V1 타입 제외, MAX_NOTIFICATION_COUNT 한계 적용)
 	 * @param userId 유저 ID
 	 * @param currentTime 현재 시간
-	 * @return 알림 로그 리스트
+	 * @return 읽지 않은 알림 개수 (최대 MAX_NOTIFICATION_COUNT)
 	 */
-	public List<NotificationLog> findUnreadUpToLimit(String userId, LocalDateTime currentTime) {
+	public int countUnreadUpToLimit(String userId, LocalDateTime currentTime) {
 		LocalDateTime sevenDaysAgo = currentTime.minusDays(7);
+		long count = notificationLogQueryRepository.countRecentUnread(userId, sevenDaysAgo);
 
-		return notificationLogQueryRepository.findRecentUnreadLogsUpToLimit(
-			userId, sevenDaysAgo, pageableFactory.create(0, StaticValue.MAX_NOTIFICATION_COUNT));
+		return (int)Math.min(count, (long)StaticValue.MAX_NOTIFICATION_COUNT);
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/v1/NotificationLogV1Service.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/v1/NotificationLogV1Service.java
@@ -14,7 +14,6 @@ import net.causw.app.main.domain.notification.notification.api.v1.mapper.Notific
 import net.causw.app.main.domain.notification.notification.entity.NotificationLog;
 import net.causw.app.main.domain.notification.notification.enums.NoticeType;
 import net.causw.app.main.domain.notification.notification.repository.NotificationLogRepository;
-
 import net.causw.app.main.domain.user.account.entity.user.User;
 import net.causw.app.main.shared.pageable.PageableFactory;
 import net.causw.global.constant.MessageUtil;
@@ -89,8 +88,9 @@ public class NotificationLogV1Service {
 
 	@Transactional(readOnly = true)
 	public NotificationCountResponseDto getNotificationLogCount(User user) {
-		List<NotificationLog> unreadNotificationLogs = notificationLogRepository.findByUserAndIsReadFalseNotificationTypes(
-			user, NoticeType.V1_TYPES, pageableFactory.create(0, StaticValue.MAX_NOTIFICATION_COUNT));
+		List<NotificationLog> unreadNotificationLogs = notificationLogRepository
+			.findByUserAndIsReadFalseNotificationTypes(
+				user, NoticeType.V1_TYPES, pageableFactory.create(0, StaticValue.MAX_NOTIFICATION_COUNT));
 
 		return NotificationCountResponseDto.builder()
 			.notificationLogCount(unreadNotificationLogs.size())

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/v1/NotificationLogV1Service.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/v1/NotificationLogV1Service.java
@@ -14,6 +14,7 @@ import net.causw.app.main.domain.notification.notification.api.v1.mapper.Notific
 import net.causw.app.main.domain.notification.notification.entity.NotificationLog;
 import net.causw.app.main.domain.notification.notification.enums.NoticeType;
 import net.causw.app.main.domain.notification.notification.repository.NotificationLogRepository;
+
 import net.causw.app.main.domain.user.account.entity.user.User;
 import net.causw.app.main.shared.pageable.PageableFactory;
 import net.causw.global.constant.MessageUtil;
@@ -88,8 +89,8 @@ public class NotificationLogV1Service {
 
 	@Transactional(readOnly = true)
 	public NotificationCountResponseDto getNotificationLogCount(User user) {
-		List<NotificationLog> unreadNotificationLogs = notificationLogRepository.findUnreadLogsUpToLimit(user,
-			pageableFactory.create(0, StaticValue.MAX_NOTIFICATION_COUNT));
+		List<NotificationLog> unreadNotificationLogs = notificationLogRepository.findByUserAndIsReadFalseNotificationTypes(
+			user, NoticeType.V1_TYPES, pageableFactory.create(0, StaticValue.MAX_NOTIFICATION_COUNT));
 
 		return NotificationCountResponseDto.builder()
 			.notificationLogCount(unreadNotificationLogs.size())

--- a/app-main/src/test/java/net/causw/app/main/domain/notification/notification/service/NotificationLogServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/notification/notification/service/NotificationLogServiceTest.java
@@ -126,14 +126,9 @@ class NotificationLogServiceTest {
 		void givenUnreadLogs_whenGetNotificationLogCount_thenReturnsNotificationCountResult() {
 			// given
 			String userId = "user-uuid-123";
-			User user = ObjectFixtures.getCertifiedUser();
-			Notification notification = ObjectFixtures.getNotification(user);
-			List<NotificationLog> logs = List.of(
-				NotificationLog.of(user, notification),
-				NotificationLog.of(user, notification));
 
-			given(notificationLogReader.findUnreadUpToLimit(eq(userId), any(LocalDateTime.class)))
-				.willReturn(logs);
+			given(notificationLogReader.countUnreadUpToLimit(eq(userId), any(LocalDateTime.class)))
+				.willReturn(2);
 
 			// when
 			NotificationCountResult result = notificationLogService.getNotificationLogCount(userId);
@@ -142,7 +137,7 @@ class NotificationLogServiceTest {
 			assertThat(result).isNotNull();
 			assertThat(result.notificationLogCount()).isEqualTo(2);
 
-			then(notificationLogReader).should().findUnreadUpToLimit(eq(userId), any(LocalDateTime.class));
+			then(notificationLogReader).should().countUnreadUpToLimit(eq(userId), any(LocalDateTime.class));
 		}
 	}
 


### PR DESCRIPTION
### 🚩 관련사항
Close #1221


### 📢 전달사항
- 이제 v1 api 에서는 v1 알림만, v2 api에서는 v1 알림은 노출되지 않습니다.
- v1 로직을 삭제할때, v1 알림 타입도 삭제할 예정입니다.

### 📸 스크린샷
<img width="733" height="869" alt="image" src="https://github.com/user-attachments/assets/6f2ab2e7-1ed7-4b0a-9e55-1557389da834" />



### 📃 진행사항
- [x] v1 알림 쿼리 변경
- [x] v2 알림 쿼리 변경
- [x] 테스트

### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 