### PR TITLE
feat: 약관 조회 API 공개 접근 허용 및 ID 필드 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ monitoring/loki-data/
 monitoring/mysqld-exporter/.my.cnf
 
 /.claude
+.bkit

--- a/app-main/src/main/java/net/causw/app/main/core/security/WebSecurityConfig.java
+++ b/app-main/src/main/java/net/causw/app/main/core/security/WebSecurityConfig.java
@@ -38,7 +38,7 @@ import lombok.RequiredArgsConstructor;
 @EnableWebSecurity
 @EnableMethodSecurity
 @RequiredArgsConstructor
-public class 	WebSecurityConfig {
+public class WebSecurityConfig {
 
 	private final JwtTokenProvider jwtTokenProvider;
 	private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;

--- a/app-main/src/main/java/net/causw/app/main/core/security/WebSecurityConfig.java
+++ b/app-main/src/main/java/net/causw/app/main/core/security/WebSecurityConfig.java
@@ -73,8 +73,9 @@ public class WebSecurityConfig {
 				.requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
 				.requestMatchers("/api/v2/auth/logout").authenticated()
 				.requestMatchers("/api/v2/auth/**", "/oauth2/**", "/login/oauth2/**",
-					"/api/v2/users/check-nickname", "/api/v2/users/check-phone",
-					"/api/v2/terms")
+					"/api/v2/users/check-nickname", "/api/v2/users/check-phone")
+				.permitAll()
+				.requestMatchers(org.springframework.http.HttpMethod.GET, "/api/v2/terms")
 				.permitAll()
 				.requestMatchers("/api/v2/admin/**").hasRole("ADMIN")
 				.anyRequest().authenticated())

--- a/app-main/src/main/java/net/causw/app/main/core/security/WebSecurityConfig.java
+++ b/app-main/src/main/java/net/causw/app/main/core/security/WebSecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -37,7 +38,7 @@ import lombok.RequiredArgsConstructor;
 @EnableWebSecurity
 @EnableMethodSecurity
 @RequiredArgsConstructor
-public class WebSecurityConfig {
+public class 	WebSecurityConfig {
 
 	private final JwtTokenProvider jwtTokenProvider;
 	private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
@@ -75,7 +76,7 @@ public class WebSecurityConfig {
 				.requestMatchers("/api/v2/auth/**", "/oauth2/**", "/login/oauth2/**",
 					"/api/v2/users/check-nickname", "/api/v2/users/check-phone")
 				.permitAll()
-				.requestMatchers(org.springframework.http.HttpMethod.GET, "/api/v2/terms")
+				.requestMatchers(HttpMethod.GET, "/api/v2/terms")
 				.permitAll()
 				.requestMatchers("/api/v2/admin/**").hasRole("ADMIN")
 				.anyRequest().authenticated())

--- a/app-main/src/main/java/net/causw/app/main/core/security/WebSecurityConfig.java
+++ b/app-main/src/main/java/net/causw/app/main/core/security/WebSecurityConfig.java
@@ -73,7 +73,8 @@ public class WebSecurityConfig {
 				.requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
 				.requestMatchers("/api/v2/auth/logout").authenticated()
 				.requestMatchers("/api/v2/auth/**", "/oauth2/**", "/login/oauth2/**",
-					"/api/v2/users/check-nickname", "/api/v2/users/check-phone")
+					"/api/v2/users/check-nickname", "/api/v2/users/check-phone",
+					"/api/v2/terms")
 				.permitAll()
 				.requestMatchers("/api/v2/admin/**").hasRole("ADMIN")
 				.anyRequest().authenticated())

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/api/v2/dto/response/TermsResponseDto.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/api/v2/dto/response/TermsResponseDto.java
@@ -8,6 +8,7 @@ import net.causw.app.main.domain.user.terms.service.v2.dto.TermsInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record TermsResponseDto(
+	@Schema(description = "약관 ID") String id,
 	@Schema(description = "제목") String title,
 	@Schema(description = "약관 종류") TermsType type,
 	@Schema(description = "필수 동의 여부") boolean isRequired,
@@ -17,6 +18,7 @@ public record TermsResponseDto(
 
 	public static TermsResponseDto from(TermsInfo info) {
 		return new TermsResponseDto(
+			info.id(),
 			info.title(),
 			info.type(),
 			info.isRequired(),

--- a/app-main/src/main/java/net/causw/app/main/domain/user/terms/service/v2/dto/TermsInfo.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/terms/service/v2/dto/TermsInfo.java
@@ -6,6 +6,7 @@ import net.causw.app.main.domain.user.terms.entity.Terms;
 import net.causw.app.main.domain.user.terms.entity.TermsType;
 
 public record TermsInfo(
+	String id,
 	String title,
 	TermsType type,
 	boolean isRequired,
@@ -15,6 +16,7 @@ public record TermsInfo(
 
 	public static TermsInfo from(Terms terms) {
 		return new TermsInfo(
+			terms.getId(),
 			terms.getTitle(),
 			terms.getType(),
 			terms.isRequired(),

--- a/app-main/src/test/java/net/causw/app/main/infrastructure/security/WebSecurityConfigTest.java
+++ b/app-main/src/test/java/net/causw/app/main/infrastructure/security/WebSecurityConfigTest.java
@@ -240,5 +240,13 @@ public class WebSecurityConfigTest {
 			mockMvc.perform(MockMvcRequestBuilders.get("/api/v2/admin/test"))
 				.andExpect(status().isNotFound());
 		}
+
+		@Test
+		@WithAnonymousUser
+		@DisplayName("/api/v2/terms 경로는 인증 없이 접근 허용")
+		void shouldAllowV2TermsAccess_WhenAnonymous() throws Exception {
+			mockMvc.perform(MockMvcRequestBuilders.get("/api/v2/terms"))
+				.andExpect(status().isNotFound());
+		}
 	}
 }


### PR DESCRIPTION
### 🚩 관련사항
Closes #1232

### 📢 전달사항
신규 회원가입 플로우에서 가입 전 이용약관 조회가 필요한데, 기존 `GET /api/v2/terms` 엔드포인트는 인증된 유저만 접근 가능한 상태였습니다.

비인증 유저(가입 전 사용자)도 이용약관을 조회할 수 있도록 두 가지를 변경하였습니다.

1. `WebSecurityConfig` V2 필터 체인 `permitAll()` 목록에 `/api/v2/terms` 추가
2. `TermsResponseDto`에 약관 ID(`id`) 필드 추가 — 클라이언트가 특정 약관을 식별할 수 있도록 응답에 포함

집중해서 봐야 할 부분:
- `WebSecurityConfig.securityFilterChainV2()` 내 `permitAll()` requestMatchers 목록 변경
- `TermsResponseDto` record에 `id` 필드 및 `from()` 팩토리 메서드 매핑 추가
- `WebSecurityConfigTest.V2ApiSecurityTest` 내 신규 테스트 케이스 (`shouldAllowV2TermsAccess_WhenAnonymous`)

### 📸 스크린샷
N/A

### 📃 진행사항
- [x] `WebSecurityConfig` V2 필터 체인의 `permitAll()` 목록에 `GET /api/v2/terms` 추가
- [x] `TermsResponseDto`에 약관 `id` 필드 추가 및 `from()` 팩토리 메서드 매핑 반영
- [x] `WebSecurityConfigTest`에 비인증 사용자의 `/api/v2/terms` 접근 허용 테스트 추가

### ⚙️ 기타사항
