### PR TITLE
feat: 앱 로그인 apple/google aud 설정 수정

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/core/security/WebSecurityConfig.java
+++ b/app-main/src/main/java/net/causw/app/main/core/security/WebSecurityConfig.java
@@ -19,7 +19,14 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.oidc.authentication.OidcIdTokenDecoderFactory;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
+import org.springframework.security.oauth2.jwt.JwtIssuerValidator;
+import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -166,6 +173,29 @@ public class WebSecurityConfig {
 
 	@Bean
 	public JwtDecoderFactory<ClientRegistration> oidcIdTokenDecoderFactory() {
-		return new OidcIdTokenDecoderFactory();
+		OidcIdTokenDecoderFactory factory = new OidcIdTokenDecoderFactory();
+
+		// Spring 기본 OIDC 검증기(OidcIdTokenValidator)가 azp 등을 추가로 강제할 수 있어,
+		// native login에서 사용하는 id_token 검증에는 timestamp/issuer/audience만 검증하도록 커스텀한다.
+		factory.setJwtValidatorFactory(clientRegistration -> {
+			OAuth2TokenValidator<Jwt> timestampValidator = new JwtTimestampValidator();
+
+			String issuerUri = clientRegistration.getProviderDetails().getIssuerUri();
+			OAuth2TokenValidator<Jwt> issuerValidator = org.springframework.util.StringUtils.hasText(issuerUri)
+				? new JwtIssuerValidator(issuerUri)
+				: token -> OAuth2TokenValidatorResult.success();
+
+			String clientId = clientRegistration.getClientId();
+			OAuth2TokenValidator<Jwt> audienceValidator = token -> {
+				if (token.getAudience() != null && token.getAudience().contains(clientId)) {
+					return OAuth2TokenValidatorResult.success();
+				}
+				return OAuth2TokenValidatorResult.failure(new OAuth2Error("invalid_token", "Invalid audience", null));
+			};
+
+			return new DelegatingOAuth2TokenValidator<>(timestampValidator, issuerValidator, audienceValidator);
+		});
+
+		return factory;
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/auth/api/v2/controller/AuthController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/auth/api/v2/controller/AuthController.java
@@ -142,12 +142,12 @@ public class AuthController {
 		return ResponseEntity.ok(ApiResponse.success(authDtoMapper.toAuthResponse(dto)));
 	}
 
-	@Operation(summary = "네이티브 소셜 로그인 V2", description = "provider에 따라 access token 또는 OIDC id token으로 검증합니다. Google/Apple은 authorizationCode·redirectUri(및 PKCE 사용 시에만 codeVerifier)로 리프레시 토큰을 발급받아 암호화 저장할 수 있습니다. codeVerifier는 선택값입니다.")
+	@Operation(summary = "네이티브 소셜 로그인 V2", description = "provider에 따라 access token 또는 OIDC id token으로 검증합니다. Google/Apple은 authorizationCode(및 PKCE 사용 시에만 codeVerifier)로 리프레시 토큰을 발급받아 암호화 저장할 수 있습니다. codeVerifier는 선택값입니다.")
 	@PostMapping("/login/native")
 	public ResponseEntity<ApiResponse<AuthResponse>> loginNativeSocial(
 		@RequestBody @Valid SocialNativeLoginRequest request) {
-		AuthResult dto = socialNativeAuthService.login(request.provider(), request.accessToken(), request.idToken(),
-			request.authorizationCode(), request.redirectUri(), request.codeVerifier());
+		AuthResult dto = socialNativeAuthService.login(request.provider(), request.platform(), request.accessToken(),
+			request.idToken(), request.authorizationCode(), request.codeVerifier());
 		return ResponseEntity.ok(ApiResponse.success(authDtoMapper.toAuthResponse(dto)));
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/user/auth/api/v2/dto/request/SocialNativeLoginRequest.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/auth/api/v2/dto/request/SocialNativeLoginRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.NotBlank;
 public record SocialNativeLoginRequest(
 	@NotBlank(message = "소셜 로그인 provider를 입력해 주세요.") @Schema(description = "소셜 로그인 provider", example = "google") String provider,
 
-	@Schema(description = "클라이언트 플랫폼 힌트. Apple은 web/ios 등에 매핑된 client registration으로 검증·인가코드 교환합니다. Google은 registration은 항상 웹 `google`이며, 네이티브 id token aud는 설정 `app.security.oidc.audiences.google`로 허용합니다.", example = "ios", nullable = true) String platform,
+	@Schema(description = "클라이언트 플랫폼 힌트. Apple은 web/ios 등에 매핑된 client registration으로 검증·인가코드 교환합니다. Google은 registration은 항상 `google`이며, 네이티브 id token의 aud는 해당 client registration의 client_id 포함 여부로 검증합니다.", example = "ios", nullable = true) String platform,
 
 	@Schema(description = "네이티브 SDK에서 획득한 provider access token", nullable = true) String accessToken,
 

--- a/app-main/src/main/java/net/causw/app/main/domain/user/auth/api/v2/dto/request/SocialNativeLoginRequest.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/auth/api/v2/dto/request/SocialNativeLoginRequest.java
@@ -7,13 +7,13 @@ import jakarta.validation.constraints.NotBlank;
 public record SocialNativeLoginRequest(
 	@NotBlank(message = "소셜 로그인 provider를 입력해 주세요.") @Schema(description = "소셜 로그인 provider", example = "google") String provider,
 
+	@Schema(description = "클라이언트 플랫폼 힌트. Apple은 web/ios 등에 매핑된 client registration으로 검증·인가코드 교환합니다. Google은 registration은 항상 웹 `google`이며, 네이티브 id token aud는 설정 `app.security.oidc.audiences.google`로 허용합니다.", example = "ios", nullable = true) String platform,
+
 	@Schema(description = "네이티브 SDK에서 획득한 provider access token", nullable = true) String accessToken,
 
 	@Schema(description = "OIDC provider(google/apple)에서 획득한 id token", nullable = true) String idToken,
 
 	@Schema(description = "OIDC 인가 코드(google/apple). 전달 시 서버가 토큰 엔드포인트로 교환해 리프레시 토큰을 저장합니다.", nullable = true) String authorizationCode,
-
-	@Schema(description = "인가 코드 발급 시 사용한 redirect URI(authorizationCode 전달 시 필수)", nullable = true) String redirectUri,
 
 	@Schema(description = "PKCE code_verifier(선택값). 앱이 PKCE를 사용하는 경우에만 전달하며, 미사용 환경(예: 일부 테스트/플레이그라운드)에서는 생략 가능합니다.", nullable = true) String codeVerifier) {
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/auth/service/SocialNativeAuthService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/auth/service/SocialNativeAuthService.java
@@ -255,7 +255,7 @@ public class SocialNativeAuthService {
 		String normalizedPlatform = normalizeKey(platform);
 		if ("apple".equals(normalizedProvider)) {
 			if (!StringUtils.hasText(normalizedPlatform)) {
-				return "apple";
+				return "apple-ios";
 			}
 			ClientRegistration appleRegistration = clientRegistrationRepository.findByRegistrationId(
 				"apple-" + normalizedPlatform);

--- a/app-main/src/main/java/net/causw/app/main/domain/user/auth/service/SocialNativeAuthService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/auth/service/SocialNativeAuthService.java
@@ -68,32 +68,36 @@ public class SocialNativeAuthService {
 	 * @param accessToken 네이티브 SDK에서 발급된 provider access token
 	 * @param idToken OIDC provider(google/apple)에서 발급된 id token
 	 * @param authorizationCode OIDC 인가 코드(선택). 전달 시 토큰 엔드포인트로 교환해 리프레시 토큰을 저장합니다.
-	 * @param redirectUri 인가 코드 교환 시 사용한 redirect URI(authorizationCode 사용 시 필수)
 	 * @param codeVerifier PKCE 사용 시 code_verifier(선택)
 	 * @return 서비스 전용 access/refresh token이 포함된 인증 결과
 	 */
 	@Transactional
-	public AuthResult login(String provider, String accessToken, String idToken, String authorizationCode,
-		String redirectUri, String codeVerifier) {
-		String registrationId = provider.toLowerCase(Locale.ROOT);
-		log.info("Native social login requested. provider={}, hasIdToken={}, hasAuthCode={}", registrationId,
-			StringUtils.hasText(idToken), StringUtils.hasText(authorizationCode));
+	public AuthResult login(String provider, String platform, String accessToken, String idToken,
+		String authorizationCode, String codeVerifier) {
+		String providerKey = provider.toLowerCase(Locale.ROOT);
+		SocialType socialType = SocialType.from(providerKey);
+		String oidcRegistrationId = resolveRegistrationId(provider, platform);
+		log.info(
+			"Native social login requested. provider={}, platform={}, oidcRegistrationId={}, hasIdToken={}, hasAuthCode={}",
+			provider, platform, oidcRegistrationId, StringUtils.hasText(idToken),
+			StringUtils.hasText(authorizationCode));
 
 		try {
-			SocialType.from(registrationId);
-
 			ClientRegistration clientRegistration = Optional.ofNullable(
-				clientRegistrationRepository.findByRegistrationId(registrationId))
+				clientRegistrationRepository.findByRegistrationId(oidcRegistrationId))
 				.orElseThrow(AuthErrorCode.UNSUPPORTED_SOCIAL_PROVIDER::toBaseException);
 
-			User user = loadAuthenticatedUser(clientRegistration, accessToken, idToken);
+			User user = loadAuthenticatedUser(socialType, clientRegistration, accessToken, idToken);
 			if (isOidcProvider(clientRegistration)) {
-				persistOidcRefreshTokenFromAuthorizationCode(clientRegistration, user, authorizationCode, redirectUri,
-					codeVerifier);
+				ClientRegistration tokenExchangeRegistration = resolveOidcTokenExchangeRegistration(socialType,
+					clientRegistration);
+				persistOidcRefreshTokenFromAuthorizationCode(tokenExchangeRegistration, socialType, user,
+					authorizationCode, codeVerifier);
 			}
 			AuthTokenPair tokens = authTokenManager.issueTokens(user, null);
 
-			log.info("Native social login succeeded. provider={}, userId={}", registrationId, user.getId());
+			log.info("Native social login succeeded. provider={}, oidcRegistrationId={}, userId={}", provider,
+				oidcRegistrationId, user.getId());
 
 			boolean hasAllRequiredLatestTerms = userTermsAgreementReader.hasAgreedToAllRequiredLatestTerms(user);
 
@@ -101,11 +105,11 @@ public class SocialNativeAuthService {
 				tokens.refreshToken(), user.isGuest(), hasAllRequiredLatestTerms, user.isAcademicCertified(),
 				user.getAcademicStatus());
 		} catch (BaseRunTimeV2Exception e) {
-			log.warn("Native social login failed. provider={}, code={}, message={}", registrationId,
+			log.warn("Native social login failed. provider={}, code={}, message={}", providerKey,
 				e.getErrorCode().getCode(), e.getMessage());
 			throw e;
 		} catch (RuntimeException e) {
-			log.error("Unexpected native social login error. provider={}", registrationId, e);
+			log.error("Unexpected native social login error. provider={}", providerKey, e);
 			throw e;
 		}
 	}
@@ -113,10 +117,10 @@ public class SocialNativeAuthService {
 	/**
 	 * provider 설정(openid scope 여부)에 따라 OAuth2(access token) 또는 OIDC(id token) 검증 경로를 선택합니다.
 	 */
-	private User loadAuthenticatedUser(ClientRegistration clientRegistration, String providerAccessToken,
-		String providerIdToken) {
+	private User loadAuthenticatedUser(SocialType socialType, ClientRegistration clientRegistration,
+		String providerAccessToken, String providerIdToken) {
 		if (isOidcProvider(clientRegistration)) {
-			return loadOidcAuthenticatedUser(clientRegistration, providerIdToken);
+			return loadOidcAuthenticatedUser(socialType, clientRegistration, providerIdToken);
 		}
 
 		return loadOAuth2AuthenticatedUser(clientRegistration, providerAccessToken);
@@ -156,12 +160,15 @@ public class SocialNativeAuthService {
 	/**
 	 * OIDC provider(Google/Apple)에서 id token을 디코딩/검증하고 claim 기반 사용자 동기화를 수행합니다.
 	 */
-	private User loadOidcAuthenticatedUser(ClientRegistration clientRegistration, String providerIdToken) {
-		log.debug("Verifying OIDC id token and loading user. provider={}", clientRegistration.getRegistrationId());
+	private User loadOidcAuthenticatedUser(SocialType socialType, ClientRegistration clientRegistration,
+		String providerIdToken) {
+		log.debug("Verifying OIDC id token and loading user. registrationId={}",
+			clientRegistration.getRegistrationId());
 
 		String normalizedIdToken = normalizeAccessToken(providerIdToken);
 		if (!StringUtils.hasText(normalizedIdToken)) {
-			log.warn("OIDC provider requested without id token. provider={}", clientRegistration.getRegistrationId());
+			log.warn("OIDC provider requested without id token. registrationId={}",
+				clientRegistration.getRegistrationId());
 			throw AuthErrorCode.INVALID_TOKEN.toBaseException();
 		}
 
@@ -169,14 +176,13 @@ public class SocialNativeAuthService {
 		validateOidcClaims(clientRegistration, jwt);
 
 		try {
-			return customOAuth2UserService.loadUserFromOidcClaims(clientRegistration.getRegistrationId(),
-				jwt.getClaims());
+			return customOAuth2UserService.loadUserFromOidcClaims(socialType.registrationId(), jwt.getClaims());
 		} catch (BaseRunTimeV2Exception e) {
-			log.warn("OIDC user mapping failed. provider={}, code={}, message={}",
+			log.warn("OIDC user mapping failed. registrationId={}, code={}, message={}",
 				clientRegistration.getRegistrationId(), e.getErrorCode().getCode(), e.getMessage());
 			throw e;
 		} catch (RuntimeException e) {
-			log.warn("OIDC user mapping failed unexpectedly. provider={}, exceptionType={}",
+			log.warn("OIDC user mapping failed unexpectedly. registrationId={}, exceptionType={}",
 				clientRegistration.getRegistrationId(), e.getClass().getSimpleName());
 			throw AuthErrorCode.INVALID_TOKEN.toBaseException();
 		}
@@ -212,7 +218,7 @@ public class SocialNativeAuthService {
 		}
 
 		List<String> audience = jwt.getAudience();
-		if (audience == null || audience.isEmpty() || !audience.contains(clientRegistration.getClientId())) {
+		if (!isAudienceAllowed(clientRegistration, audience)) {
 			throw AuthErrorCode.INVALID_TOKEN.toBaseException();
 		}
 
@@ -221,6 +227,49 @@ public class SocialNativeAuthService {
 			&& (jwt.getIssuer() == null || !expectedIssuer.equals(jwt.getIssuer().toString()))) {
 			throw AuthErrorCode.INVALID_TOKEN.toBaseException();
 		}
+	}
+
+	private boolean isAudienceAllowed(ClientRegistration clientRegistration, List<String> tokenAudience) {
+		if (tokenAudience == null || tokenAudience.isEmpty()) {
+			return false;
+		}
+
+		String clientId = clientRegistration.getClientId();
+		for (String aud : tokenAudience) {
+			if (StringUtils.hasText(aud) && aud.equals(clientId)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private String resolveRegistrationId(String provider, String platform) {
+		String normalizedProvider = normalizeKey(provider);
+		if (!StringUtils.hasText(normalizedProvider)) {
+			return provider;
+		}
+		if ("google".equals(normalizedProvider)) {
+			return "google";
+		}
+
+		String normalizedPlatform = normalizeKey(platform);
+		if ("apple".equals(normalizedProvider)) {
+			if (!StringUtils.hasText(normalizedPlatform)) {
+				return "apple";
+			}
+			ClientRegistration appleRegistration = clientRegistrationRepository.findByRegistrationId(
+				"apple-" + normalizedPlatform);
+			return appleRegistration != null ? appleRegistration.getRegistrationId() : "apple";
+		}
+
+		return normalizedProvider;
+	}
+
+	private String normalizeKey(String raw) {
+		if (!StringUtils.hasText(raw)) {
+			return null;
+		}
+		return raw.trim().toLowerCase(Locale.ROOT);
 	}
 
 	/**
@@ -234,7 +283,7 @@ public class SocialNativeAuthService {
 		}
 
 		String registrationId = clientRegistration.getRegistrationId();
-		if (SocialType.APPLE.matchesRegistrationId(registrationId)) {
+		if (registrationId != null && registrationId.toLowerCase(Locale.ROOT).startsWith("apple")) {
 			return APPLE_ISSUER;
 		}
 
@@ -268,17 +317,23 @@ public class SocialNativeAuthService {
 		return AuthErrorCode.INVALID_TOKEN.toBaseException();
 	}
 
-	private void persistOidcRefreshTokenFromAuthorizationCode(ClientRegistration registration, User user,
-		String authorizationCode, String redirectUri, String codeVerifier) {
+	private ClientRegistration resolveOidcTokenExchangeRegistration(SocialType socialType,
+		ClientRegistration oidcClientRegistration) {
+		if (socialType == SocialType.GOOGLE) {
+			return Optional
+				.ofNullable(clientRegistrationRepository.findByRegistrationId(SocialType.GOOGLE.registrationId()))
+				.orElseThrow(AuthErrorCode.UNSUPPORTED_SOCIAL_PROVIDER::toBaseException);
+		}
+		return oidcClientRegistration;
+	}
+
+	private void persistOidcRefreshTokenFromAuthorizationCode(ClientRegistration registration, SocialType socialType,
+		User user, String authorizationCode, String codeVerifier) {
 		if (!StringUtils.hasText(authorizationCode)) {
 			return;
 		}
-		if (!StringUtils.hasText(redirectUri)) {
-			throw AuthErrorCode.NATIVE_SOCIAL_REDIRECT_URI_REQUIRED.toBaseException();
-		}
-		SocialType socialType = SocialType.from(registration.getRegistrationId());
 		String refreshToken = oidcAuthorizationCodeTokenClient.exchangeAuthorizationCode(registration,
-			authorizationCode, redirectUri, codeVerifier);
+			authorizationCode, codeVerifier);
 		if (!StringUtils.hasText(refreshToken)) {
 			log.info("Native OIDC token exchange returned no refresh_token; cipher not updated. provider={}",
 				registration.getRegistrationId());

--- a/app-main/src/main/java/net/causw/app/main/domain/user/auth/service/implementation/OidcAuthorizationCodeTokenClient.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/auth/service/implementation/OidcAuthorizationCodeTokenClient.java
@@ -38,15 +38,18 @@ public class OidcAuthorizationCodeTokenClient {
 	 * @return 응답에 포함된 refresh_token. 없으면 null (예: Google 재동의 시 미반환)
 	 */
 	public String exchangeAuthorizationCode(ClientRegistration registration, String authorizationCode,
-		String redirectUri, String codeVerifier) {
-		if (!StringUtils.hasText(authorizationCode) || !StringUtils.hasText(redirectUri)) {
+		String codeVerifier) {
+		if (!StringUtils.hasText(authorizationCode)) {
 			throw AuthErrorCode.INVALID_TOKEN.toBaseException();
 		}
 
 		MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
 		form.add("grant_type", "authorization_code");
 		form.add("code", authorizationCode.trim());
-		form.add("redirect_uri", redirectUri.trim());
+		String redirectUri = registration.getRedirectUri();
+		if (StringUtils.hasText(redirectUri)) {
+			form.add("redirect_uri", redirectUri.trim());
+		}
 		form.add("client_id", registration.getClientId());
 		if (StringUtils.hasText(registration.getClientSecret())) {
 			form.add("client_secret", registration.getClientSecret());

--- a/app-main/src/main/java/net/causw/app/main/domain/user/auth/service/implementation/OidcAuthorizationCodeTokenClient.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/auth/service/implementation/OidcAuthorizationCodeTokenClient.java
@@ -24,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @Slf4j
 public class OidcAuthorizationCodeTokenClient {
+	private static final String APPLE_IOS_REGISTRATION_ID = "apple-ios";
 
 	private final ObjectMapper objectMapper;
 	private final RestClient restClient;
@@ -43,20 +44,7 @@ public class OidcAuthorizationCodeTokenClient {
 			throw AuthErrorCode.INVALID_TOKEN.toBaseException();
 		}
 
-		MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
-		form.add("grant_type", "authorization_code");
-		form.add("code", authorizationCode.trim());
-		String redirectUri = registration.getRedirectUri();
-		if (StringUtils.hasText(redirectUri)) {
-			form.add("redirect_uri", redirectUri.trim());
-		}
-		form.add("client_id", registration.getClientId());
-		if (StringUtils.hasText(registration.getClientSecret())) {
-			form.add("client_secret", registration.getClientSecret());
-		}
-		if (StringUtils.hasText(codeVerifier)) {
-			form.add("code_verifier", codeVerifier.trim());
-		}
+		MultiValueMap<String, String> form = buildTokenRequestForm(registration, authorizationCode, codeVerifier);
 
 		String tokenUri = registration.getProviderDetails().getTokenUri();
 		try {
@@ -96,6 +84,31 @@ public class OidcAuthorizationCodeTokenClient {
 			log.warn("Token exchange failed. registrationId={}", registration.getRegistrationId(), e);
 			throw AuthErrorCode.INVALID_TOKEN.toBaseException();
 		}
+	}
+
+	MultiValueMap<String, String> buildTokenRequestForm(ClientRegistration registration, String authorizationCode,
+		String codeVerifier) {
+		MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+		form.add("grant_type", "authorization_code");
+		form.add("code", authorizationCode.trim());
+		String redirectUri = registration.getRedirectUri();
+		if (StringUtils.hasText(redirectUri) && shouldIncludeRedirectUri(registration)) {
+			form.add("redirect_uri", redirectUri.trim());
+		}
+		form.add("client_id", registration.getClientId());
+		if (StringUtils.hasText(registration.getClientSecret())) {
+			form.add("client_secret", registration.getClientSecret());
+		}
+		if (StringUtils.hasText(codeVerifier)) {
+			form.add("code_verifier", codeVerifier.trim());
+		}
+		return form;
+	}
+
+	private boolean shouldIncludeRedirectUri(ClientRegistration registration) {
+		String registrationId = registration.getRegistrationId();
+		return !StringUtils.hasText(registrationId)
+			|| !APPLE_IOS_REGISTRATION_ID.equalsIgnoreCase(registrationId);
 	}
 
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/auth/service/implementation/OidcAuthorizationCodeTokenClient.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/auth/service/implementation/OidcAuthorizationCodeTokenClient.java
@@ -24,8 +24,6 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @Slf4j
 public class OidcAuthorizationCodeTokenClient {
-	private static final String APPLE_IOS_REGISTRATION_ID = "apple-ios";
-
 	private final ObjectMapper objectMapper;
 	private final RestClient restClient;
 
@@ -91,10 +89,6 @@ public class OidcAuthorizationCodeTokenClient {
 		MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
 		form.add("grant_type", "authorization_code");
 		form.add("code", authorizationCode.trim());
-		String redirectUri = registration.getRedirectUri();
-		if (StringUtils.hasText(redirectUri) && shouldIncludeRedirectUri(registration)) {
-			form.add("redirect_uri", redirectUri.trim());
-		}
 		form.add("client_id", registration.getClientId());
 		if (StringUtils.hasText(registration.getClientSecret())) {
 			form.add("client_secret", registration.getClientSecret());
@@ -103,12 +97,6 @@ public class OidcAuthorizationCodeTokenClient {
 			form.add("code_verifier", codeVerifier.trim());
 		}
 		return form;
-	}
-
-	private boolean shouldIncludeRedirectUri(ClientRegistration registration) {
-		String registrationId = registration.getRegistrationId();
-		return !StringUtils.hasText(registrationId)
-			|| !APPLE_IOS_REGISTRATION_ID.equalsIgnoreCase(registrationId);
 	}
 
 }

--- a/app-main/src/main/java/net/causw/app/main/shared/exception/errorcode/AuthErrorCode.java
+++ b/app-main/src/main/java/net/causw/app/main/shared/exception/errorcode/AuthErrorCode.java
@@ -27,8 +27,6 @@ public enum AuthErrorCode implements BaseResponseCode {
 	NO_PERMISSION_FOR_RESOURCE(HttpStatus.FORBIDDEN, "AUTH_403_001", "해당 자원에 대한 접근 또는 조작 권한이 없습니다."),
 	UNVERIFIED_SOCIAL_EMAIL(HttpStatus.FORBIDDEN, "AUTH_403_002", "소셜로그인 계정의 이메일이 인증되지 않았습니다."),
 	ALREADY_LINKED_SOCIAL_PROVIDER(HttpStatus.CONFLICT, "AUTH_409_001", "하나의 계정에 소셜로그인 별 하나의 계정만 연동 가능합니다."),
-	NATIVE_SOCIAL_REDIRECT_URI_REQUIRED(HttpStatus.BAD_REQUEST, "AUTH_400_006",
-		"네이티브 소셜 인가 코드로 토큰을 교환하려면 redirectUri가 필요합니다."),
 
 	// 이메일 인증 관련
 	EMAIL_VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_404_001", "유효한 이메일 인증 정보를 찾을 수 없습니다."),

--- a/app-main/src/test/java/net/causw/app/main/domain/user/auth/service/implementation/OidcAuthorizationCodeTokenClientTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/user/auth/service/implementation/OidcAuthorizationCodeTokenClientTest.java
@@ -1,0 +1,41 @@
+package net.causw.app.main.domain.user.auth.service.implementation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class OidcAuthorizationCodeTokenClientTest {
+
+	@Test
+	@DisplayName("native/login authorization code 교환 요청에는 redirect_uri를 포함하지 않는다")
+	void buildTokenRequestForm_doesNotIncludeRedirectUri() {
+		OidcAuthorizationCodeTokenClient client = new OidcAuthorizationCodeTokenClient(new ObjectMapper(),
+			RestClient.builder());
+
+		ClientRegistration registration = ClientRegistration.withRegistrationId("google")
+			.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+			.clientId("google-client-id")
+			.clientSecret("google-client-secret")
+			.authorizationUri("https://example.com/oauth/authorize")
+			.tokenUri("https://example.com/oauth/token")
+			.redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+			.scope("openid", "email", "profile")
+			.clientName("google")
+			.build();
+
+		MultiValueMap<String, String> form = client.buildTokenRequestForm(registration, "auth-code", null);
+
+		assertThat(form).containsEntry("grant_type", java.util.List.of("authorization_code"));
+		assertThat(form).containsEntry("code", java.util.List.of("auth-code"));
+		assertThat(form).containsEntry("client_id", java.util.List.of("google-client-id"));
+		assertThat(form).containsEntry("client_secret", java.util.List.of("google-client-secret"));
+		assertThat(form).doesNotContainKey("redirect_uri");
+	}
+}

--- a/app-main/src/test/java/net/causw/app/main/domain/user/auth/service/v2/SocialNativeAuthServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/user/auth/service/v2/SocialNativeAuthServiceTest.java
@@ -3,6 +3,8 @@ package net.causw.app.main.domain.user.auth.service.v2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
@@ -91,7 +93,7 @@ class SocialNativeAuthServiceTest {
 		given(authTokenManager.issueTokens(user, null))
 			.willReturn(AuthTokenPair.of(APP_ACCESS_TOKEN, APP_REFRESH_TOKEN));
 
-		AuthResult result = socialNativeAuthService.login("kakao", PROVIDER_ACCESS_TOKEN, null, null, null, null);
+		AuthResult result = socialNativeAuthService.login("kakao", null, PROVIDER_ACCESS_TOKEN, null, null, null);
 
 		assertThat(result.accessToken()).isEqualTo(APP_ACCESS_TOKEN);
 		assertThat(result.refreshToken()).isEqualTo(APP_REFRESH_TOKEN);
@@ -99,7 +101,7 @@ class SocialNativeAuthServiceTest {
 
 		verify(customOAuth2UserService).loadUser(any(OAuth2UserRequest.class));
 		verify(authTokenManager).issueTokens(user, null);
-		verify(oidcAuthorizationCodeTokenClient, never()).exchangeAuthorizationCode(any(), any(), any(), any());
+		verify(oidcAuthorizationCodeTokenClient, never()).exchangeAuthorizationCode(any(), any(), any());
 	}
 
 	@Test
@@ -114,7 +116,7 @@ class SocialNativeAuthServiceTest {
 		given(authTokenManager.issueTokens(user, null))
 			.willReturn(AuthTokenPair.of(APP_ACCESS_TOKEN, APP_REFRESH_TOKEN));
 
-		AuthResult result = socialNativeAuthService.login("kakao", BEARER_PROVIDER_ACCESS_TOKEN, null, null, null,
+		AuthResult result = socialNativeAuthService.login("kakao", null, BEARER_PROVIDER_ACCESS_TOKEN, null, null,
 			null);
 
 		assertThat(result.accessToken()).isEqualTo(APP_ACCESS_TOKEN);
@@ -141,14 +143,14 @@ class SocialNativeAuthServiceTest {
 		given(authTokenManager.issueTokens(user, null))
 			.willReturn(AuthTokenPair.of(APP_ACCESS_TOKEN, APP_REFRESH_TOKEN));
 
-		AuthResult result = socialNativeAuthService.login("google", null, PROVIDER_ID_TOKEN, null, null, null);
+		AuthResult result = socialNativeAuthService.login("google", null, null, PROVIDER_ID_TOKEN, null, null);
 
 		assertThat(result.accessToken()).isEqualTo(APP_ACCESS_TOKEN);
 		assertThat(result.refreshToken()).isEqualTo(APP_REFRESH_TOKEN);
 
 		verify(customOAuth2UserService).loadUserFromOidcClaims("google", jwt.getClaims());
 		verify(customOAuth2UserService, never()).loadUser(any(OAuth2UserRequest.class));
-		verify(oidcAuthorizationCodeTokenClient, never()).exchangeAuthorizationCode(any(), any(), any(), any());
+		verify(oidcAuthorizationCodeTokenClient, never()).exchangeAuthorizationCode(any(), any(), any());
 	}
 
 	@Test
@@ -171,13 +173,68 @@ class SocialNativeAuthServiceTest {
 		given(authTokenManager.issueTokens(user, null))
 			.willReturn(AuthTokenPair.of(APP_ACCESS_TOKEN, APP_REFRESH_TOKEN));
 
-		AuthResult result = socialNativeAuthService.login("apple", null, PROVIDER_ID_TOKEN, null, null, null);
+		AuthResult result = socialNativeAuthService.login("apple", null, null, PROVIDER_ID_TOKEN, null, null);
 
 		assertThat(result.accessToken()).isEqualTo(APP_ACCESS_TOKEN);
 		assertThat(result.refreshToken()).isEqualTo(APP_REFRESH_TOKEN);
 
 		verify(customOAuth2UserService).loadUserFromOidcClaims("apple", jwt.getClaims());
-		verify(oidcAuthorizationCodeTokenClient, never()).exchangeAuthorizationCode(any(), any(), any(), any());
+		verify(oidcAuthorizationCodeTokenClient, never()).exchangeAuthorizationCode(any(), any(), any());
+	}
+
+	@Test
+	@DisplayName("성공: Apple platform 힌트로 분리된 registration으로 OIDC id token을 검증한다")
+	void login_apple_oidc_success_with_ios_registration() {
+		ClientRegistration appleIos = clientRegistration("apple-ios", "openid", "email", "name");
+		User user = mockUser();
+		JwtDecoder jwtDecoder = org.mockito.Mockito.mock(JwtDecoder.class);
+		Jwt jwt = oidcJwt(Map.of(
+			"sub", "apple-sub",
+			"email", "user@cau.ac.kr",
+			"email_verified", true,
+			"iss", "https://appleid.apple.com",
+			"aud", List.of("apple-ios-client-id")));
+
+		given(clientRegistrationRepository.findByRegistrationId("apple-ios")).willReturn(appleIos);
+		given(oidcIdTokenDecoderFactory.createDecoder(appleIos)).willReturn(jwtDecoder);
+		given(jwtDecoder.decode(PROVIDER_ID_TOKEN)).willReturn(jwt);
+		given(customOAuth2UserService.loadUserFromOidcClaims("apple", jwt.getClaims())).willReturn(user);
+		given(authTokenManager.issueTokens(user, null))
+			.willReturn(AuthTokenPair.of(APP_ACCESS_TOKEN, APP_REFRESH_TOKEN));
+
+		AuthResult result = socialNativeAuthService.login("apple", "ios", null, PROVIDER_ID_TOKEN, null, null);
+
+		assertThat(result.accessToken()).isEqualTo(APP_ACCESS_TOKEN);
+		assertThat(result.refreshToken()).isEqualTo(APP_REFRESH_TOKEN);
+		verify(customOAuth2UserService).loadUserFromOidcClaims("apple", jwt.getClaims());
+	}
+
+	@Test
+	@DisplayName("성공: Google 인가코드 교환은 항상 google registration으로 수행한다")
+	void login_google_oidc_exchanges_auth_code_with_google_registration() {
+		ClientRegistration google = clientRegistration("google", "openid", "email", "profile");
+		User user = mockUser();
+		JwtDecoder jwtDecoder = org.mockito.Mockito.mock(JwtDecoder.class);
+		Jwt jwt = oidcJwt(Map.of(
+			"sub", "google-sub",
+			"email", "user@cau.ac.kr",
+			"email_verified", true,
+			"iss", "https://accounts.google.com",
+			"aud", List.of("google-client-id")));
+
+		given(clientRegistrationRepository.findByRegistrationId("google")).willReturn(google);
+		given(oidcIdTokenDecoderFactory.createDecoder(google)).willReturn(jwtDecoder);
+		given(jwtDecoder.decode(PROVIDER_ID_TOKEN)).willReturn(jwt);
+		given(customOAuth2UserService.loadUserFromOidcClaims("google", jwt.getClaims())).willReturn(user);
+		given(authTokenManager.issueTokens(user, null))
+			.willReturn(AuthTokenPair.of(APP_ACCESS_TOKEN, APP_REFRESH_TOKEN));
+		given(oidcAuthorizationCodeTokenClient.exchangeAuthorizationCode(eq(google), eq("auth-code"),
+			isNull())).willReturn("provider-refresh");
+
+		AuthResult result = socialNativeAuthService.login("google", "ios", null, PROVIDER_ID_TOKEN, "auth-code", null);
+
+		assertThat(result.accessToken()).isEqualTo(APP_ACCESS_TOKEN);
+		verify(oidcAuthorizationCodeTokenClient).exchangeAuthorizationCode(eq(google), eq("auth-code"), isNull());
 	}
 
 	@Test
@@ -187,7 +244,8 @@ class SocialNativeAuthServiceTest {
 
 		given(clientRegistrationRepository.findByRegistrationId("apple")).willReturn(apple);
 
-		assertThatThrownBy(() -> socialNativeAuthService.login("apple", PROVIDER_ACCESS_TOKEN, null, null, null, null))
+		assertThatThrownBy(
+			() -> socialNativeAuthService.login("apple", null, PROVIDER_ACCESS_TOKEN, null, null, null))
 			.isInstanceOf(BaseRunTimeV2Exception.class)
 			.hasMessage(AuthErrorCode.INVALID_TOKEN.getMessage());
 
@@ -204,7 +262,7 @@ class SocialNativeAuthServiceTest {
 		given(oidcIdTokenDecoderFactory.createDecoder(google)).willReturn(jwtDecoder);
 		given(jwtDecoder.decode(PROVIDER_ID_TOKEN)).willThrow(new RuntimeException("bad id token"));
 
-		assertThatThrownBy(() -> socialNativeAuthService.login("google", null, PROVIDER_ID_TOKEN, null, null, null))
+		assertThatThrownBy(() -> socialNativeAuthService.login("google", null, null, PROVIDER_ID_TOKEN, null, null))
 			.isInstanceOf(BaseRunTimeV2Exception.class)
 			.hasMessage(AuthErrorCode.INVALID_TOKEN.getMessage());
 	}
@@ -227,7 +285,7 @@ class SocialNativeAuthServiceTest {
 		given(jwtDecoder.decode(PROVIDER_ID_TOKEN)).willReturn(jwt);
 		given(customOAuth2UserService.loadUserFromOidcClaims("google", jwt.getClaims())).willThrow(domainException);
 
-		assertThatThrownBy(() -> socialNativeAuthService.login("google", null, PROVIDER_ID_TOKEN, null, null, null))
+		assertThatThrownBy(() -> socialNativeAuthService.login("google", null, null, PROVIDER_ID_TOKEN, null, null))
 			.isInstanceOf(BaseRunTimeV2Exception.class)
 			.hasMessage(AuthErrorCode.SOCIAL_EMAIL_REQUIRED.getMessage());
 
@@ -243,7 +301,7 @@ class SocialNativeAuthServiceTest {
 		given(customOAuth2UserService.loadUser(any(OAuth2UserRequest.class)))
 			.willThrow(new RuntimeException("provider rejected token"));
 
-		assertThatThrownBy(() -> socialNativeAuthService.login("kakao", PROVIDER_ACCESS_TOKEN, null, null, null, null))
+		assertThatThrownBy(() -> socialNativeAuthService.login("kakao", null, PROVIDER_ACCESS_TOKEN, null, null, null))
 			.isInstanceOf(BaseRunTimeV2Exception.class)
 			.hasMessage(AuthErrorCode.INVALID_TOKEN.getMessage());
 
@@ -253,7 +311,7 @@ class SocialNativeAuthServiceTest {
 	@Test
 	@DisplayName("실패: 지원하지 않는 provider면 예외를 반환한다")
 	void login_fail_when_provider_unsupported() {
-		assertThatThrownBy(() -> socialNativeAuthService.login("naver", PROVIDER_ACCESS_TOKEN, null, null, null, null))
+		assertThatThrownBy(() -> socialNativeAuthService.login("naver", null, PROVIDER_ACCESS_TOKEN, null, null, null))
 			.isInstanceOf(BaseRunTimeV2Exception.class)
 			.hasMessage(AuthErrorCode.UNSUPPORTED_SOCIAL_PROVIDER.getMessage());
 	}
@@ -268,7 +326,7 @@ class SocialNativeAuthServiceTest {
 		given(customOAuth2UserService.loadUser(any(OAuth2UserRequest.class)))
 			.willThrow(new InternalAuthenticationServiceException("social login failed", domainException));
 
-		assertThatThrownBy(() -> socialNativeAuthService.login("kakao", PROVIDER_ACCESS_TOKEN, null, null, null, null))
+		assertThatThrownBy(() -> socialNativeAuthService.login("kakao", null, PROVIDER_ACCESS_TOKEN, null, null, null))
 			.isInstanceOf(BaseRunTimeV2Exception.class)
 			.hasMessage(AuthErrorCode.SOCIAL_EMAIL_REQUIRED.getMessage());
 

--- a/app-main/src/test/java/net/causw/app/main/domain/user/auth/service/v2/SocialNativeAuthServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/user/auth/service/v2/SocialNativeAuthServiceTest.java
@@ -154,9 +154,9 @@ class SocialNativeAuthServiceTest {
 	}
 
 	@Test
-	@DisplayName("성공: Apple OIDC id token 검증 후 앱 토큰을 발급한다")
+	@DisplayName("성공: Apple OIDC id token 검증 후 앱 토큰을 발급한다 (platform 미지정 시 apple-ios 사용)")
 	void login_apple_oidc_success() {
-		ClientRegistration apple = clientRegistration("apple", "openid", "email", "name");
+		ClientRegistration appleIos = clientRegistration("apple-ios", "openid", "email", "name");
 		User user = mockUser();
 		JwtDecoder jwtDecoder = org.mockito.Mockito.mock(JwtDecoder.class);
 		Jwt jwt = oidcJwt(Map.of(
@@ -164,10 +164,10 @@ class SocialNativeAuthServiceTest {
 			"email", "user@cau.ac.kr",
 			"email_verified", true,
 			"iss", "https://appleid.apple.com",
-			"aud", List.of("apple-client-id")));
+			"aud", List.of("apple-ios-client-id")));
 
-		given(clientRegistrationRepository.findByRegistrationId("apple")).willReturn(apple);
-		given(oidcIdTokenDecoderFactory.createDecoder(apple)).willReturn(jwtDecoder);
+		given(clientRegistrationRepository.findByRegistrationId("apple-ios")).willReturn(appleIos);
+		given(oidcIdTokenDecoderFactory.createDecoder(appleIos)).willReturn(jwtDecoder);
 		given(jwtDecoder.decode(PROVIDER_ID_TOKEN)).willReturn(jwt);
 		given(customOAuth2UserService.loadUserFromOidcClaims("apple", jwt.getClaims())).willReturn(user);
 		given(authTokenManager.issueTokens(user, null))
@@ -240,9 +240,10 @@ class SocialNativeAuthServiceTest {
 	@Test
 	@DisplayName("실패: OIDC provider 요청에서 id token이 없으면 INVALID_TOKEN을 반환한다")
 	void login_oidc_fail_when_id_token_missing() {
-		ClientRegistration apple = clientRegistration("apple", "openid", "email", "name");
+		ClientRegistration appleIos = clientRegistration("apple-ios", "openid", "email", "name");
 
-		given(clientRegistrationRepository.findByRegistrationId("apple")).willReturn(apple);
+		// platform 미지정 시 기본 registration은 apple-ios
+		given(clientRegistrationRepository.findByRegistrationId("apple-ios")).willReturn(appleIos);
 
 		assertThatThrownBy(
 			() -> socialNativeAuthService.login("apple", null, PROVIDER_ACCESS_TOKEN, null, null, null))


### PR DESCRIPTION
### 🚩 관련사항
관련된 이슈번호 혹은 PR 번호를 기록합니다.
Close #1229 

### 📢 전달사항
데스크톱 소셜 로그인에 사용하는 웹 클라이언트와 프론트에서 앱 로그인 시 사용하는 앱 SDK의 클라이언트가 달라 기존 검증에 문제가 있었습니다. 따라서, 별도 클라이언트에 대해서도 검증이 가능하도록 + 탈퇴를 위해 provider 측의 리프레시토큰을 가져와 저장할 수 있도록 aud 설정을 수정하였습니다.

구글의 경우 교차 클라이언트를 지원하기 때문에 프론트 측에서 serverClientId 처리를 하여 단일 웹 클라이언트에 대해 검증하는 방향으로 구현하였고, 애플의 경우 registration을 분리하여 플랫폼 별로 각 클라이언트에 대해 검증을 수행하도록 구현하였습니다.

프론트 팀장님 도움 받아 토큰에 대한 로컬 테스트를 완료했습니다~

### 📃 진행사항
- [x] application.yml 수정 (apple registration 분리)
- [x] apple registration 분리에 따른 별도 검증/RTK 호출 로직 구현
- [x] 앱 소셜 로그인 요청 중 redirect_uri 제거 (서버 측에서 관리)
- [x] 로컬 테스트

### ⚙️ 기타사항
애플/구글의 클라이언트 정책이 달라서 자료조사에 시간이 좀 걸렸습니다.

참고 자료: https://developers.google.com/identity/protocols/oauth2/cross-client-identity?hl=ko

개발기간: 