### PR TITLE
feat: 사물함 위치 조회 응답에 정책 만료일 추가 (#1262)

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -3,6 +3,7 @@ name: CD - Develop
 on:
   push:
     branches: [ "dev" ]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -3,6 +3,7 @@ name: CD - Production
 on:
   push:
     branches: [ "main" ]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/api/v2/controller/dto/response/LockerLocationResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/api/v2/controller/dto/response/LockerLocationResponse.java
@@ -1,5 +1,6 @@
 package net.causw.app.main.domain.asset.locker.api.v2.controller.dto.response;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -20,7 +21,9 @@ public record LockerLocationResponse(
 	@Schema(description = "정책 상태")
 	public record PolicyInfo(
 		@Schema(description = "신청 가능 기간 여부", example = "true") boolean canApply,
-		@Schema(description = "연장 가능 기간 여부", example = "false") boolean canExtend) {
+		@Schema(description = "연장 가능 기간 여부", example = "false") boolean canExtend,
+		@Schema(description = "현재 사물함 신청/연장 시 만료 기간") LocalDateTime expireDate
+	) {
 	}
 
 	@Schema(description = "사물함 집계")

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/api/v2/controller/dto/response/LockerLocationResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/api/v2/controller/dto/response/LockerLocationResponse.java
@@ -22,7 +22,7 @@ public record LockerLocationResponse(
 	public record PolicyInfo(
 		@Schema(description = "신청 가능 기간 여부", example = "true") boolean canApply,
 		@Schema(description = "연장 가능 기간 여부", example = "false") boolean canExtend,
-		@Schema(description = "현재 사물함 신청/연장 시 만료 기간") LocalDateTime expireDate
+		@Schema(description = "현재 사물함 신청/연장 시 만료 일시") LocalDateTime expireDate
 	) {
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/api/v2/controller/dto/response/LockerLocationResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/api/v2/controller/dto/response/LockerLocationResponse.java
@@ -22,8 +22,7 @@ public record LockerLocationResponse(
 	public record PolicyInfo(
 		@Schema(description = "신청 가능 기간 여부", example = "true") boolean canApply,
 		@Schema(description = "연장 가능 기간 여부", example = "false") boolean canExtend,
-		@Schema(description = "현재 사물함 신청/연장 시 만료 일시") LocalDateTime expireDate
-	) {
+		@Schema(description = "현재 사물함 신청/연장 시 만료 일시") LocalDateTime expireDate) {
 	}
 
 	@Schema(description = "사물함 집계")

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/v2/LockerService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/v2/LockerService.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,7 +36,6 @@ import lombok.RequiredArgsConstructor;
  * @see LockerAdminService 관리자용 사물함 서비스
  * @see LockerPolicyAdminService 사물함 정책 관리 서비스
  */
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class LockerService {
@@ -195,8 +193,10 @@ public class LockerService {
 		LockerLocation location = lockerLocationReader.findById(locationId);
 		List<Locker> lockers = lockerReader.findByLocationIdWithUser(locationId);
 
-		boolean canApplyPolicy = lockerPeriodResolver.isRegisterActive(LocalDateTime.now());
-		boolean canExtendPolicy = lockerPeriodResolver.isExtendActive(LocalDateTime.now());
+		LocalDateTime now = LocalDateTime.now();
+
+		boolean canApplyPolicy = lockerPeriodResolver.isRegisterActive(now);
+		boolean canExtendPolicy = lockerPeriodResolver.isExtendActive(now);
 		LocalDateTime expireDate = null;
 		if (canApplyPolicy) {
 			expireDate = lockerPolicyReader.findExpireDate();
@@ -206,6 +206,7 @@ public class LockerService {
 
 		List<LockerLocationResult.LockerItemResult> lockerItems = LockerMapper.toLockerItemResults(lockers, userId);
 
-		return LockerMapper.toLocationResult(location, lockers, lockerItems, canApplyPolicy, canExtendPolicy, expireDate);
+		return LockerMapper.toLocationResult(location, lockers, lockerItems, canApplyPolicy, canExtendPolicy,
+			expireDate);
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/v2/LockerService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/v2/LockerService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,6 +37,7 @@ import lombok.RequiredArgsConstructor;
  * @see LockerAdminService 관리자용 사물함 서비스
  * @see LockerPolicyAdminService 사물함 정책 관리 서비스
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class LockerService {
@@ -195,9 +197,15 @@ public class LockerService {
 
 		boolean canApplyPolicy = lockerPeriodResolver.isRegisterActive(LocalDateTime.now());
 		boolean canExtendPolicy = lockerPeriodResolver.isExtendActive(LocalDateTime.now());
+		LocalDateTime expireDate = null;
+		if (canApplyPolicy) {
+			expireDate = lockerPolicyReader.findExpireDate();
+		} else if (canExtendPolicy) {
+			expireDate = lockerPolicyReader.findNextExpireDate();
+		}
 
 		List<LockerLocationResult.LockerItemResult> lockerItems = LockerMapper.toLockerItemResults(lockers, userId);
 
-		return LockerMapper.toLocationResult(location, lockers, lockerItems, canApplyPolicy, canExtendPolicy);
+		return LockerMapper.toLocationResult(location, lockers, lockerItems, canApplyPolicy, canExtendPolicy, expireDate);
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/v2/dto/result/LockerLocationResult.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/v2/dto/result/LockerLocationResult.java
@@ -38,7 +38,7 @@ public record LockerLocationResult(
 	 *
 	 * @param canApply  현재 사물함 신청 가능 여부
 	 * @param canExtend 현재 사물함 연장 가능 여부
-	 * @param expireDate 현재 설정된 사물함 연장시 만료기간
+	 * @param expireDate 현재 설정된 사물함 연장시 만료일시
 	 */
 	@Builder
 	public record PolicyResult(boolean canApply, boolean canExtend, LocalDateTime expireDate) {

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/v2/dto/result/LockerLocationResult.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/v2/dto/result/LockerLocationResult.java
@@ -1,5 +1,6 @@
 package net.causw.app.main.domain.asset.locker.service.v2.dto.result;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import net.causw.app.main.domain.asset.locker.entity.LockerStatus;
@@ -37,9 +38,10 @@ public record LockerLocationResult(
 	 *
 	 * @param canApply  현재 사물함 신청 가능 여부
 	 * @param canExtend 현재 사물함 연장 가능 여부
+	 * @param expireDate 현재 설정된 사물함 연장시 만료기간
 	 */
 	@Builder
-	public record PolicyResult(boolean canApply, boolean canExtend) {
+	public record PolicyResult(boolean canApply, boolean canExtend, LocalDateTime expireDate) {
 	}
 
 	/**

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/util/LockerMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/util/LockerMapper.java
@@ -1,5 +1,6 @@
 package net.causw.app.main.domain.asset.locker.util;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import net.causw.app.main.domain.asset.locker.entity.Locker;
@@ -60,7 +61,9 @@ public class LockerMapper {
 		List<Locker> lockers,
 		List<LockerLocationResult.LockerItemResult> lockerItems,
 		boolean canApplyPolicy,
-		boolean canExtendPolicy) {
+		boolean canExtendPolicy,
+		LocalDateTime expireDate
+		) {
 
 		return LockerLocationResult.builder()
 			.floor(LockerLocationResult.FloorResult.builder()
@@ -71,6 +74,7 @@ public class LockerMapper {
 			.currentPolicy(LockerLocationResult.PolicyResult.builder()
 				.canApply(canApplyPolicy)
 				.canExtend(canExtendPolicy)
+				.expireDate(expireDate)
 				.build())
 			.summary(LockerLocationResult.SummaryResult.builder()
 				.totalCount(lockers.size())

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/util/LockerMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/util/LockerMapper.java
@@ -62,8 +62,7 @@ public class LockerMapper {
 		List<LockerLocationResult.LockerItemResult> lockerItems,
 		boolean canApplyPolicy,
 		boolean canExtendPolicy,
-		LocalDateTime expireDate
-		) {
+		LocalDateTime expireDate) {
 
 		return LockerLocationResult.builder()
 			.floor(LockerLocationResult.FloorResult.builder()


### PR DESCRIPTION
### 🚩 관련사항
Close #1262

### 📢 전달사항
층별 사물함 조회 API(`GET /api/v2/lockers/locations/{locationId}`) 응답의 `PolicyInfo`에 `expireDate(LocalDateTime)` 필드를 추가합니다.

클라이언트가 신청/연장 가능 여부(`canApply`, `canExtend`)만으로는 만료 시점을 알 수 없어, 실제 기한을 UI에 표시하기 어렵다는 문제를 해결합니다.

**변경 로직**
- `canApply == true` → 현재 신청 기간의 만료 일시(`lockerPolicyReader.findExpireDate()`)를 반환
- `canExtend == true` → 다음 연장 기간의 만료 일시(`lockerPolicyReader.findNextExpireDate()`)를 반환
- 둘 다 `false`이면 `null` 반환

**변경 범위**
- `LockerLocationResult.PolicyResult` — `expireDate` 필드 추가
- `LockerLocationResponse.PolicyInfo` — `expireDate` 필드 추가 (Swagger 스키마 포함)
- `LockerService.findByLocation()` — `expireDate` 조회 및 세팅 로직 추가
- `LockerMapper.toLocationResult()` — `expireDate` 파라미터 추가 및 빌더에 반영

### 📸 스크린샷
<img width="941" height="771" alt="image" src="https://github.com/user-attachments/assets/883a8bd3-461f-40fa-bd8b-0e9ac3176944" />

<img width="714" height="546" alt="image" src="https://github.com/user-attachments/assets/cf34b2af-5765-4254-b7bd-022ca44668de" />

### 📃 진행사항
- [x] `LockerLocationResult.PolicyResult`에 `expireDate(LocalDateTime)` 필드 추가
- [x] `LockerLocationResponse.PolicyInfo`에 `expireDate(LocalDateTime)` 필드 추가
- [x] `LockerService.findByLocation()`에서 신청/연장 가능 여부에 따라 만료일 조회 및 세팅
- [x] `LockerMapper.toLocationResult()`에 `expireDate` 파라미터 추가 및 빌더 반영

### ⚙️ 기타사항

개발기간: 2026-04-26 ~ 2026-04-26
