### PR TITLE
feat: 내 정보 조회 API 응답 필드 추가 및 온보딩 상태 로직 개선 (#1239)

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/dto/response/UserMeResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/dto/response/UserMeResponse.java
@@ -1,5 +1,7 @@
 package net.causw.app.main.domain.user.account.api.v2.dto.response;
 
+import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.AcademicStatus;
+import net.causw.app.main.domain.user.auth.enums.OnboardingStatus;
 import net.causw.app.main.shared.dto.ProfileImageDto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -17,5 +19,9 @@ public record UserMeResponse(
 
 	@Schema(description = "입학년도", example = "2020") Integer admissionYear,
 
-	@Schema(description = "직업", example = "개발자", nullable = true) String job) {
+	@Schema(description = "직업", example = "개발자", nullable = true) String job,
+
+	@Schema(description = "온보딩 플로우 분기 상태", example = "ACTIVE") OnboardingStatus onboardingStatus,
+
+	@Schema(description = "현재 학적 상태", example = "ENROLLED") AcademicStatus academicStatus) {
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/dto/result/UserMeResult.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/dto/result/UserMeResult.java
@@ -1,7 +1,9 @@
 package net.causw.app.main.domain.user.account.service.dto.result;
 
+import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.AcademicStatus;
 import net.causw.app.main.domain.user.account.entity.user.User;
 import net.causw.app.main.domain.user.account.entity.userInfo.UserInfo;
+import net.causw.app.main.domain.user.auth.enums.OnboardingStatus;
 import net.causw.app.main.shared.dto.ProfileImageDto;
 
 public record UserMeResult(
@@ -10,7 +12,9 @@ public record UserMeResult(
 	String nickname,
 	ProfileImageDto profileImage,
 	Integer admissionYear,
-	String job) {
+	String job,
+	OnboardingStatus onboardingStatus,
+	AcademicStatus academicStatus) {
 
 	public static UserMeResult from(User user, UserInfo userInfo) {
 		return new UserMeResult(
@@ -19,6 +23,8 @@ public record UserMeResult(
 			user.getNickname(),
 			ProfileImageDto.from(user),
 			user.getAdmissionYear(),
-			userInfo != null ? userInfo.getJob() : null);
+			userInfo != null ? userInfo.getJob() : null,
+			OnboardingStatus.resolve(user.isGuest(), user.isTermsAgreed(), user.isAcademicCertified()),
+			user.getAcademicStatus());
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/auth/api/v2/dto/AuthDtoMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/auth/api/v2/dto/AuthDtoMapper.java
@@ -4,7 +4,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 import net.causw.app.main.domain.user.auth.api.v2.dto.response.AuthResponse;
-import net.causw.app.main.domain.user.auth.api.v2.dto.response.OnboardingStatus;
+import net.causw.app.main.domain.user.auth.enums.OnboardingStatus;
 import net.causw.app.main.domain.user.auth.service.dto.AuthResult;
 
 @Mapper(componentModel = "spring")
@@ -15,15 +15,6 @@ public interface AuthDtoMapper {
 
 	default OnboardingStatus resolveOnboardingStatus(boolean isGuest, boolean isTermsAgreed,
 		boolean isAcademicCertified) {
-		if (isGuest) {
-			return OnboardingStatus.GUEST;
-		}
-		if (!isAcademicCertified) {
-			return OnboardingStatus.ACADEMIC_CERTIFICATION_REQUIRED;
-		}
-		if (!isTermsAgreed) {
-			return OnboardingStatus.TERMS_REQUIRED;
-		}
-		return OnboardingStatus.ACTIVE;
+		return OnboardingStatus.resolve(isGuest, isTermsAgreed, isAcademicCertified);
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/auth/api/v2/dto/response/AuthResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/auth/api/v2/dto/response/AuthResponse.java
@@ -1,6 +1,7 @@
 package net.causw.app.main.domain.user.auth.api.v2.dto.response;
 
 import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.AcademicStatus;
+import net.causw.app.main.domain.user.auth.enums.OnboardingStatus;
 import net.causw.app.main.shared.dto.ProfileImageDto;
 
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/app-main/src/main/java/net/causw/app/main/domain/user/auth/enums/OnboardingStatus.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/auth/enums/OnboardingStatus.java
@@ -1,4 +1,4 @@
-package net.causw.app.main.domain.user.auth.api.v2.dto.response;
+package net.causw.app.main.domain.user.auth.enums;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -14,5 +14,18 @@ public enum OnboardingStatus {
 	ACADEMIC_CERTIFICATION_REQUIRED,
 
 	@Schema(description = "온보딩 완료")
-	ACTIVE
+	ACTIVE;
+
+	public static OnboardingStatus resolve(boolean isGuest, boolean isTermsAgreed, boolean isAcademicCertified) {
+		if (isGuest) {
+			return GUEST;
+		}
+		if (!isAcademicCertified) {
+			return ACADEMIC_CERTIFICATION_REQUIRED;
+		}
+		if (!isTermsAgreed) {
+			return TERMS_REQUIRED;
+		}
+		return ACTIVE;
+	}
 }


### PR DESCRIPTION
### 🚩 관련사항
Close #1239

### 📢 전달사항
`GET /api/v2/users/me` 응답 DTO인 `UserMeResponse`에 `onboardingStatus`와 `academicStatus` 필드를 추가합니다.

기존에는 로그인 응답(`AuthResponse`)에서만 두 값을 내려줬는데, 앱 진입 후 내 정보 화면에서도 온보딩 플로우 분기와 학적 상태 분기가 필요해 `GET /api/v2/users/me`에서도 반환하도록 변경했습니다.

**핵심 변경 포인트**

1. **`OnboardingStatus` 이동** (`auth/api/v2/dto/response` → `auth/enums`)
   - 기존에 API 표현 계층 패키지에 위치해 있어, 서비스 계층 DTO가 이를 직접 참조할 수 없는 계층 의존 역전 문제가 있었습니다.
   - `domain.user.auth.enums` 패키지로 이동해 서비스·API 계층 모두에서 참조 가능하도록 정리했습니다.
   - `AcademicStatus`가 `domain.user.academic.enums`에 있는 것과 동일한 패턴입니다.

2. **`OnboardingStatus.resolve()` 정적 메서드 추출**
   - 기존 `AuthDtoMapper`의 `default resolveOnboardingStatus()` 로직을 `OnboardingStatus` enum의 정적 메서드로 추출했습니다.
   - `AuthDtoMapper`는 해당 메서드에 위임하고, `UserMeResult.from()`에서도 동일 메서드를 재사용해 중복을 제거했습니다.

3. **`UserMeResult` / `UserMeResponse` 필드 추가**
   - `UserMeResult`(서비스 계층 DTO): `onboardingStatus`, `academicStatus` 필드 추가. `from(User, UserInfo)`에서 값 세팅.
   - `UserMeResponse`(API 계층 DTO): 동일 필드 추가 및 Swagger `@Schema` 어노테이션 반영.
   - `UserMeMapper`(MapStruct)는 동일 필드명 자동 매핑으로 별도 수정 없이 처리됩니다.

### 📸 스크린샷
<img width="1415" height="959" alt="image" src="https://github.com/user-attachments/assets/cfbc0bfe-11da-4562-9873-1820b3ff4b52" />


### 📃 진행사항
- [x] `OnboardingStatus` enum을 `auth/api/v2/dto/response`에서 `auth/enums`로 이동
- [x] `OnboardingStatus.resolve(isGuest, isTermsAgreed, isAcademicCertified)` 정적 메서드 추출
- [x] `AuthDtoMapper.resolveOnboardingStatus()` → `OnboardingStatus.resolve()` 위임으로 변경
- [x] `UserMeResult`에 `onboardingStatus(OnboardingStatus)`, `academicStatus(AcademicStatus)` 필드 추가
- [x] `UserMeResult.from(User, UserInfo)`에서 두 필드 값 세팅
- [x] `UserMeResponse`에 두 필드 추가 및 Swagger 스펙 반영

### ⚙️ 기타사항

개발기간: 2026-04-14 ~ 2026-04-14
