### PR TITLE
Refactor/#1252 이메일 전송 실패 시 에러 로그 추가

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/shared/infra/mail/GoogleMailSender.java
+++ b/app-main/src/main/java/net/causw/app/main/shared/infra/mail/GoogleMailSender.java
@@ -1,5 +1,6 @@
 package net.causw.app.main.shared.infra.mail;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class GoogleMailSender {
 	private final JavaMailSender javaMailSender;
 	@Value("${spring.mail.username}")
@@ -104,6 +106,7 @@ public class GoogleMailSender {
 			// 이메일 전송
 			javaMailSender.send(message);
 		} catch (MailException | MessagingException exception) {
+			log.error("이메일 전송 실패: 송신자: {}, 수신자: {}, 제목: {}, 내용: {}", from, to, title, content, exception);
 			throw new ServiceUnavailableException(ErrorCode.SERVICE_UNAVAILABLE, "이메일을 전송할 수 없습니다.");
 		}
 	}


### PR DESCRIPTION
### 🚩 관련사항
#1252

### 📢 전달사항
`GoogleMailSender.sendMail()`에서 `MailException` 또는 `MessagingException` 발생 시, 예외를 `ServiceUnavailableException`으로 감싸 재던지기만 하고 원본 예외를 로그하지 않고 있었습니다.

이로 인해 운영 환경에서 이메일 전송이 실패하더라도 SMTP 인증 오류, 연결 타임아웃, 잘못된 수신 주소 등 구체적인 원인을 로그에서 확인할 수 없는 문제가 있었습니다.

이번 PR에서는 `@Slf4j`를 추가하고 catch 블록에 `log.error()`를 삽입하여, 실패 시 송신자·수신자·제목·본문 및 원본 예외 스택 트레이스가 함께 기록되도록 개선했습니다.

`sendMail()`은 `sendPasswordResetCodeMail()`, `sendEmailVerificationMail()` 등 모든 메일 전송 경로에서 공통으로 호출되므로, 이 한 곳만 수정하면 전체 메일 전송 실패 케이스에 로그가 적용됩니다.

### 📸 스크린샷
N/A

### 📃 진행사항
- [x] `GoogleMailSender`에 `@Slf4j` 어노테이션 추가
- [x] `sendMail()` catch 블록에 `log.error()` 추가 (송신자, 수신자, 제목, 본문, 원본 예외 포함)

### ⚙️ 기타사항

개발기간: 2026-04-17 ~ 2026-04-17