### PR TITLE
feat: swagger 접근 시 spring security FormLogin 인증 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,5 @@ monitoring/mysqld-exporter/.my.cnf
 
 /.claude
 .bkit
+
+CLAUDE.md

--- a/app-main/src/main/java/net/causw/app/main/CauswApplication.java
+++ b/app-main/src/main/java/net/causw/app/main/CauswApplication.java
@@ -1,30 +1,66 @@
 package net.causw.app.main;
 
+import java.util.Arrays;
 import java.util.TimeZone;
 
+import org.springframework.boot.Banner;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.SpringBootVersion;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.env.Environment;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.servers.Server;
 import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
+@RequiredArgsConstructor
 @OpenAPIDefinition(servers = {
 	@Server(url = "/", description = "Default Server URL")
 })
 @SpringBootApplication
 public class CauswApplication {
 
+	private final Environment environment;
+
 	static {
 		System.setProperty("com.amazonaws.sdk.disableEc2Metadata", "true");
 	}
 
 	public static void main(String[] args) {
-		SpringApplication.run(CauswApplication.class, args);
+		SpringApplication app = new SpringApplication(CauswApplication.class);
+		app.setBannerMode(Banner.Mode.OFF);
+		app.run(args);
 	}
 
 	@PostConstruct
 	public void init() {
 		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
+
+	@EventListener(ApplicationReadyEvent.class)
+	@Order(2)
+	public void onApplicationReady() {
+		String profiles = String.join(", ", Arrays.asList(environment.getActiveProfiles()));
+		if (profiles.isBlank()) {
+			profiles = "default";
+		}
+
+		log.info("\n"
+			+ "   ██████╗  █████╗ ██╗   ██╗███████╗██╗    ██╗\n"
+			+ "  ██╔════╝ ██╔══██╗██║   ██║██╔════╝██║    ██║\n"
+			+ "  ██║      ███████║██║   ██║███████╗██║ █╗ ██║\n"
+			+ "  ██║      ██╔══██║██║   ██║╚════██║██║███╗██║\n"
+			+ "  ╚██████╗ ██║  ██║╚██████╔╝███████║╚███╔███╔╝\n"
+			+ "   ╚═════╝ ╚═╝  ╚═╝ ╚═════╝ ╚══════╝ ╚══╝╚══╝\n"
+			+ "  :: CAU Student Web Application ::");
+		log.info("Spring Boot    : {}", SpringBootVersion.getVersion());
+		log.info("Java Version   : {}", System.getProperty("java.version"));
+		log.info("Active Profile : {}", profiles);
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/core/datasourceProxy/ApiQueryLoggingAspect.java
+++ b/app-main/src/main/java/net/causw/app/main/core/datasourceProxy/ApiQueryLoggingAspect.java
@@ -36,6 +36,10 @@ public class ApiQueryLoggingAspect {
 			path = request.getRequestURI();
 		}
 
+		if (!path.startsWith("/api/v1") && !path.startsWith("/api/v2")) {
+			return joinPoint.proceed();
+		}
+
 		try {
 			Object result = joinPoint.proceed();
 			return result;

--- a/app-main/src/main/java/net/causw/app/main/core/filter/RequestLoggingFilter.java
+++ b/app-main/src/main/java/net/causw/app/main/core/filter/RequestLoggingFilter.java
@@ -24,7 +24,7 @@ import lombok.extern.slf4j.Slf4j;
  * - traceId   : 요청 추적용 고유 ID (타임스탬프 + 요청 순번 조합)
  * - path      : 요청 URI
  * - httpMethod: HTTP 메서드 (GET, POST, ...)
- * - remoteIP  : 클라이언트 IP (X-Forwarded-For 우선)
+ * - remoteIP  : 클라이언트 IP (ForwardedHeaderFilter가 X-Forwarded-For 처리 후 getRemoteAddr()에 반영)
  * - userId    : 인증된 사용자 이름 (미인증 시 미설정)
  * - status    : HTTP 응답 코드
  * - duration  : 처리 시간 (ms)
@@ -108,14 +108,10 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
 
 	/**
 	 * 실제 클라이언트 IP를 반환한다.
-	 * 로드밸런서/리버스 프록시 환경에서는 X-Forwarded-For 헤더에 원본 IP가 담기므로 우선 확인한다.
-	 * 헤더에 여러 IP가 콤마로 나열된 경우 가장 앞에 있는 값이 최초 클라이언트 IP다.
+	 * ForwardedHeaderFilter(framework 전략)가 X-Forwarded-For를 처리한 뒤 헤더를 제거하고
+	 * getRemoteAddr()에 원본 클라이언트 IP를 반영하므로 직접 참조한다.
 	 */
 	private String getClientIp(HttpServletRequest request) {
-		String forwarded = request.getHeader("X-Forwarded-For");
-		if (forwarded != null && !forwarded.isBlank()) {
-			return forwarded.split(",")[0].trim();
-		}
 		return request.getRemoteAddr();
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/core/security/SwaggerSecurityConfig.java
+++ b/app-main/src/main/java/net/causw/app/main/core/security/SwaggerSecurityConfig.java
@@ -8,55 +8,96 @@ import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
-@Profile("!prod")
-@Configuration
-@EnableWebSecurity
 public class SwaggerSecurityConfig {
 
-	@Value("${swagger.username}")
-	private String swaggerUsername;
+	private static final String[] SWAGGER_PATHS = {
+		"/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**"
+	};
 
-	@Value("${swagger.password}")
-	private String swaggerPassword;
+	private static final String[] SWAGGER_LOGIN_PATHS = {
+		"/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**", "/login"
+	};
 
-	@Bean
-	@Order(0)
-	public SecurityFilterChain swaggerSecurityFilterChain(HttpSecurity http) throws Exception {
-		http
-			.securityMatcher("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**", "/login")
-			.csrf(AbstractHttpConfigurer::disable)
-			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/login").permitAll()
-				.anyRequest().authenticated())
-			.formLogin(form -> form
-				.defaultSuccessUrl("/swagger-ui/index.html", true))
-			.authenticationProvider(swaggerAuthenticationProvider());
+	/** prod: Swagger 경로 전면 차단 (403) */
+	@Profile("prod")
+	@Configuration
+	public static class ProdConfig {
 
-		return http.build();
+		@Bean
+		@Order(0)
+		public SecurityFilterChain swaggerSecurityFilterChain(HttpSecurity http) throws Exception {
+			http
+				.securityMatcher(SWAGGER_PATHS)
+				.csrf(AbstractHttpConfigurer::disable)
+				.authorizeHttpRequests(auth -> auth.anyRequest().denyAll());
+			return http.build();
+		}
 	}
 
-	/**
-	 * @Bean 어노테이션을 빼서 스프링 글로벌 컨텍스트에 등록하지 않습니다.
-	 * 이렇게 하면 기존 REST API의 DB 연동 UserDetailsService 등과 절대 충돌하지 않습니다.
-	 */
-	private AuthenticationProvider swaggerAuthenticationProvider() {
-		UserDetails user = User.withUsername(swaggerUsername)
-			.password("{noop}" + swaggerPassword)
-			.roles("ADMIN")
-			.build();
+	/** local: Swagger 경로 인증 없이 전면 허용 */
+	@Profile("local")
+	@Configuration
+	public static class LocalConfig {
 
-		InMemoryUserDetailsManager userDetailsService = new InMemoryUserDetailsManager(user);
+		@Bean
+		@Order(0)
+		public SecurityFilterChain swaggerSecurityFilterChain(HttpSecurity http) throws Exception {
+			http
+				.securityMatcher(SWAGGER_PATHS)
+				.csrf(AbstractHttpConfigurer::disable)
+				.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+			return http.build();
+		}
+	}
 
-		DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
-		provider.setUserDetailsService(userDetailsService);
+	/** prod·local 외(예: dev): 폼 로그인으로 Swagger 접근 제어 */
+	@Profile("!prod & !local")
+	@Configuration
+	public static class DefaultConfig {
 
-		return provider;
+		@Value("${swagger.username:admin}")
+		private String swaggerUsername;
+
+		@Value("${swagger.password:admin}")
+		private String swaggerPassword;
+
+		@Bean
+		@Order(0)
+		public SecurityFilterChain swaggerSecurityFilterChain(HttpSecurity http) throws Exception {
+			http
+				.securityMatcher(SWAGGER_LOGIN_PATHS)
+				.csrf(AbstractHttpConfigurer::disable)
+				.authorizeHttpRequests(auth -> auth
+					.requestMatchers("/login").permitAll()
+					.anyRequest().authenticated())
+				.formLogin(form -> form
+					.defaultSuccessUrl("/swagger-ui/index.html", true))
+				.authenticationProvider(swaggerAuthenticationProvider());
+			return http.build();
+		}
+
+		/**
+		 * @Bean 없이 직접 생성 — 글로벌 컨텍스트에 등록되지 않으므로
+		 * REST API의 DB 연동 UserDetailsService와 충돌하지 않는다.
+		 */
+		private AuthenticationProvider swaggerAuthenticationProvider() {
+			UserDetails user = User.withUsername(swaggerUsername)
+				.password("{noop}" + swaggerPassword)
+				.roles("ADMIN")
+				.build();
+
+			InMemoryUserDetailsManager userDetailsService = new InMemoryUserDetailsManager(user);
+
+			DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+			provider.setUserDetailsService(userDetailsService);
+
+			return provider;
+		}
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/core/security/SwaggerSecurityConfig.java
+++ b/app-main/src/main/java/net/causw/app/main/core/security/SwaggerSecurityConfig.java
@@ -20,45 +20,43 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 public class SwaggerSecurityConfig {
 
-    @Value("${swagger.username}")
-    private String swaggerUsername;
+	@Value("${swagger.username}")
+	private String swaggerUsername;
 
-    @Value("${swagger.password}")
-    private String swaggerPassword;
+	@Value("${swagger.password}")
+	private String swaggerPassword;
 
-    @Bean
-    @Order(0)
-    public SecurityFilterChain swaggerSecurityFilterChain(HttpSecurity http) throws Exception {
-        http
-                .securityMatcher("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**", "/login")
-                .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/login").permitAll()
-                        .anyRequest().authenticated()
-                )
-                .formLogin(form -> form
-                        .defaultSuccessUrl("/swagger-ui/index.html", true)
-                )
-                .authenticationProvider(swaggerAuthenticationProvider());
+	@Bean
+	@Order(0)
+	public SecurityFilterChain swaggerSecurityFilterChain(HttpSecurity http) throws Exception {
+		http
+			.securityMatcher("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**", "/login")
+			.csrf(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/login").permitAll()
+				.anyRequest().authenticated())
+			.formLogin(form -> form
+				.defaultSuccessUrl("/swagger-ui/index.html", true))
+			.authenticationProvider(swaggerAuthenticationProvider());
 
-        return http.build();
-    }
+		return http.build();
+	}
 
-    /**
-     * @Bean 어노테이션을 빼서 스프링 글로벌 컨텍스트에 등록하지 않습니다.
-     * 이렇게 하면 기존 REST API의 DB 연동 UserDetailsService 등과 절대 충돌하지 않습니다.
-     */
-    private AuthenticationProvider swaggerAuthenticationProvider() {
-        UserDetails user = User.withUsername(swaggerUsername)
-                .password("{noop}" + swaggerPassword)
-                .roles("ADMIN")
-                .build();
+	/**
+	 * @Bean 어노테이션을 빼서 스프링 글로벌 컨텍스트에 등록하지 않습니다.
+	 * 이렇게 하면 기존 REST API의 DB 연동 UserDetailsService 등과 절대 충돌하지 않습니다.
+	 */
+	private AuthenticationProvider swaggerAuthenticationProvider() {
+		UserDetails user = User.withUsername(swaggerUsername)
+			.password("{noop}" + swaggerPassword)
+			.roles("ADMIN")
+			.build();
 
-        InMemoryUserDetailsManager userDetailsService = new InMemoryUserDetailsManager(user);
+		InMemoryUserDetailsManager userDetailsService = new InMemoryUserDetailsManager(user);
 
-        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
-        provider.setUserDetailsService(userDetailsService);
+		DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+		provider.setUserDetailsService(userDetailsService);
 
-        return provider;
-    }
+		return provider;
+	}
 }

--- a/app-main/src/main/java/net/causw/app/main/core/security/SwaggerSecurityConfig.java
+++ b/app-main/src/main/java/net/causw/app/main/core/security/SwaggerSecurityConfig.java
@@ -1,0 +1,64 @@
+package net.causw.app.main.core.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Profile("!prod")
+@Configuration
+@EnableWebSecurity
+public class SwaggerSecurityConfig {
+
+    @Value("${swagger.username}")
+    private String swaggerUsername;
+
+    @Value("${swagger.password}")
+    private String swaggerPassword;
+
+    @Bean
+    @Order(0)
+    public SecurityFilterChain swaggerSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**", "/login")
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/login").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(form -> form
+                        .defaultSuccessUrl("/swagger-ui/index.html", true)
+                )
+                .authenticationProvider(swaggerAuthenticationProvider());
+
+        return http.build();
+    }
+
+    /**
+     * @Bean 어노테이션을 빼서 스프링 글로벌 컨텍스트에 등록하지 않습니다.
+     * 이렇게 하면 기존 REST API의 DB 연동 UserDetailsService 등과 절대 충돌하지 않습니다.
+     */
+    private AuthenticationProvider swaggerAuthenticationProvider() {
+        UserDetails user = User.withUsername(swaggerUsername)
+                .password("{noop}" + swaggerPassword)
+                .roles("ADMIN")
+                .build();
+
+        InMemoryUserDetailsManager userDetailsService = new InMemoryUserDetailsManager(user);
+
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userDetailsService);
+
+        return provider;
+    }
+}

--- a/app-main/src/main/java/net/causw/app/main/core/security/WebConfig.java
+++ b/app-main/src/main/java/net/causw/app/main/core/security/WebConfig.java
@@ -9,7 +9,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
-	private OctetStreamReadMsgConverter octetStreamReadMsgConverter;
+	private final OctetStreamReadMsgConverter octetStreamReadMsgConverter;
 
 	@Autowired
 	public WebConfig(OctetStreamReadMsgConverter octetStreamReadMsgConverter) {

--- a/app-main/src/main/java/net/causw/app/main/domain/campus/schedule/service/HolidayScheduleSyncService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/campus/schedule/service/HolidayScheduleSyncService.java
@@ -10,6 +10,7 @@ import java.util.Set;
 
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +36,7 @@ public class HolidayScheduleSyncService {
 	private final ScheduleWriter scheduleWriter;
 
 	@EventListener(ApplicationReadyEvent.class)
+	@Order(1)
 	@Transactional
 	public void syncOnApplicationReady() {
 		syncHolidays("application-ready");

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v1/controller/UserController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v1/controller/UserController.java
@@ -291,11 +291,6 @@ public class UserController {
 	}
 
 	private String extractClientIp(HttpServletRequest request) {
-		String xForwardedFor = request.getHeader("X-Forwarded-For");
-		if (xForwardedFor != null && !xForwardedFor.isEmpty()) {
-			// 여러 IP가 있을 수 있어 첫 번째가 원래 IP
-			return xForwardedFor.split(",")[0].trim();
-		}
 		return request.getRemoteAddr();
 	}
 


### PR DESCRIPTION
### 🚩 관련사항
<img width="572" height="407" alt="image" src="https://github.com/user-attachments/assets/824055ae-70b6-4c2d-bc71-dea2c888905f" />

Close #1243

### 📢 전달사항

Swagger UI 접근 제어 및 애플리케이션 운영 개선을 위한 변경입니다.

**1. Swagger UI 환경별 접근 제어 세분화** (`core/security/SwaggerSecurityConfig.java`)

기존 draft 내용에서 실제 구현이 확장되었습니다. 단일 설정이 아닌 환경별로 분리된 세 개의 inner `@Configuration` 클래스로 구성됩니다.

- **`ProdConfig`** (`@Profile("prod")`) — `/swagger-ui/**`, `/v3/api-docs/**` 경로 전면 차단 (403). Swagger 자체가 노출되지 않음
- **`LocalConfig`** (`@Profile("local")`) — 인증 없이 전면 허용. 개발 편의성 확보
- **`DefaultConfig`** (`@Profile("!prod & !local")`, e.g. dev) — 폼 로그인으로 접근 제어. `application.yml`의 `swagger.username` / `swagger.password` 로 자격증명 주입. `swaggerAuthenticationProvider()`는 `@Bean` 없이 직접 생성하여 REST API의 DB 연동 `UserDetailsService`와의 충돌 차단

모든 설정은 `@Order(0)`으로 JWT 기반 `SecurityFilterChain`보다 우선 적용됩니다.

**2. X-Forwarded-For 수동 파싱 로직 제거** (`RequestLoggingFilter`, `UserController`)

`ForwardedHeaderFilter`(Spring 프레임워크 전략)가 X-Forwarded-For 헤더를 처리한 뒤 `getRemoteAddr()`에 원본 IP를 반영하므로, 직접 헤더를 파싱하던 중복 코드를 제거했습니다.

**3. 애플리케이션 시작 로그 개선** (`CauswApplication.java`, `HolidayScheduleSyncService.java`)

- Spring Boot 기본 배너를 비활성화하고, 모든 컨텍스트 초기화가 완료된 뒤 `ApplicationReadyEvent`에서 CAUSW ASCII 아트와 환경 정보(Spring Boot 버전, Java 버전, Active Profile)를 출력
- 공휴일 동기화(`HolidayScheduleSyncService.syncOnApplicationReady`)가 배너 출력보다 먼저 실행되도록 `@Order(1)` / `@Order(2)` 로 실행 순서 명시
- 환경 정보는 Grafana 테이블 뷰에서 독립 행으로 조회 가능하도록 각각 별도 `log.info`로 분리

**집중해서 봐야 할 부분**
- `SwaggerSecurityConfig` inner class 별 `@Profile` 조건이 운영 환경에서 의도대로 활성화되는지 확인
- `swaggerAuthenticationProvider()`를 `@Bean` 없이 private 메서드로 선언한 이유: 글로벌 컨텍스트에 등록 시 REST API 인증 흐름에 간섭할 수 있음
- `ApplicationReadyEvent` 리스너 간 `@Order` 순서: 공휴일 동기화(1) → 배너 출력(2)

### 📸 스크린샷

N/A

### 📃 진행사항

- [x] Swagger UI 접근 제어를 위한 `SwaggerSecurityConfig` 구현 (폼 로그인, InMemory 인증)
- [x] 환경별 Swagger 접근 정책 세분화 (prod: 차단 / local: 허용 / dev: 폼 로그인)
- [x] `RequestLoggingFilter`의 X-Forwarded-For 수동 파싱 코드 제거
- [x] `UserController.extractClientIp()`의 X-Forwarded-For 수동 파싱 코드 제거
- [x] 애플리케이션 시작 시 CAUSW ASCII 아트 및 환경 정보 로그 출력 (`ApplicationReadyEvent`)
- [x] `HolidayScheduleSyncService` / `CauswApplication` `@Order` 실행 순서 조정
- [x] `ApiQueryLoggingAspect` — `/api/v1`, `/api/v2` 경로만 쿼리 성능 측정하도록 필터링 

### ⚙️ 기타사항

개발기간: 2026-04-15 ~ 2026-04-15
