### PR TITLE
feat: 내 정보 조회 API 응답에 이메일 필드 추가 (#1247)

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/dto/response/UserMeResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/dto/response/UserMeResponse.java
@@ -11,6 +11,8 @@ public record UserMeResponse(
 
 	@Schema(description = "사용자 ID", example = "550e8400-e29b-41d4-a716-446655440000") String id,
 
+	@Schema(description = "이메일", example = "user@example.com") String email,
+
 	@Schema(description = "이름", example = "홍길동") String name,
 
 	@Schema(description = "닉네임", example = "푸앙") String nickname,

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/dto/result/UserMeResult.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/dto/result/UserMeResult.java
@@ -8,6 +8,7 @@ import net.causw.app.main.shared.dto.ProfileImageDto;
 
 public record UserMeResult(
 	String id,
+	String email,
 	String name,
 	String nickname,
 	ProfileImageDto profileImage,
@@ -19,6 +20,7 @@ public record UserMeResult(
 	public static UserMeResult from(User user, UserInfo userInfo, boolean hasAllRequiredLatestTerms) {
 		return new UserMeResult(
 			user.getId(),
+			user.getEmail(),
 			user.getName(),
 			user.getNickname(),
 			ProfileImageDto.from(user),


### PR DESCRIPTION
### 🚩 관련사항
#1247

### 📢 전달사항
`GET /api/v2/users/me` (내 정보 조회 V2) API 응답에 이메일(`email`) 필드를 추가합니다.

기존 `UserMeResponse`에는 이메일 필드가 없어, 클라이언트가 내 정보 화면에서 이메일을 표시하려면 별도 API를 추가로 호출해야 하는 불편함이 있었습니다.

**변경 내용**
- `UserMeResult` record에 `email` 필드를 추가하고, `from()` 팩토리 메서드에서 `user.getEmail()`을 매핑하도록 수정했습니다.
- `UserMeResponse` record에 `email` 필드 및 Swagger `@Schema` 어노테이션을 추가했습니다.
- `UserMeMapper`(MapStruct)는 필드명 기반 자동 매핑이므로 별도 수정 없이 동작합니다.

### 📸 스크린샷
<img width="1135" height="874" alt="image" src="https://github.com/user-attachments/assets/1e006ae7-4fd5-4744-a01f-3bc86fb0476c" />


### 📃 진행사항
- [x] `UserMeResult`에 `email` 필드 추가 및 `from()` 팩토리 매핑
- [x] `UserMeResponse`에 `email` 필드 추가 (`@Schema` 포함)

### ⚙️ 기타사항

개발기간: 2026-04-15 ~ 2026-04-15
