### PR TITLE
Feat/#1249 user list

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/controller/UserAdminController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/controller/UserAdminController.java
@@ -9,11 +9,13 @@ import org.springframework.web.bind.annotation.*;
 
 import net.causw.app.main.domain.user.account.api.v2.dto.request.AdmissionListRequest;
 import net.causw.app.main.domain.user.account.api.v2.dto.request.AdmissionRejectRequest;
+import net.causw.app.main.domain.user.account.api.v2.dto.request.DeletedUserSearchCondition;
 import net.causw.app.main.domain.user.account.api.v2.dto.request.UserDropRequest;
 import net.causw.app.main.domain.user.account.api.v2.dto.request.UserListRequest;
 import net.causw.app.main.domain.user.account.api.v2.dto.request.UserRoleUpdateRequest;
 import net.causw.app.main.domain.user.account.api.v2.dto.response.AdmissionListItemResponse;
 import net.causw.app.main.domain.user.account.api.v2.dto.response.AdmissionResponse;
+import net.causw.app.main.domain.user.account.api.v2.dto.response.DeletedUserListResponse;
 import net.causw.app.main.domain.user.account.api.v2.dto.response.UserDetailResponse;
 import net.causw.app.main.domain.user.account.api.v2.dto.response.UserDropResponse;
 import net.causw.app.main.domain.user.account.api.v2.dto.response.UserListItemResponse;
@@ -50,7 +52,9 @@ public class UserAdminController {
 
 	// ── 회원 관리 ──
 
-	@Operation(summary = "회원 목록 조회 V2", description = "관리자가 회원 목록을 조회합니다. 이름/학번 키워드 검색, 상태/학적/학과 필터링, 페이징을 지원합니다.")
+	@Operation(summary = "회원 목록 조회 V2", description = "관리자가 회원 목록을 조회합니다. "
+		+ "이메일/이름/학번 키워드 검색, 상태 멀티 필터링, 학과/학적/입학년도 범위 필터, 정렬, 페이징을 지원합니다. "
+		+ "삭제(탈퇴) 회원은 기본 제외됩니다.")
 	@GetMapping
 	public ApiResponse<PageResponse<UserListItemResponse>> getUsers(
 		@ModelAttribute @Validated UserListRequest request,
@@ -60,6 +64,30 @@ public class UserAdminController {
 			userAdminService
 				.getUserList(userListMapper.toCondition(request), pageable)
 				.map(userListMapper::toResponse));
+
+		return ApiResponse.success(response);
+	}
+
+	@Operation(summary = "삭제(탈퇴) 회원 목록 조회 V2", description = "관리자가 탈퇴 처리된 회원 목록을 조회합니다. deletedAt이 설정된 회원만 반환됩니다.")
+	@GetMapping("/deleted")
+	public ApiResponse<PageResponse<DeletedUserListResponse>> getDeletedUsers(
+		@ModelAttribute DeletedUserSearchCondition request,
+		@PageableDefault(page = 0, size = 10) Pageable pageable) {
+
+		PageResponse<DeletedUserListResponse> response = PageResponse.from(
+			userAdminService
+				.getDeletedUserList(userListMapper.toDeletedCondition(request), pageable)
+				.map(item -> new DeletedUserListResponse(
+					item.id(),
+					item.name(),
+					item.email(),
+					item.studentId(),
+					item.admissionYear(),
+					item.department(),
+					item.userState(),
+					item.academicStatus(),
+					item.deletedAt(),
+					item.dropReason())));
 
 		return ApiResponse.success(response);
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/controller/UserAdminController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/controller/UserAdminController.java
@@ -77,17 +77,7 @@ public class UserAdminController {
 		PageResponse<DeletedUserListResponse> response = PageResponse.from(
 			userAdminService
 				.getDeletedUserList(userListMapper.toDeletedCondition(request), pageable)
-				.map(item -> new DeletedUserListResponse(
-					item.id(),
-					item.name(),
-					item.email(),
-					item.studentId(),
-					item.admissionYear(),
-					item.department(),
-					item.userState(),
-					item.academicStatus(),
-					item.deletedAt(),
-					item.dropReason())));
+				.map(userListMapper::toDeletedResponse));
 
 		return ApiResponse.success(response);
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/dto/request/DeletedUserSearchCondition.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/dto/request/DeletedUserSearchCondition.java
@@ -1,0 +1,16 @@
+package net.causw.app.main.domain.user.account.api.v2.dto.request;
+
+import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.AcademicStatus;
+import net.causw.app.main.domain.user.account.enums.user.DeletedUserSortType;
+import net.causw.app.main.domain.user.account.enums.user.Department;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record DeletedUserSearchCondition(
+	@Schema(description = "키워드 (이메일·이름·학번 like 검색)") String keyword,
+	@Schema(description = "학과") Department department,
+	@Schema(description = "입학년도 시작 (포함)") Integer admissionYearFrom,
+	@Schema(description = "입학년도 끝 (포함)") Integer admissionYearTo,
+	@Schema(description = "학적 상태") AcademicStatus academicStatus,
+	@Schema(description = "정렬 기준 (기본: DELETED_AT_DESC)") DeletedUserSortType sortBy) {
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/dto/request/UserListRequest.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/dto/request/UserListRequest.java
@@ -1,7 +1,10 @@
 package net.causw.app.main.domain.user.account.api.v2.dto.request;
 
+import java.util.List;
+
 import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.AcademicStatus;
 import net.causw.app.main.domain.user.account.enums.user.Department;
+import net.causw.app.main.domain.user.account.enums.user.UserSortType;
 import net.causw.app.main.domain.user.account.enums.user.UserState;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -9,11 +12,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "관리자 유저 목록 조회 요청")
 public record UserListRequest(
 
-	@Schema(description = "이름 또는 학번 검색 키워드", example = "홍길동") String keyword,
+	@Schema(description = "이름, 학번 또는 이메일 검색 키워드", example = "홍길동") String keyword,
 
-	@Schema(description = "유저 상태 필터링", example = "ACTIVE") UserState state,
+	@Schema(description = "유저 상태 멀티 필터링 (미지정 시 ACTIVE)", example = "[\"ACTIVE\"]") List<UserState> states,
 
 	@Schema(description = "학적 상태 필터링", example = "ENROLLED") AcademicStatus academicStatus,
 
-	@Schema(description = "소속 학과 필터링", example = "SCHOOL_OF_SW") Department department) {
+	@Schema(description = "소속 학과 필터링", example = "SCHOOL_OF_SW") Department department,
+
+	@Schema(description = "입학년도 시작 (포함)", example = "2020") Integer admissionYearFrom,
+
+	@Schema(description = "입학년도 끝 (포함)", example = "2023") Integer admissionYearTo,
+
+	@Schema(description = "정렬 기준 (기본: CREATED_AT_DESC)", example = "CREATED_AT_DESC") UserSortType sortBy) {
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/dto/response/DeletedUserListResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/dto/response/DeletedUserListResponse.java
@@ -1,4 +1,4 @@
-package net.causw.app.main.domain.user.account.service.dto.response;
+package net.causw.app.main.domain.user.account.api.v2.dto.response;
 
 import java.time.LocalDateTime;
 
@@ -6,14 +6,16 @@ import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.Academic
 import net.causw.app.main.domain.user.account.enums.user.Department;
 import net.causw.app.main.domain.user.account.enums.user.UserState;
 
-public record UserListItem(
+public record DeletedUserListResponse(
+
 	String id,
 	String name,
 	String email,
 	String studentId,
 	Integer admissionYear,
 	Department department,
-	UserState state,
+	UserState userState,
 	AcademicStatus academicStatus,
-	LocalDateTime createdAt) {
+	LocalDateTime deletedAt,
+	String dropReason) {
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/dto/response/UserListItemResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/dto/response/UserListItemResponse.java
@@ -14,7 +14,11 @@ public record UserListItemResponse(
 
 	@Schema(description = "이름", example = "홍길동") String name,
 
+	@Schema(description = "이메일", example = "hong@causw.net") String email,
+
 	@Schema(description = "학번", example = "20201234") String studentId,
+
+	@Schema(description = "입학년도", example = "2020") Integer admissionYear,
 
 	@Schema(description = "소속 학과", example = "SCHOOL_OF_SW") Department department,
 

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/mapper/UserListMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/mapper/UserListMapper.java
@@ -1,15 +1,15 @@
 package net.causw.app.main.domain.user.account.api.v2.mapper;
 
-import net.causw.app.main.domain.user.account.api.v2.dto.response.DeletedUserListResponse;
-import net.causw.app.main.domain.user.account.service.dto.result.DeletedUserListItemDto;
 import org.mapstruct.Mapper;
 
 import net.causw.app.main.domain.user.account.api.v2.dto.request.DeletedUserSearchCondition;
 import net.causw.app.main.domain.user.account.api.v2.dto.request.UserListRequest;
+import net.causw.app.main.domain.user.account.api.v2.dto.response.DeletedUserListResponse;
 import net.causw.app.main.domain.user.account.api.v2.dto.response.UserListItemResponse;
 import net.causw.app.main.domain.user.account.service.dto.request.DeletedUserQueryCondition;
 import net.causw.app.main.domain.user.account.service.dto.request.UserListCondition;
 import net.causw.app.main.domain.user.account.service.dto.response.UserListItem;
+import net.causw.app.main.domain.user.account.service.dto.result.DeletedUserListItemDto;
 
 @Mapper(componentModel = "spring")
 public interface UserListMapper {

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/mapper/UserListMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/mapper/UserListMapper.java
@@ -1,5 +1,7 @@
 package net.causw.app.main.domain.user.account.api.v2.mapper;
 
+import net.causw.app.main.domain.user.account.api.v2.dto.response.DeletedUserListResponse;
+import net.causw.app.main.domain.user.account.service.dto.result.DeletedUserListItemDto;
 import org.mapstruct.Mapper;
 
 import net.causw.app.main.domain.user.account.api.v2.dto.request.DeletedUserSearchCondition;
@@ -17,4 +19,6 @@ public interface UserListMapper {
 	UserListItemResponse toResponse(UserListItem dto);
 
 	DeletedUserQueryCondition toDeletedCondition(DeletedUserSearchCondition request);
+
+	DeletedUserListResponse toDeletedResponse(DeletedUserListItemDto dto);
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/mapper/UserListMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/mapper/UserListMapper.java
@@ -2,8 +2,10 @@ package net.causw.app.main.domain.user.account.api.v2.mapper;
 
 import org.mapstruct.Mapper;
 
+import net.causw.app.main.domain.user.account.api.v2.dto.request.DeletedUserSearchCondition;
 import net.causw.app.main.domain.user.account.api.v2.dto.request.UserListRequest;
 import net.causw.app.main.domain.user.account.api.v2.dto.response.UserListItemResponse;
+import net.causw.app.main.domain.user.account.service.dto.request.DeletedUserQueryCondition;
 import net.causw.app.main.domain.user.account.service.dto.request.UserListCondition;
 import net.causw.app.main.domain.user.account.service.dto.response.UserListItem;
 
@@ -13,4 +15,6 @@ public interface UserListMapper {
 	UserListCondition toCondition(UserListRequest request);
 
 	UserListItemResponse toResponse(UserListItem dto);
+
+	DeletedUserQueryCondition toDeletedCondition(DeletedUserSearchCondition request);
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/enums/user/DeletedUserSortType.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/enums/user/DeletedUserSortType.java
@@ -1,0 +1,7 @@
+package net.causw.app.main.domain.user.account.enums.user;
+
+public enum DeletedUserSortType {
+	DELETED_AT_DESC,
+	DELETED_AT_ASC,
+	NAME_ASC
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/enums/user/UserSortType.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/enums/user/UserSortType.java
@@ -1,0 +1,9 @@
+package net.causw.app.main.domain.user.account.enums.user;
+
+public enum UserSortType {
+	CREATED_AT_DESC,
+	CREATED_AT_ASC,
+	NAME_ASC,
+	NAME_DESC,
+	STUDENT_ID_ASC
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/user/query/DeletedUserListQueryResult.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/user/query/DeletedUserListQueryResult.java
@@ -1,4 +1,4 @@
-package net.causw.app.main.domain.user.account.service.dto.response;
+package net.causw.app.main.domain.user.account.repository.user.query;
 
 import java.time.LocalDateTime;
 
@@ -6,14 +6,21 @@ import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.Academic
 import net.causw.app.main.domain.user.account.enums.user.Department;
 import net.causw.app.main.domain.user.account.enums.user.UserState;
 
-public record UserListItem(
+import com.querydsl.core.annotations.QueryProjection;
+
+public record DeletedUserListQueryResult(
 	String id,
 	String name,
 	String email,
 	String studentId,
 	Integer admissionYear,
 	Department department,
-	UserState state,
+	UserState userState,
 	AcademicStatus academicStatus,
-	LocalDateTime createdAt) {
+	LocalDateTime deletedAt,
+	String dropReason) {
+
+	@QueryProjection
+	public DeletedUserListQueryResult {
+	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/user/query/UserListQueryResult.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/user/query/UserListQueryResult.java
@@ -1,4 +1,4 @@
-package net.causw.app.main.domain.user.account.service.dto.response;
+package net.causw.app.main.domain.user.account.repository.user.query;
 
 import java.time.LocalDateTime;
 
@@ -6,7 +6,9 @@ import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.Academic
 import net.causw.app.main.domain.user.account.enums.user.Department;
 import net.causw.app.main.domain.user.account.enums.user.UserState;
 
-public record UserListItem(
+import com.querydsl.core.annotations.QueryProjection;
+
+public record UserListQueryResult(
 	String id,
 	String name,
 	String email,
@@ -16,4 +18,8 @@ public record UserListItem(
 	UserState state,
 	AcademicStatus academicStatus,
 	LocalDateTime createdAt) {
+
+	@QueryProjection
+	public UserListQueryResult {
+	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/user/query/UserQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/user/query/UserQueryRepository.java
@@ -14,12 +14,17 @@ import org.springframework.stereotype.Repository;
 import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.AcademicStatus;
 import net.causw.app.main.domain.user.account.entity.user.QUser;
 import net.causw.app.main.domain.user.account.entity.user.User;
+import net.causw.app.main.domain.user.account.enums.user.DeletedUserSortType;
 import net.causw.app.main.domain.user.account.enums.user.Department;
 import net.causw.app.main.domain.user.account.enums.user.Role;
+import net.causw.app.main.domain.user.account.enums.user.UserSortType;
 import net.causw.app.main.domain.user.account.enums.user.UserState;
+import net.causw.app.main.domain.user.account.service.dto.request.DeletedUserQueryCondition;
+import net.causw.app.main.domain.user.account.service.dto.request.UserListCondition;
 import net.causw.app.main.domain.user.account.service.dto.request.UserQueryCondition;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -123,27 +128,61 @@ public class UserQueryRepository {
 			.fetch();
 	}
 
-	public Page<User> findUserList(
-		String keyword,
-		UserState state,
-		AcademicStatus academicStatus,
-		Department department,
-		Pageable pageable) {
-		QUser user = QUser.user;
+	/**
+	 * 관리자 유저 목록 조회 — QueryDSL Projection으로 DTO 직접 반환.
+	 * 삭제 회원 제외(notDeleted), states 미지정 시 ACTIVE만 조회.
+	 */
+	public Page<UserListQueryResult> findUserList(UserListCondition condition, Pageable pageable) {
+		List<UserState> states = (condition.states() == null || condition.states().isEmpty())
+			? List.of(UserState.ACTIVE)
+			: condition.states();
 
 		BooleanBuilder where = new BooleanBuilder()
 			.and(notDeleted())
-			.and(keywordSearchCondition(keyword))
-			.and(userStateCondition(state))
-			.and(academicStatusCondition(academicStatus))
-			.and(departmentCondition(department));
+			.and(userListKeywordCondition(condition.keyword()))
+			.and(userStatesCondition(states))
+			.and(academicStatusCondition(condition.academicStatus()))
+			.and(departmentCondition(condition.department()))
+			.and(admissionYearBetween(condition.admissionYearFrom(), condition.admissionYearTo()));
 
-		List<User> content = jpaQueryFactory
-			.selectFrom(user)
+		List<UserListQueryResult> content = jpaQueryFactory
+			.select(toUserListQueryResult(user))
+			.from(user)
 			.where(where)
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
-			.orderBy(user.createdAt.desc())
+			.orderBy(resolveUserListOrder(condition.sortBy()))
+			.fetch();
+
+		JPAQuery<Long> countQuery = jpaQueryFactory
+			.select(user.count())
+			.from(user)
+			.where(where);
+
+		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+	}
+
+	/**
+	 * 삭제(탈퇴) 회원 전용 목록 조회 — deletedAt이 null이 아닌 유저만 반환.
+	 */
+	public Page<DeletedUserListQueryResult> findDeletedUserList(
+		DeletedUserQueryCondition condition,
+		Pageable pageable) {
+
+		BooleanBuilder where = new BooleanBuilder()
+			.and(user.deletedAt.isNotNull())
+			.and(adminKeywordCondition(condition.keyword()))
+			.and(departmentCondition(condition.department()))
+			.and(admissionYearBetween(condition.admissionYearFrom(), condition.admissionYearTo()))
+			.and(academicStatusCondition(condition.academicStatus()));
+
+		List<DeletedUserListQueryResult> content = jpaQueryFactory
+			.select(toDeletedUserListQueryResult(user))
+			.from(user)
+			.where(where)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.orderBy(resolveDeletedUserOrder(condition.sortBy()))
 			.fetch();
 
 		JPAQuery<Long> countQuery = jpaQueryFactory
@@ -163,12 +202,12 @@ public class UserQueryRepository {
 
 		BooleanBuilder where = new BooleanBuilder()
 			.and(notDeleted())
-			.and(keywordSearchCondition(keyword))
+			.and(nameOrStudentIdKeywordCondition(keyword))
 			.and(userStateCondition(state))
 			.and(academicStatusCondition(academicStatus))
 			.and(reportedUserCondition());
 
-		List<User> content = jpaQueryFactory
+		List<User> contentList = jpaQueryFactory
 			.selectFrom(user)
 			.where(where)
 			.offset(pageable.getOffset())
@@ -181,7 +220,7 @@ public class UserQueryRepository {
 			.from(user)
 			.where(where);
 
-		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+		return PageableExecutionUtils.getPage(contentList, pageable, countQuery::fetchOne);
 	}
 
 	public Optional<User> findByIdNotDeleted(String userId) {
@@ -241,13 +280,62 @@ public class UserQueryRepository {
 			.fetchOne();
 	}
 
-	private BooleanExpression keywordSearchCondition(String keyword) {
+	// ─── 정렬 헬퍼 ──────────────────────────────────────────────────────────────
+
+	private OrderSpecifier<?> resolveUserListOrder(UserSortType sortBy) {
+		if (sortBy == null) {
+			return user.createdAt.desc();
+		}
+		return switch (sortBy) {
+			case CREATED_AT_ASC -> user.createdAt.asc();
+			case NAME_ASC -> user.name.asc();
+			case NAME_DESC -> user.name.desc();
+			case STUDENT_ID_ASC -> user.studentId.asc();
+			default -> user.createdAt.desc();
+		};
+	}
+
+	private OrderSpecifier<?> resolveDeletedUserOrder(DeletedUserSortType sortBy) {
+		if (sortBy == null) {
+			return user.deletedAt.desc();
+		}
+		return switch (sortBy) {
+			case DELETED_AT_ASC -> user.deletedAt.asc();
+			case NAME_ASC -> user.name.asc();
+			default -> user.deletedAt.desc();
+		};
+	}
+
+	// ─── 조건 헬퍼 ──────────────────────────────────────────────────────────────
+
+	/** 이메일·이름·학번 OR like 검색 (관리자 유저 목록, 삭제 회원 검색용) */
+	private BooleanExpression userListKeywordCondition(String keyword) {
+		if (keyword == null || keyword.isBlank()) {
+			return null;
+		}
+		String k = keyword.trim();
+		return user.email.containsIgnoreCase(k)
+			.or(user.name.containsIgnoreCase(k))
+			.or(user.studentId.containsIgnoreCase(k));
+	}
+
+	/** 이메일·이름·학번 OR like 검색 (삭제 회원 전용) */
+	private BooleanExpression adminKeywordCondition(String keyword) {
+		return userListKeywordCondition(keyword);
+	}
+
+	/** 이름·학번 OR like 검색 (신고 유저 목록 등 기존 용도) */
+	private BooleanExpression nameOrStudentIdKeywordCondition(String keyword) {
 		QUser user = QUser.user;
 		if (keyword == null || keyword.isBlank()) {
 			return null;
 		}
 		return user.name.containsIgnoreCase(keyword)
 			.or(user.studentId.containsIgnoreCase(keyword));
+	}
+
+	private BooleanExpression userStatesCondition(List<UserState> states) {
+		return (states == null || states.isEmpty()) ? null : user.state.in(states);
 	}
 
 	private BooleanExpression userStateCondition(UserState state) {
@@ -265,8 +353,50 @@ public class UserQueryRepository {
 		return department == null ? null : user.department.eq(department);
 	}
 
+	private BooleanExpression admissionYearBetween(Integer from, Integer to) {
+		if (from == null && to == null) {
+			return null;
+		}
+		if (from == null) {
+			return user.admissionYear.loe(to);
+		}
+		if (to == null) {
+			return user.admissionYear.goe(from);
+		}
+		return user.admissionYear.between(from, to);
+	}
+
 	private BooleanExpression reportedUserCondition() {
 		QUser user = QUser.user;
 		return user.reportCount.gt(0);
+	}
+
+	// ─── Projection 팩토리 ──────────────────────────────────────────────────────
+
+	private static QUserListQueryResult toUserListQueryResult(QUser user) {
+		return new QUserListQueryResult(
+			user.id,
+			user.name,
+			user.email,
+			user.studentId,
+			user.admissionYear,
+			user.department,
+			user.state,
+			user.academicStatus,
+			user.createdAt);
+	}
+
+	private static QDeletedUserListQueryResult toDeletedUserListQueryResult(QUser user) {
+		return new QDeletedUserListQueryResult(
+			user.id,
+			user.name,
+			user.email,
+			user.studentId,
+			user.admissionYear,
+			user.department,
+			user.state,
+			user.academicStatus,
+			user.deletedAt,
+			user.rejectionOrDropReason);
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAdminService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAdminService.java
@@ -13,12 +13,14 @@ import net.causw.app.main.domain.asset.locker.service.v2.implementation.LockerWr
 import net.causw.app.main.domain.user.account.entity.user.User;
 import net.causw.app.main.domain.user.account.enums.user.Role;
 import net.causw.app.main.domain.user.account.enums.user.UserState;
+import net.causw.app.main.domain.user.account.service.dto.request.DeletedUserQueryCondition;
 import net.causw.app.main.domain.user.account.service.dto.request.UserListCondition;
 import net.causw.app.main.domain.user.account.service.dto.response.UserDetailItem;
 import net.causw.app.main.domain.user.account.service.dto.response.UserDropResult;
 import net.causw.app.main.domain.user.account.service.dto.response.UserListItem;
 import net.causw.app.main.domain.user.account.service.dto.response.UserRestoreResult;
 import net.causw.app.main.domain.user.account.service.dto.response.UserRoleUpdateResult;
+import net.causw.app.main.domain.user.account.service.dto.result.DeletedUserListItemDto;
 import net.causw.app.main.domain.user.account.service.implementation.UserAdminActionLogWriter;
 import net.causw.app.main.domain.user.account.service.implementation.UserReader;
 import net.causw.app.main.domain.user.account.service.implementation.UserWriter;
@@ -38,11 +40,15 @@ public class UserAdminService {
 
 	// 필터링 조건과 페이징 정보를 기반으로 전체 사용자 목록 조회
 	@Transactional(readOnly = true)
-	public Page<UserListItem> getUserList(
-		UserListCondition condition,
+	public Page<UserListItem> getUserList(UserListCondition condition, Pageable pageable) {
+		return userReader.findUserList(condition, pageable);
+	}
+
+	@Transactional(readOnly = true)
+	public Page<DeletedUserListItemDto> getDeletedUserList(
+		DeletedUserQueryCondition condition,
 		Pageable pageable) {
-		return userReader.findUserList(condition, pageable)
-			.map(UserListItem::from);
+		return userReader.findDeletedUserList(condition, pageable);
 	}
 
 	@Transactional(readOnly = true)

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/dto/request/DeletedUserQueryCondition.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/dto/request/DeletedUserQueryCondition.java
@@ -1,18 +1,14 @@
 package net.causw.app.main.domain.user.account.service.dto.request;
 
-import java.util.List;
-
 import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.AcademicStatus;
+import net.causw.app.main.domain.user.account.enums.user.DeletedUserSortType;
 import net.causw.app.main.domain.user.account.enums.user.Department;
-import net.causw.app.main.domain.user.account.enums.user.UserSortType;
-import net.causw.app.main.domain.user.account.enums.user.UserState;
 
-public record UserListCondition(
+public record DeletedUserQueryCondition(
 	String keyword,
-	List<UserState> states,
-	AcademicStatus academicStatus,
 	Department department,
 	Integer admissionYearFrom,
 	Integer admissionYearTo,
-	UserSortType sortBy) {
+	AcademicStatus academicStatus,
+	DeletedUserSortType sortBy) {
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/dto/response/UserListItem.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/dto/response/UserListItem.java
@@ -28,7 +28,6 @@ public record UserListItem(
 			queryResult.department(),
 			queryResult.state(),
 			queryResult.academicStatus(),
-			queryResult.createdAt()
-		);
+			queryResult.createdAt());
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/dto/response/UserListItem.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/dto/response/UserListItem.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.AcademicStatus;
 import net.causw.app.main.domain.user.account.enums.user.Department;
 import net.causw.app.main.domain.user.account.enums.user.UserState;
+import net.causw.app.main.domain.user.account.repository.user.query.UserListQueryResult;
 
 public record UserListItem(
 	String id,
@@ -16,4 +17,18 @@ public record UserListItem(
 	UserState state,
 	AcademicStatus academicStatus,
 	LocalDateTime createdAt) {
+
+	public static UserListItem from(UserListQueryResult queryResult) {
+		return new UserListItem(
+			queryResult.id(),
+			queryResult.name(),
+			queryResult.email(),
+			queryResult.studentId(),
+			queryResult.admissionYear(),
+			queryResult.department(),
+			queryResult.state(),
+			queryResult.academicStatus(),
+			queryResult.createdAt()
+		);
+	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/dto/result/DeletedUserListItemDto.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/dto/result/DeletedUserListItemDto.java
@@ -1,4 +1,4 @@
-package net.causw.app.main.domain.user.account.service.dto.response;
+package net.causw.app.main.domain.user.account.service.dto.result;
 
 import java.time.LocalDateTime;
 
@@ -6,14 +6,15 @@ import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.Academic
 import net.causw.app.main.domain.user.account.enums.user.Department;
 import net.causw.app.main.domain.user.account.enums.user.UserState;
 
-public record UserListItem(
+public record DeletedUserListItemDto(
 	String id,
 	String name,
 	String email,
 	String studentId,
 	Integer admissionYear,
 	Department department,
-	UserState state,
+	UserState userState,
 	AcademicStatus academicStatus,
-	LocalDateTime createdAt) {
+	LocalDateTime deletedAt,
+	String dropReason) {
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/dto/result/DeletedUserListItemDto.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/dto/result/DeletedUserListItemDto.java
@@ -30,7 +30,6 @@ public record DeletedUserListItemDto(
 			queryResult.userState(),
 			queryResult.academicStatus(),
 			queryResult.deletedAt(),
-			queryResult.dropReason()
-		);
+			queryResult.dropReason());
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/dto/result/DeletedUserListItemDto.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/dto/result/DeletedUserListItemDto.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.AcademicStatus;
 import net.causw.app.main.domain.user.account.enums.user.Department;
 import net.causw.app.main.domain.user.account.enums.user.UserState;
+import net.causw.app.main.domain.user.account.repository.user.query.DeletedUserListQueryResult;
 
 public record DeletedUserListItemDto(
 	String id,
@@ -17,4 +18,19 @@ public record DeletedUserListItemDto(
 	AcademicStatus academicStatus,
 	LocalDateTime deletedAt,
 	String dropReason) {
+
+	public static DeletedUserListItemDto from(DeletedUserListQueryResult queryResult) {
+		return new DeletedUserListItemDto(
+			queryResult.id(),
+			queryResult.name(),
+			queryResult.email(),
+			queryResult.studentId(),
+			queryResult.admissionYear(),
+			queryResult.department(),
+			queryResult.userState(),
+			queryResult.academicStatus(),
+			queryResult.deletedAt(),
+			queryResult.dropReason()
+		);
+	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/implementation/UserReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/implementation/UserReader.java
@@ -89,24 +89,38 @@ public class UserReader {
 		return userQueryRepository.searchByCondition(condition);
 	}
 
+	/**
+	 * 유저 목록을 조회합니다. 이메일/이름/학번 키워드 검색, 상태 필터링, 학적 상태 필터링을 지원합니다.
+	 * @param condition 조회 조건 (예: 키워드, 상태, 학적 상태 등)
+	 * @param pageable 페이지네이션 정보
+	 * @return 유저 목록 페이지
+	 */
 	public Page<UserListItem> findUserList(UserListCondition condition, Pageable pageable) {
 		return userQueryRepository.findUserList(condition, pageable)
-			.map(r -> new UserListItem(
-				r.id(), r.name(), r.email(), r.studentId(),
-				r.admissionYear(), r.department(), r.state(),
-				r.academicStatus(), r.createdAt()));
+			.map(UserListItem::from);
 	}
 
+	/**
+	 * 삭제된 유저 목록을 조회합니다.
+	 * @param condition 조회 조건 (예: 삭제된 날짜 범위, 키워드 등)
+	 * @param pageable 페이지네이션 정보
+	 * @return 삭제된 유저 목록 페이지
+	 */
 	public Page<DeletedUserListItemDto> findDeletedUserList(
 		DeletedUserQueryCondition condition,
 		Pageable pageable) {
 		return userQueryRepository.findDeletedUserList(condition, pageable)
-			.map(r -> new DeletedUserListItemDto(
-				r.id(), r.name(), r.email(), r.studentId(),
-				r.admissionYear(), r.department(), r.userState(),
-				r.academicStatus(), r.deletedAt(), r.dropReason()));
+			.map(DeletedUserListItemDto::from);
 	}
 
+	/**
+	 * 신고된 유저 목록을 조회합니다. 키워드 검색, 상태 필터링, 학적 상태 필터링을 지원합니다.
+	 * @param keyword 이메일/이름/학번 키워드 검색 (null 또는 빈 문자열인 경우 검색 제외)
+	 * @param state 사용자 상태 필터 (null인 경우 모든 상태 포함)
+	 * @param academicStatus 학적 상태 필터 (null인 경우 모든 학적 상태 포함)
+	 * @param pageable 페이지네이션 정보
+	 * @return 신고된 유저 목록 페이지
+	 */
 	public Page<User> findReportedUserList(
 		String keyword,
 		UserState state,

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/implementation/UserReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/implementation/UserReader.java
@@ -18,8 +18,11 @@ import net.causw.app.main.domain.user.account.enums.user.UserState;
 import net.causw.app.main.domain.user.account.repository.user.SocialAccountRepository;
 import net.causw.app.main.domain.user.account.repository.user.UserRepository;
 import net.causw.app.main.domain.user.account.repository.user.query.UserQueryRepository;
+import net.causw.app.main.domain.user.account.service.dto.request.DeletedUserQueryCondition;
 import net.causw.app.main.domain.user.account.service.dto.request.UserListCondition;
 import net.causw.app.main.domain.user.account.service.dto.request.UserQueryCondition;
+import net.causw.app.main.domain.user.account.service.dto.response.UserListItem;
+import net.causw.app.main.domain.user.account.service.dto.result.DeletedUserListItemDto;
 import net.causw.app.main.shared.exception.errorcode.UserErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -86,15 +89,22 @@ public class UserReader {
 		return userQueryRepository.searchByCondition(condition);
 	}
 
-	public Page<User> findUserList(
-		UserListCondition condition,
+	public Page<UserListItem> findUserList(UserListCondition condition, Pageable pageable) {
+		return userQueryRepository.findUserList(condition, pageable)
+			.map(r -> new UserListItem(
+				r.id(), r.name(), r.email(), r.studentId(),
+				r.admissionYear(), r.department(), r.state(),
+				r.academicStatus(), r.createdAt()));
+	}
+
+	public Page<DeletedUserListItemDto> findDeletedUserList(
+		DeletedUserQueryCondition condition,
 		Pageable pageable) {
-		return userQueryRepository.findUserList(
-			normalizeKeyword(condition.keyword()),
-			condition.state(),
-			condition.academicStatus(),
-			condition.department(),
-			pageable);
+		return userQueryRepository.findDeletedUserList(condition, pageable)
+			.map(r -> new DeletedUserListItemDto(
+				r.id(), r.name(), r.email(), r.studentId(),
+				r.admissionYear(), r.department(), r.userState(),
+				r.academicStatus(), r.deletedAt(), r.dropReason()));
 	}
 
 	public Page<User> findReportedUserList(

--- a/app-main/src/test/java/net/causw/app/main/domain/user/account/service/UserAdminServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/user/account/service/UserAdminServiceTest.java
@@ -72,22 +72,31 @@ class UserAdminServiceTest {
 		// given
 		UserListCondition condition = new UserListCondition(
 			"홍길동",
-			UserState.ACTIVE,
+			List.of(UserState.ACTIVE),
 			AcademicStatus.ENROLLED,
-			Department.SCHOOL_OF_SW);
+			Department.SCHOOL_OF_SW,
+			null,
+			null,
+			null);
 
 		Pageable pageable = PageRequest.of(0, 10);
 
-		User user1 = ObjectFixtures.getCertifiedUserWithId("user-1");
-		User user2 = ObjectFixtures.getCertifiedUserWithId("user-2");
+		UserListItem item1 = new UserListItem(
+			"user-1", "홍길동", "hong@test.com", "20210001",
+			2021, Department.SCHOOL_OF_SW, UserState.ACTIVE,
+			AcademicStatus.ENROLLED, LocalDateTime.now());
+		UserListItem item2 = new UserListItem(
+			"user-2", "김철수", "kim@test.com", "20210002",
+			2021, Department.SCHOOL_OF_SW, UserState.ACTIVE,
+			AcademicStatus.ENROLLED, LocalDateTime.now());
 
-		Page<User> users = new PageImpl<>(
-			List.of(user1, user2),
+		Page<UserListItem> userListItems = new PageImpl<>(
+			List.of(item1, item2),
 			pageable,
 			2);
 
 		when(userReader.findUserList(any(UserListCondition.class), any(Pageable.class)))
-			.thenReturn(users);
+			.thenReturn(userListItems);
 
 		// when
 		Page<UserListItem> result = userAdminService.getUserList(condition, pageable);
@@ -96,7 +105,7 @@ class UserAdminServiceTest {
 		assertThat(result).isNotNull();
 		assertThat(result.getContent()).hasSize(2)
 			.extracting(UserListItem::name)
-			.containsExactly("name", "name");
+			.containsExactly("홍길동", "김철수");
 
 		assertThat(result.getTotalElements()).isEqualTo(2);
 		assertThat(result.getNumber()).isEqualTo(0);


### PR DESCRIPTION
### 🚩 관련사항

#1249

### 📢 전달사항

관리자 회원 목록 조회 API(`GET /api/v2/admin/users`)의 필터 기능을 확장하고,
탈퇴 회원 전용 조회 API(`GET /api/v2/admin/users/deleted`)를 신규 추가했습니다.

**1. 회원 목록 조회 필터 확장 (`UserAdminController.getUsers`)**

기존에는 단일 `UserState` 필터만 지원했으나, 이번 변경으로 아래 항목이 추가되었습니다.

- `states`: `List<UserState>` 멀티 선택 필터 (예: AWAIT, ACTIVE 동시 조회)
- `admissionYearFrom` / `admissionYearTo`: 입학년도 범위 필터
- `sortBy`: `UserSortType` 정렬 옵션 (CREATED_AT_DESC/ASC, NAME_ASC/DESC, STUDENT_ID_ASC)
- 응답에 `email`, `admissionYear` 필드 추가

**2. 탈퇴 회원 조회 API 신규 추가 (`GET /api/v2/admin/users/deleted`)**

`deletedAt`이 설정된 회원(소프트 삭제)만 별도 엔드포인트로 조회합니다.
키워드(이메일/이름/학번), 학과/학적/입학년도 범위 필터, `DeletedUserSortType` 정렬을 지원합니다.

**3. Repository - Service 레이어 DTO 분리 (QueryDSL 의존성 격리)**

QueryDSL `@QueryProjection`이 서비스 DTO에 올라오지 않도록 레이어를 분리했습니다.

- `repository/user/query/` 패키지에 `UserListQueryResult`, `DeletedUserListQueryResult` 신규 생성
  - `@QueryProjection` 어노테이션이 적용된 QueryDSL 전용 Projection DTO
  - `UserQueryRepository`에 static factory 메서드 `toUserListQueryResult()`, `toDeletedUserListQueryResult()` 추가하여 Q-type 생성자 호출 캡슐화
- `service/dto/` 의 `UserListItem`, `DeletedUserListItemDto`는 QueryDSL 의존 없이 유지
  - `UserListItem.from(UserListQueryResult)`, `DeletedUserListItemDto.from(DeletedUserListQueryResult)` static factory 메서드로 변환
  - `UserReader`에서 repo DTO → service DTO 변환 담당

리뷰 시 `UserQueryRepository`의 projection 팩토리 메서드 위치와 `UserReader`의 매핑 흐름을 함께 확인해 주시면 좋겠습니다.

### 📸 스크린샷

N/A

### 📃 진행사항

- [x] `UserListRequest` 필터 필드 확장 (states 멀티, admissionYearFrom/To, sortBy)
- [x] `UserListItemResponse` 응답 필드 추가 (email, admissionYear)
- [x] `UserSortType`, `DeletedUserSortType` enum 추가
- [x] `UserQueryRepository.findUserList()` 조건 확장 및 QueryDSL Projection 적용
- [x] 탈퇴 회원 전용 DTO 추가 (`DeletedUserSearchCondition`, `DeletedUserListResponse`, `DeletedUserQueryCondition`, `DeletedUserListItemDto`)
- [x] `UserQueryRepository.findDeletedUserList()` 신규 구현
- [x] `UserAdminController` 탈퇴 회원 조회 엔드포인트 추가 (`GET /api/v2/admin/users/deleted`)
- [x] Repository 전용 Projection DTO 분리 (`UserListQueryResult`, `DeletedUserListQueryResult`)
- [x] `UserReader` 매핑 로직 분리 (repo DTO → service DTO)
- [x] `UserAdminServiceTest` 신규 API 시그니처에 맞게 업데이트

### ⚙️ 기타사항

개발기간: 2026-04-16 ~ 2026-04-16
