### PR TITLE
infra: 테스트 실패시 report comment 제대로 발생하지 않는 이슈

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -137,6 +137,7 @@ jobs:
       # 테스트 결과 아티팩트 업로드
       - name: Upload test results
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: app-main-test-results
           path: ./app-main/build/test-results/test

--- a/app-main/src/test/java/net/causw/app/main/domain/user/auth/service/v2/AuthServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/user/auth/service/v2/AuthServiceTest.java
@@ -124,12 +124,6 @@ public class AuthServiceTest {
 	class RegisterEmailUserTest {
 
 		@Test
-		@DisplayName("CI 테스트 실패 리포트 확인용")
-		void ci_test_failure() {
-			assertThat(1).isEqualTo(2);
-		}
-
-		@Test
 		@DisplayName("성공: 모든 검증을 통과하면 사용자가 저장되고 응답을 반환한다.")
 		void success() {
 			// given

--- a/app-main/src/test/java/net/causw/app/main/domain/user/auth/service/v2/AuthServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/user/auth/service/v2/AuthServiceTest.java
@@ -124,6 +124,12 @@ public class AuthServiceTest {
 	class RegisterEmailUserTest {
 
 		@Test
+		@DisplayName("CI 테스트 실패 리포트 확인용")
+		void ci_test_failure() {
+			assertThat(1).isEqualTo(2);
+		}
+
+		@Test
 		@DisplayName("성공: 모든 검증을 통과하면 사용자가 저장되고 응답을 반환한다.")
 		void success() {
 			// given


### PR DESCRIPTION
### 🚩 관련사항
#1110 


### 📢 전달사항
**[버그 및 원인]**

CI 과정에서 JUnit 테스트가 실패했을 때, PR 코멘트(Test Results Summary)에 실패 내역이 뜨지 않고 0 tests로 잘못 표기되는 이슈가 있었습니다.

원인을 파악해 보니, GitHub Actions의 기본 동작 원리상 앞선 테스트 스텝이 실패(fail)하면 다음 스텝인 Upload test results가 통째로 스킵(Skip)되어 리포트를 생성할 결과 파일(XML)이 업로드되지 않는 것이 문제였습니다.

**[해결 방법]**

테스트 결과 아티팩트 업로드 스텝에 if: always() 조건을 추가했습니다.

이제 테스트 성공/실패 여부와 관계없이 항상 결과 파일이 업로드되며, 최종 코멘트 봇이 실패한 테스트의 상세 내역을 정상적으로 읽어와 리포팅합니다.


### 📸 스크린샷
<img width="423" height="277" alt="image" src="https://github.com/user-attachments/assets/7edfa9ab-51e1-41d1-a5b7-6faee6c01d1f" />

테스트 실패시 Test Results Summary가 잘못된 값을 발생시킴

<img width="349" height="520" alt="image" src="https://github.com/user-attachments/assets/df3a6489-3dc2-4989-bea2-8740ee6dddea" />

CI 과정에서 테스트 실패시 'Upload test results' 부분을 스킵하는 것을 확인

<img width="498" height="360" alt="image" src="https://github.com/user-attachments/assets/ffd30e5f-ad44-4d73-ae2d-7d5ccddff369" />

해결


### 📃 진행사항
- [x] 테스트 실패 시 리포트 누락 버그 원인 파악
- [x] Upload test results 스텝에 if: always() 조건 추가
- [x] 의도적 테스트 실패를 통한 CI 리포트 정상 동작(실패 카운트 및 에러 로그 표기) 테스트 완료

### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 1h