### PR TITLE
feat: CD 워크플로우에 특정 브랜치 체크아웃 설정 추가 및 checkout 액션 v6으로 업데이트 (#1264)

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -16,7 +16,9 @@ jobs:
     steps:
       # 작업 엑세스 가능하게 $GITHUB_WORKSPACE에서 저장소를 체크아웃
       - name: Checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          ref: dev
 
       # JDK & Gradle 설정
       - name: Setup JDK and Gradle
@@ -130,7 +132,9 @@ jobs:
     steps:
       # 작업 엑세스 가능하게 $GITHUB_WORKSPACE에서 저장소를 체크아웃
       - name: Checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          ref: dev
 
       - name: Notify Success
         if: ${{ github.actor != 'nektos/act' && needs.app-main-deploy.result == 'success' }}

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -14,7 +14,9 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          ref: main
 
       - name: Setup JDK and Gradle
         uses: ./.github/actions/setup-jdk-gradle
@@ -124,6 +126,8 @@ jobs:
       # 작업 엑세스 가능하게 $GITHUB_WORKSPACE에서 저장소를 체크아웃
       - name: Checkout branch
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Notify Success
         if: ${{ github.actor != 'nektos/act' && needs.app-main-deploy.result == 'success' }}


### PR DESCRIPTION
### 🚩 관련사항
Close #1264

### 📢 전달사항
`workflow_dispatch`로 CD 워크플로우를 수동 실행할 때, `ref`가 명시되지 않아 GitHub 기본 브랜치(main)로 체크아웃될 수 있는 문제를 수정했습니다.

- `dev-cd.yml`: `app-main-build` 잡과 `notify` 잡의 Checkout 스텝에 `ref: dev` 추가
- `main-cd.yml`: `app-main-build` 잡과 `notify` 잡의 Checkout 스텝에 `ref: main` 추가

push 트리거(브랜치 push 시 자동 실행)는 해당 커밋 SHA로 자동 체크아웃되므로 영향 없으며, `workflow_dispatch` 수동 실행 시에만 적용되는 변경입니다.

`.github/actions/discord-notify` 같은 composite action을 사용하는 `notify` 잡도 로컬 action 파일을 참조하므로 `ref` 명시가 필요합니다.

아울러 `actions/checkout`을 v4 → v6으로 업그레이드했습니다. Node.js 24 런타임 사용 및 크리덴셜을 `$RUNNER_TEMP`에 분리 저장하는 보안 개선이 포함됩니다.

### 📸 스크린샷
N/A

### 📃 진행사항
- [x] `dev-cd.yml` Checkout 스텝에 `ref: dev` 명시 (build, notify 잡)
- [x] `main-cd.yml` Checkout 스텝에 `ref: main` 명시 (build, notify 잡)
- [x] `actions/checkout` v4 → v6 업그레이드

### ⚙️ 기타사항

개발기간: 2026-04-26 ~ 2026-04-26
