### PR TITLE
feat: 동문 수첩 프로필 리스트 조회 시 본인 프로필 제외 (#1234)

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/controller/UserInfoController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/controller/UserInfoController.java
@@ -95,12 +95,13 @@ public class UserInfoController {
 	 */
 	@GetMapping
 	@ResponseStatus(HttpStatus.OK)
-	@Operation(summary = "동문 수첩 프로필 리스트 조회 및 검색", description = "검색어 또는 필터를 포함해 동문 수첩 프로필 리스트를 조회합니다.")
+	@Operation(summary = "동문 수첩 프로필 리스트 조회 및 검색", description = "검색어 또는 필터를 포함해 동문 수첩 프로필 리스트를 조회합니다. (본인 프로필 제외)")
 	public ApiResponse<PageResponse<UserInfoSummaryResponse>> getUserInfoPage(
 		@ModelAttribute @Valid UserInfoListRequest request,
-		@RequestParam(name = "pageNum", required = false, defaultValue = "0") Integer pageNum) {
+		@RequestParam(name = "pageNum", required = false, defaultValue = "0") Integer pageNum,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		Page<UserInfoSummaryResult> result = userInfoService.getUserInfoPage(userInfoDtoMapper.toListCondition(request),
-			pageNum);
+			pageNum, userDetails.getUserId());
 		Page<UserInfoSummaryResponse> response = result.map(userInfoDtoMapper::toSummaryResponse);
 		return ApiResponse.success(PageResponse.from(response));
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/userInfo/UserInfoQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/userInfo/UserInfoQueryRepository.java
@@ -33,13 +33,13 @@ public class UserInfoQueryRepository {
 
 	private final JPAQueryFactory jpaQueryFactory;
 
-	public Page<UserInfo> findAllWithFilter(UserInfoListCondition filter, Pageable pageable) {
+	public Page<UserInfo> findAllWithFilter(UserInfoListCondition filter, Pageable pageable, String excludeUserId) {
 		QUserInfo userInfo = QUserInfo.userInfo;
 		QUser user = QUser.user;
 		QUserProfileImage userProfileImage = QUserProfileImage.userProfileImage;
 		QUuidFile uuidFile = QUuidFile.uuidFile;
 
-		BooleanExpression condition = baseCondition(filter, userInfo);
+		BooleanExpression condition = baseCondition(filter, userInfo, excludeUserId);
 
 		List<UserInfo> content = jpaQueryFactory
 			.selectFrom(userInfo)
@@ -61,8 +61,13 @@ public class UserInfoQueryRepository {
 		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
 	}
 
-	private BooleanExpression baseCondition(UserInfoListCondition filter, QUserInfo userInfo) {
+	private BooleanExpression baseCondition(UserInfoListCondition filter, QUserInfo userInfo, String excludeUserId) {
 		BooleanExpression condition = Expressions.TRUE.isTrue();
+
+		// 본인 프로필 제외
+		if (excludeUserId != null) {
+			condition = condition.and(userInfo.user.id.ne(excludeUserId));
+		}
 		List<String> academicStatusList = filter.academicStatus();
 		Integer admissionYearStart = filter.admissionYearStart();
 		Integer admissionYearEnd = filter.admissionYearEnd();

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserInfoService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserInfoService.java
@@ -92,10 +92,12 @@ public class UserInfoService {
 	 * @return 동문 수첩 프로필 리스트
 	 */
 	@Transactional(readOnly = true)
-	public Page<UserInfoSummaryResult> getUserInfoPage(UserInfoListCondition condition, Integer pageNum,
-		String userId) {
+	public Page<UserInfoSummaryResult> getUserInfoPage(
+		UserInfoListCondition condition,
+		Integer pageNum,
+		String excludeUserId) {
 		Pageable pageable = pageableFactory.create(pageNum, StaticValue.USER_LIST_PAGE_SIZE);
-		Page<UserInfo> userInfos = userInfoReader.findUserInfoWithFilter(condition, pageable, userId);
+		Page<UserInfo> userInfos = userInfoReader.findUserInfoWithFilter(condition, pageable, excludeUserId);
 
 		return userInfos.map(userInfoMapper::toSummaryResult);
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserInfoService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserInfoService.java
@@ -92,9 +92,10 @@ public class UserInfoService {
 	 * @return 동문 수첩 프로필 리스트
 	 */
 	@Transactional(readOnly = true)
-	public Page<UserInfoSummaryResult> getUserInfoPage(UserInfoListCondition condition, Integer pageNum) {
+	public Page<UserInfoSummaryResult> getUserInfoPage(UserInfoListCondition condition, Integer pageNum,
+		String userId) {
 		Pageable pageable = pageableFactory.create(pageNum, StaticValue.USER_LIST_PAGE_SIZE);
-		Page<UserInfo> userInfos = userInfoReader.findUserInfoWithFilter(condition, pageable);
+		Page<UserInfo> userInfos = userInfoReader.findUserInfoWithFilter(condition, pageable, userId);
 
 		return userInfos.map(userInfoMapper::toSummaryResult);
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/implementation/UserInfoReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/implementation/UserInfoReader.java
@@ -40,8 +40,9 @@ public class UserInfoReader {
 	 * @param pageable 페이징 정보
 	 * @return 동문 수첩 프로필 페이지
 	 */
-	public Page<UserInfo> findUserInfoWithFilter(UserInfoListCondition condition, Pageable pageable) {
-		return userInfoQueryRepository.findAllWithFilter(condition, pageable);
+	public Page<UserInfo> findUserInfoWithFilter(UserInfoListCondition condition, Pageable pageable,
+		String excludeUserId) {
+		return userInfoQueryRepository.findAllWithFilter(condition, pageable, excludeUserId);
 	}
 
 	/**

--- a/app-main/src/test/java/net/causw/app/main/domain/user/account/service/UserInfoServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/user/account/service/UserInfoServiceTest.java
@@ -256,6 +256,7 @@ class UserInfoServiceTest {
 			// given
 			UserInfoListCondition condition = ObjectFixtures.getMockUserInfoListCondition();
 			Integer pageNum = 1;
+			String userId = "test-user-id";
 
 			Pageable pageable = ObjectFixtures.getMockPageable();
 			when(pageableFactory.create(pageNum, StaticValue.USER_LIST_PAGE_SIZE)).thenReturn(pageable);
@@ -267,18 +268,18 @@ class UserInfoServiceTest {
 			UserInfoSummaryResult s1 = ObjectFixtures.getMockUserInfoSummaryResult();
 			UserInfoSummaryResult s2 = ObjectFixtures.getMockUserInfoSummaryResult();
 
-			when(userInfoReader.findUserInfoWithFilter(condition, pageable)).thenReturn(page);
+			when(userInfoReader.findUserInfoWithFilter(condition, pageable, userId)).thenReturn(page);
 			when(userInfoMapper.toSummaryResult(u1)).thenReturn(s1);
 			when(userInfoMapper.toSummaryResult(u2)).thenReturn(s2);
 
 			// when
-			Page<UserInfoSummaryResult> result = userInfoService.getUserInfoPage(condition, pageNum);
+			Page<UserInfoSummaryResult> result = userInfoService.getUserInfoPage(condition, pageNum, userId);
 
 			// then
 			assertThat(result.getContent()).containsExactly(s1, s2);
 
 			verify(pageableFactory).create(pageNum, StaticValue.USER_LIST_PAGE_SIZE);
-			verify(userInfoReader).findUserInfoWithFilter(condition, pageable);
+			verify(userInfoReader).findUserInfoWithFilter(condition, pageable, userId);
 			verify(userInfoMapper).toSummaryResult(u1);
 			verify(userInfoMapper).toSummaryResult(u2);
 		}


### PR DESCRIPTION
### 🚩 관련사항
#1234

### 📢 전달사항
동문 수첩 프로필 리스트 조회 시, 본인의 프로필이 목록에 포함되지 않도록합니다.

**변경 내용**
- `UserInfoController` - 기존 파라미터에 `@AuthenticationPrincipal CustomUserDetails userDetails`를 추가하고, 서비스 호출 시 `userDetails.getUserId()`를 함께 전달합니다.
- `UserInfoService` - `getUserInfoPage()` 시그니처에 `String userId` 파라미터를 추가하고, Reader로 전달합니다.
- `UserInfoReader` - `findUserInfoWithFilter()` 시그니처에 `String excludeUserId`를 추가하고, QueryRepository로 전달합니다.
- `UserInfoQueryRepository` - `baseCondition()`에 `userInfo.user.id.ne(excludeUserId)` 조건을 추가해 본인 프로필을 QueryDSL 쿼리 레벨에서 필터링합니다. `excludeUserId`가 `null`이면 조건을 적용하지 않아 안전합니다.
- `UserInfoServiceTest` - 변경된 시그니처에 맞춰 테스트 mock 및 verify를 수정합니다.

**집중해서 봐야 할 부분**
- `UserInfoQueryRepository.baseCondition()`의 `ne(excludeUserId)` 조건 추가 위치 — 기존 조건들보다 앞에 위치하며 `null` 가드가 적용되어 있습니다.
- Controller에서 `@AuthenticationPrincipal` 주입 방식이 기존 엔드포인트들과 일관성을 가지는지 확인이 필요합니다.

### 📸 스크린샷
N/A

### 📃 진행사항
- [x] 동문 수첩 프로필 리스트 조회 시 본인 프로필 제외 기능 구현 (Controller → Service → Reader → QueryRepository 레이어 전체 반영)
- [x] UserInfoServiceTest 수정 (변경된 시그니처 반영)

### ⚙️ 기타사항

개발기간: 2026-04-13 ~ 2026-04-13
