### PR TITLE
Refactor: RTK 전달 방식 변경

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/core/config/swagger/RefreshBearerSwaggerIndexTransformer.java
+++ b/app-main/src/main/java/net/causw/app/main/core/config/swagger/RefreshBearerSwaggerIndexTransformer.java
@@ -1,0 +1,90 @@
+package net.causw.app.main.core.config.swagger;
+
+import static org.springdoc.core.utils.Constants.SWAGGER_INITIALIZER_JS;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.springdoc.core.properties.SwaggerUiConfigParameters;
+import org.springdoc.core.properties.SwaggerUiConfigProperties;
+import org.springdoc.core.properties.SwaggerUiOAuthProperties;
+import org.springdoc.core.providers.ObjectMapperProvider;
+import org.springdoc.webmvc.ui.SwaggerIndexPageTransformer;
+import org.springdoc.webmvc.ui.SwaggerWelcomeCommon;
+import org.springframework.core.io.Resource;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.servlet.resource.ResourceTransformerChain;
+import org.springframework.web.servlet.resource.TransformedResource;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class RefreshBearerSwaggerIndexTransformer extends SwaggerIndexPageTransformer {
+
+	private static final String SWAGGER_BUNDLE_START = "SwaggerUIBundle({";
+
+	private static final String REQUEST_INTERCEPTOR = """
+			requestInterceptor: function(request) {
+			  var headers = request.headers || {};
+			  var authorization = headers['Authorization'];
+			  if (typeof authorization === 'string') {
+			    var authTrimmed = authorization.trim();
+			    if (authTrimmed !== '' && !/^Bearer\\s+/i.test(authTrimmed)) {
+			      headers['Authorization'] = 'Bearer ' + authTrimmed;
+			    }
+			  }
+			  var refreshAuthorization = headers['Refresh-Authorization'];
+			  if (typeof refreshAuthorization === 'string') {
+			    var refreshTrimmed = refreshAuthorization.trim();
+			    if (refreshTrimmed !== '' && !/^Bearer\\s+/i.test(refreshTrimmed)) {
+			      headers['Refresh-Authorization'] = 'Bearer ' + refreshTrimmed;
+			    }
+			  }
+			  request.headers = headers;
+			  return request;
+			},
+		""";
+
+	public RefreshBearerSwaggerIndexTransformer(SwaggerUiConfigProperties swaggerUiConfig,
+		SwaggerUiOAuthProperties swaggerUiOAuthProperties,
+		SwaggerUiConfigParameters swaggerUiConfigParameters,
+		SwaggerWelcomeCommon swaggerWelcomeCommon,
+		ObjectMapperProvider objectMapperProvider) {
+		super(swaggerUiConfig, swaggerUiOAuthProperties, swaggerUiConfigParameters,
+			swaggerWelcomeCommon, objectMapperProvider);
+	}
+
+	@Override
+	public Resource transform(HttpServletRequest request, Resource resource,
+		ResourceTransformerChain transformerChain) throws IOException {
+		Resource transformed = super.transform(request, resource, transformerChain);
+
+		AntPathMatcher antPathMatcher = new AntPathMatcher();
+		boolean isInitializer = antPathMatcher.match("**/swagger-ui/**/" + SWAGGER_INITIALIZER_JS,
+			resource.getURL().toString());
+
+		if (!isInitializer) {
+			return transformed;
+		}
+
+		String initializerScript = new String(transformed.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+		return new TransformedResource(transformed,
+			injectRequestInterceptor(initializerScript).getBytes(StandardCharsets.UTF_8));
+	}
+
+	private String injectRequestInterceptor(String initializerScript) {
+		if (initializerScript.contains("requestInterceptor:")) {
+			return initializerScript;
+		}
+
+		int bundleStart = initializerScript.indexOf(SWAGGER_BUNDLE_START);
+		if (bundleStart < 0) {
+			return initializerScript;
+		}
+
+		int insertPosition = bundleStart + SWAGGER_BUNDLE_START.length();
+		return initializerScript.substring(0, insertPosition)
+			+ System.lineSeparator()
+			+ REQUEST_INTERCEPTOR
+			+ initializerScript.substring(insertPosition);
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/core/config/swagger/SwaggerConfig.java
+++ b/app-main/src/main/java/net/causw/app/main/core/config/swagger/SwaggerConfig.java
@@ -1,6 +1,12 @@
 package net.causw.app.main.core.config.swagger;
 
 import org.springdoc.core.models.GroupedOpenApi;
+import org.springdoc.core.properties.SwaggerUiConfigParameters;
+import org.springdoc.core.properties.SwaggerUiConfigProperties;
+import org.springdoc.core.properties.SwaggerUiOAuthProperties;
+import org.springdoc.core.providers.ObjectMapperProvider;
+import org.springdoc.webmvc.ui.SwaggerIndexTransformer;
+import org.springdoc.webmvc.ui.SwaggerWelcomeCommon;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -94,10 +100,24 @@ public class SwaggerConfig {
 			.components(new Components()
 				.addSecuritySchemes("bearerAuth",
 					new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
-						.in(SecurityScheme.In.HEADER).name("Authorization")))
+						.in(SecurityScheme.In.HEADER).name("Authorization"))
+				.addSecuritySchemes("refreshBearerAuth",
+					new SecurityScheme().type(SecurityScheme.Type.APIKEY)
+						.in(SecurityScheme.In.HEADER).name("Refresh-Authorization")))
 			.addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
 			.info(new Info().title(StaticValue.SWAGGER_API_NAME)
 				.version(StaticValue.SWAGGER_API_VERSION)
 				.description(StaticValue.SWAGGER_API_DESCRIPTION));
+	}
+
+	@Bean
+	public SwaggerIndexTransformer refreshBearerSwaggerIndexTransformer(
+		SwaggerUiConfigProperties swaggerUiConfig,
+		SwaggerUiOAuthProperties swaggerUiOAuthProperties,
+		SwaggerUiConfigParameters swaggerUiConfigParameters,
+		SwaggerWelcomeCommon swaggerWelcomeCommon,
+		ObjectMapperProvider objectMapperProvider) {
+		return new RefreshBearerSwaggerIndexTransformer(swaggerUiConfig, swaggerUiOAuthProperties,
+			swaggerUiConfigParameters, swaggerWelcomeCommon, objectMapperProvider);
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/controller/UserController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/controller/UserController.java
@@ -5,12 +5,12 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -43,9 +43,10 @@ import net.causw.app.main.domain.user.auth.api.v2.dto.response.AuthResponse;
 import net.causw.app.main.domain.user.auth.service.dto.AuthResult;
 import net.causw.app.main.domain.user.auth.userdetails.CustomUserDetails;
 import net.causw.app.main.shared.dto.ApiResponse;
-import net.causw.app.main.shared.exception.errorcode.AuthErrorCode;
+import net.causw.app.main.shared.util.AuthorizationExtractor;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -120,14 +121,15 @@ public class UserController {
 	// ── FCM ──
 
 	@PostMapping("/fcm")
-	@Operation(summary = "fcm 토큰 등록 API", description = "유저와 fcm 토큰을 매핑한다.")
+	@Operation(summary = "fcm 토큰 등록 API", description = "유저와 fcm 토큰을 매핑한다.", security = {
+		@SecurityRequirement(name = "refreshBearerAuth")
+	})
 	public ApiResponse<UserFcmTokenResponseDto> createFcmToken(
-		@CookieValue(name = "refresh_token", required = false) String refreshToken,
+		@RequestHeader(value = AuthorizationExtractor.REFRESH_AUTHORIZATION_HEADER, required = false) String refreshAuthHeader,
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@Valid @RequestBody() UserFcmTokenRequest body) {
-		if (refreshToken == null) {
-			throw AuthErrorCode.REFRESH_TOKEN_MISSING.toBaseException();
-		}
+		AuthorizationExtractor.validateRefresh(refreshAuthHeader);
+		String refreshToken = AuthorizationExtractor.extractRefresh(refreshAuthHeader);
 		return ApiResponse
 			.success(userNotificationService.createFcmToken(userDetails.getUserId(), body.fcmToken(), refreshToken));
 	}
@@ -139,13 +141,14 @@ public class UserController {
 	}
 
 	@PatchMapping("/me/registration")
-	@Operation(summary = "소셜로그인 이후 사용자 정보 및 약관 동의 입력 API", description = "GUEST 상태의 유저에게 가입에 필요한 정보와 필수 약관 동의를 받고 AWAIT 상태로 변경한다.")
+	@Operation(summary = "소셜로그인 이후 사용자 정보 및 약관 동의 입력 API", description = "GUEST 상태의 유저에게 가입에 필요한 정보와 필수 약관 동의를 받고 AWAIT 상태로 변경한다.", security = {
+		@SecurityRequirement(name = "refreshBearerAuth")
+	})
 	public ApiResponse<AuthResponse> submitRegistration(
-		@CookieValue(name = "refresh_token", required = false) String refreshToken,
+		@RequestHeader(value = AuthorizationExtractor.REFRESH_AUTHORIZATION_HEADER, required = false) String refreshAuthHeader,
 		@AuthenticationPrincipal CustomUserDetails userDetails, @Valid @RequestBody UserRegistrationRequest body) {
-		if (refreshToken == null) {
-			throw AuthErrorCode.REFRESH_TOKEN_MISSING.toBaseException();
-		}
+		AuthorizationExtractor.validateRefresh(refreshAuthHeader);
+		String refreshToken = AuthorizationExtractor.extractRefresh(refreshAuthHeader);
 		AuthResult dto = userAccountService.completeRegistration(userDetails.getUserId(), body.nickname(),
 			body.phoneNumber(), body.name(), body.agreedTermsIds(), refreshToken);
 		return ApiResponse.success(authDtoMapper.toAuthResponse(dto));

--- a/app-main/src/main/java/net/causw/app/main/domain/user/auth/api/v2/controller/AuthController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/auth/api/v2/controller/AuthController.java
@@ -1,13 +1,11 @@
 package net.causw.app.main.domain.user.auth.api.v2.controller;
 
-import java.time.Duration;
 import java.util.Optional;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -39,9 +37,9 @@ import net.causw.app.main.domain.user.auth.service.dto.EmailFindResult;
 import net.causw.app.main.domain.user.auth.userdetails.CustomUserDetails;
 import net.causw.app.main.shared.dto.ApiResponse;
 import net.causw.app.main.shared.util.AuthorizationExtractor;
-import net.causw.global.constant.StaticValue;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -119,7 +117,7 @@ public class AuthController {
 	@PostMapping("/login")
 	public ResponseEntity<ApiResponse<AuthResponse>> emailSignIn(@RequestBody @Valid EmailLoginRequest request) {
 		AuthResult dto = authService.loginEmailUser(request.email(), request.password());
-		return createAuthResponse(dto);
+		return ResponseEntity.ok(ApiResponse.success(authDtoMapper.toAuthResponse(dto)));
 	}
 
 	@Operation(summary = "이메일 찾기 V2", description = "이름과 연락처로 가입된 이메일(마스킹) 및 연동된 소셜 계정 정보를 조회합니다.")
@@ -129,15 +127,19 @@ public class AuthController {
 		return ApiResponse.success(result.map(emailFindDtoMapper::toEmailFindResponse).orElse(null));
 	}
 
-	@Operation(summary = "토큰 재발급 V2", description = "리프레시토큰을 통해 액세스토큰을 재발급 받습니다.")
+	@Operation(summary = "토큰 재발급 V2", description = "리프레시토큰을 통해 액세스토큰을 재발급 받습니다.", security = {
+		@SecurityRequirement(name = "bearerAuth"),
+		@SecurityRequirement(name = "refreshBearerAuth")
+	})
 	@PostMapping("/refresh")
 	public ResponseEntity<ApiResponse<AuthResponse>> reissue(
-		@CookieValue(name = "refresh_token", required = false) String refreshToken,
-		@RequestHeader(value = "Authorization", required = false) String authHeader) {
+		@RequestHeader(value = "Authorization", required = false) String authHeader,
+		@RequestHeader(value = AuthorizationExtractor.REFRESH_AUTHORIZATION_HEADER, required = false) String refreshAuthHeader) {
 		// CSRF 방어 로직
 		AuthorizationExtractor.validate(authHeader);
-		AuthResult dto = authService.updateToken(refreshToken);
-		return createAuthResponse(dto);
+		AuthorizationExtractor.validateRefresh(refreshAuthHeader);
+		AuthResult dto = authService.updateToken(AuthorizationExtractor.extractRefresh(refreshAuthHeader));
+		return ResponseEntity.ok(ApiResponse.success(authDtoMapper.toAuthResponse(dto)));
 	}
 
 	@Operation(summary = "네이티브 소셜 로그인 V2", description = "provider에 따라 access token 또는 OIDC id token으로 검증합니다. Google/Apple은 authorizationCode·redirectUri(및 PKCE 사용 시에만 codeVerifier)로 리프레시 토큰을 발급받아 암호화 저장할 수 있습니다. codeVerifier는 선택값입니다.")
@@ -146,17 +148,22 @@ public class AuthController {
 		@RequestBody @Valid SocialNativeLoginRequest request) {
 		AuthResult dto = socialNativeAuthService.login(request.provider(), request.accessToken(), request.idToken(),
 			request.authorizationCode(), request.redirectUri(), request.codeVerifier());
-		return createAuthResponse(dto);
+		return ResponseEntity.ok(ApiResponse.success(authDtoMapper.toAuthResponse(dto)));
 	}
 
-	@Operation(summary = "로그아웃 V2", description = "토큰을 만료시킵니다.")
+	@Operation(summary = "로그아웃 V2", description = "토큰을 만료시킵니다.", security = {
+		@SecurityRequirement(name = "bearerAuth"),
+		@SecurityRequirement(name = "refreshBearerAuth")
+	})
 	@PostMapping("/logout")
 	public ResponseEntity<ApiResponse<String>> logout(
 		@RequestHeader("Authorization") String bearerToken,
-		@CookieValue(name = "refresh_token", required = false) String refreshToken,
+		@RequestHeader(value = AuthorizationExtractor.REFRESH_AUTHORIZATION_HEADER, required = false) String refreshAuthHeader,
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@RequestBody(required = false) SignOutRequest body) {
 		String accessToken = AuthorizationExtractor.extract(bearerToken);
+		AuthorizationExtractor.validateRefresh(refreshAuthHeader);
+		String refreshToken = AuthorizationExtractor.extractRefresh(refreshAuthHeader);
 		AuthTokenPair tokens = AuthTokenPair.of(accessToken, refreshToken);
 		String fcmToken = (body != null) ? body.fcmToken() : null;
 		authService.signOut(userDetails.getUserId(), tokens, fcmToken);
@@ -172,20 +179,4 @@ public class AuthController {
 			.body(ApiResponse.success("로그아웃 성공"));
 	}
 
-	private ResponseEntity<ApiResponse<AuthResponse>> createAuthResponse(AuthResult dto) {
-		ResponseCookie cookie = buildRefreshTokenCookie(dto.refreshToken());
-		return ResponseEntity.ok()
-			.header(HttpHeaders.SET_COOKIE, cookie.toString())
-			.body(ApiResponse.success(authDtoMapper.toAuthResponse(dto)));
-	}
-
-	private ResponseCookie buildRefreshTokenCookie(String refreshToken) {
-		return ResponseCookie.from("refresh_token", refreshToken)
-			.httpOnly(false)
-			.secure(true)
-			.path("/")
-			.maxAge(Duration.ofMillis(StaticValue.JWT_REFRESH_TOKEN_VALID_TIME))
-			.sameSite("None")
-			.build();
-	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/auth/api/v2/dto/response/AuthResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/auth/api/v2/dto/response/AuthResponse.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 @Schema(description = "인증 응답")
 public record AuthResponse(
 	@Schema(description = "액세스 토큰") String accessToken,
+	@Schema(description = "리프레시 토큰") String refreshToken,
 	@Schema(description = "사용자 프로필: 이름", example = "홍길동") String name,
 	@Schema(description = "사용자 프로필: 이메일", example = "user@cau.ac.kr") String email,
 	@Schema(description = "사용자 프로필: 프로필 이미지 정보") ProfileImageDto profileImage,

--- a/app-main/src/main/java/net/causw/app/main/domain/user/auth/handler/OAuth2SuccessHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/auth/handler/OAuth2SuccessHandler.java
@@ -1,7 +1,6 @@
 package net.causw.app.main.domain.user.auth.handler;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Optional;
 
 import org.springframework.http.HttpHeaders;
@@ -24,7 +23,6 @@ import net.causw.app.main.domain.user.auth.service.implementation.OAuth2RefreshT
 import net.causw.app.main.domain.user.auth.service.implementation.SocialAccountOauthRefreshStore;
 import net.causw.app.main.domain.user.auth.util.OAuthRedirectResolver;
 import net.causw.app.main.shared.exception.errorcode.AuthErrorCode;
-import net.causw.global.constant.StaticValue;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -34,7 +32,7 @@ import lombok.RequiredArgsConstructor;
  * OAuth2/OIDC 소셜 로그인 성공 후 후처리를 담당하는 핸들러입니다.
  * <p>
  * 인증 principal을 기준으로 사용자 엔티티를 조회하고,
- * 리프레시 토큰 쿠키를 발급한 뒤 프론트 redirect URI로 이동시킵니다.
+	 * 리프레시 토큰을 발급한 뒤 프론트 redirect URI의 쿼리 파라미터로 전달합니다.
  */
 @Component
 @RequiredArgsConstructor
@@ -48,7 +46,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 	/**
 	 * 소셜 로그인 성공 시 호출됩니다.
 	 * <p>
-	 * 1) principal로 사용자 조회, 2) 리프레시 토큰 쿠키 설정,
+	 * 1) principal로 사용자 조회, 2) 리프레시 토큰 발급,
 	 * 3) 사용자 상태 기반 redirect URL 생성 순서로 처리합니다.
 	 *
 	 * @param request 현재 HTTP 요청
@@ -62,23 +60,14 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 		User user = resolveAuthenticatedUser(authentication);
 		saveProviderOAuthRefreshTokenIfPresent(request, authentication, user);
 
-		// 리프레시토큰 생성 및 쿠키 저장
 		String refreshToken = authTokenManager.createRefreshToken(user.getId());
-		ResponseCookie cookie = ResponseCookie.from("refresh_token", refreshToken)
-			.httpOnly(false)
-			.secure(true)
-			.path("/")
-			.maxAge(Duration.ofMillis(StaticValue.JWT_REFRESH_TOKEN_VALID_TIME))
-			.sameSite("None")
-			.build();
-		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
 		String baseUrl = oAuthRedirectResolver.resolveRedirectBase(request);
 		ResponseCookie envCookie = oAuthRedirectResolver.clearEnvCookie(request);
 		response.addHeader(HttpHeaders.SET_COOKIE, envCookie.toString());
 
 		// 상태에 따른 리다이렉트 경로 결정
-		String targetUrl = determineTargetUrl(baseUrl);
+		String targetUrl = determineTargetUrl(baseUrl, refreshToken);
 
 		// 리다이렉트 실행
 		if (response.isCommitted()) {
@@ -158,10 +147,12 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 	 * 사용자 상태에 따라 프론트 redirect URL을 생성합니다.
 	 *
 	 * @param baseUrl 기본 URL
+	 * @param refreshToken 리다이렉트 URL에 포함할 리프레시 토큰
 	 * @return redirect 대상 URL
 	 */
-	private String determineTargetUrl(String baseUrl) {
+	private String determineTargetUrl(String baseUrl, String refreshToken) {
 		return UriComponentsBuilder.fromUriString(baseUrl)
+			.queryParam("refreshToken", refreshToken)
 			.build().toUriString();
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/shared/util/AuthorizationExtractor.java
+++ b/app-main/src/main/java/net/causw/app/main/shared/util/AuthorizationExtractor.java
@@ -7,23 +7,51 @@ import jakarta.servlet.http.HttpServletRequest;
 public class AuthorizationExtractor {
 
 	public static final String AUTHORIZATION_HEADER = "Authorization";
+	public static final String REFRESH_AUTHORIZATION_HEADER = "Refresh-Authorization";
 	public static final String BEARER_PREFIX = "Bearer ";
 
 	public static void validate(String authHeader) {
-		if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
+		String token = normalizeToken(authHeader);
+		if (token == null || token.isBlank()) {
 			throw AuthErrorCode.NO_PERMISSION_FOR_RESOURCE.toBaseException();
 		}
 	}
 
-	public static String extract(String authHeader) {
-		if (authHeader != null && authHeader.startsWith(BEARER_PREFIX)) {
-			return authHeader.substring(BEARER_PREFIX.length());
+	public static void validateRefresh(String refreshAuthHeader) {
+		String token = normalizeToken(refreshAuthHeader);
+		if (token == null || token.isBlank()) {
+			throw AuthErrorCode.REFRESH_TOKEN_MISSING.toBaseException();
 		}
-		return null;
+	}
+
+	public static String extract(String authHeader) {
+		return normalizeToken(authHeader);
+	}
+
+	public static String extractRefresh(String refreshAuthHeader) {
+		return extract(refreshAuthHeader);
 	}
 
 	public static String extract(HttpServletRequest request) {
 		String header = request.getHeader(AUTHORIZATION_HEADER);
 		return extract(header);
+	}
+
+	private static String normalizeToken(String headerValue) {
+		if (headerValue == null) {
+			return null;
+		}
+
+		String trimmed = headerValue.trim();
+		if (trimmed.isBlank()) {
+			return null;
+		}
+
+		if (trimmed.regionMatches(true, 0, BEARER_PREFIX, 0, BEARER_PREFIX.length())) {
+			String token = trimmed.substring(BEARER_PREFIX.length()).trim();
+			return token.isBlank() ? null : token;
+		}
+
+		return trimmed;
 	}
 }


### PR DESCRIPTION
### 🚩 관련사항
#1260 

### 📢 전달사항
FE 측과 BE에서 사용하는 도메인이 다르기 때문에 FE 측에서 접근할 수 있는 쿠키를 백엔드 측에서 구워줄 수 없어 모바일 환경과 웹 환경의 RTK 동기화가 힘든 상황입니다. 따라서, RTK 전달 방식을 쿠키에서 다시 응답/헤더로 전달하는 방식으로 변경하였습니다.

변경 범위
- 이메일 회원가입/로그인 API
- 앱 소셜 로그인 API
- 데스크탑 소셜 로그인
- 로그아웃 API
- 토큰 재발급 API
- FCM 토큰 등록 API
- 소셜로그인 이후 추가 정보 입력 API

### 📃 진행사항
- [ ] AuthResponse 수정
- [ ] 데스크탑 소셜로그인 RTK 전달 방식을 쿼리 파라미터로 수정
- [ ] RTK를 받아오는 로직 수정
- [ ] 스웨거에서 RTK 넣어서 테스트할 수 있도록 명세 수정


### ⚙️ 기타사항
현재 데스크탑 소셜로그인에서의 전달 방식은 보안 상 문제가 존재하긴 합니다만, RTK 관리 방식이 RTR이라는 점, 곧 QA가 이루어져야한다는 점 고려하여 추후 임시토큰을 전달하여 리프레시토큰과 교환하는 방식으로 보완하게 될 것 같습니다!

개발기간: 