### PR TITLE
Feat: 게시글 작성 가능한 게시판 목록 조회 API 개발

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/controller/BoardController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/controller/BoardController.java
@@ -8,7 +8,9 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import net.causw.app.main.domain.community.board.api.v2.dto.response.BoardReadableListResponse;
+import net.causw.app.main.domain.community.board.api.v2.dto.response.BoardWritableListResponse;
 import net.causw.app.main.domain.community.board.api.v2.mapper.BoardReadableMapper;
+import net.causw.app.main.domain.community.board.api.v2.mapper.BoardWritableMapper;
 import net.causw.app.main.domain.community.board.service.v2.BoardService;
 import net.causw.app.main.domain.user.auth.userdetails.CustomUserDetails;
 import net.causw.app.main.shared.dto.ApiResponse;
@@ -25,6 +27,7 @@ public class BoardController {
 
 	private final BoardService boardService;
 	private final BoardReadableMapper boardReadableMapper;
+	private final BoardWritableMapper boardWritableMapper;
 
 	@GetMapping("/available")
 	@ResponseStatus(HttpStatus.OK)
@@ -33,5 +36,14 @@ public class BoardController {
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		return ApiResponse.success(
 			boardReadableMapper.toReadableListResponse(boardService.getReadableBoards(userDetails.getUser().getId())));
+	}
+
+	@GetMapping("/writable")
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(summary = "쓰기 가능한 게시판 목록", description = "현재 사용자가 쓰기 가능한 게시판의 id, name 목록을 표시 순서대로 반환합니다.")
+	public ApiResponse<BoardWritableListResponse> getWritableBoards(
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		return ApiResponse.success(
+			boardWritableMapper.toWritableListResponse(boardService.getWritableBoards(userDetails.getUser().getId())));
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/dto/response/BoardWritableItemResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/dto/response/BoardWritableItemResponse.java
@@ -1,0 +1,9 @@
+package net.causw.app.main.domain.community.board.api.v2.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "쓰기 가능한 게시판 한 건")
+public record BoardWritableItemResponse(
+	@Schema(description = "게시판 ID") String id,
+	@Schema(description = "게시판 이름") String name) {
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/dto/response/BoardWritableListResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/dto/response/BoardWritableListResponse.java
@@ -1,0 +1,10 @@
+package net.causw.app.main.domain.community.board.api.v2.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "쓰기 가능한 게시판 목록 응답")
+public record BoardWritableListResponse(
+	@Schema(description = "쓰기 가능한 게시판 목록 (표시 순서)") List<BoardWritableItemResponse> boards) {
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/dto/response/BoardWritableListResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/dto/response/BoardWritableListResponse.java
@@ -6,5 +6,5 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "쓰기 가능한 게시판 목록 응답")
 public record BoardWritableListResponse(
-	@Schema(description = "쓰기 가능한 게시판 목록 (표시 순서)") List<BoardWritableItemResponse> boards) {
+	@Schema(description = "쓰기 가능한 게시판 목록 (표시 순서에 따라 정렬)") List<BoardWritableItemResponse> boards) {
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/mapper/BoardWritableMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/mapper/BoardWritableMapper.java
@@ -1,0 +1,20 @@
+package net.causw.app.main.domain.community.board.api.v2.mapper;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+
+import net.causw.app.main.domain.community.board.api.v2.dto.response.BoardWritableItemResponse;
+import net.causw.app.main.domain.community.board.api.v2.dto.response.BoardWritableListResponse;
+import net.causw.app.main.domain.community.board.service.v2.dto.BoardWritableItemResult;
+
+@Mapper(componentModel = "spring")
+public interface BoardWritableMapper {
+	BoardWritableItemResponse toWritableItemResponse(BoardWritableItemResult result);
+
+	List<BoardWritableItemResponse> toWritableItemResponseList(List<BoardWritableItemResult> results);
+
+	default BoardWritableListResponse toWritableListResponse(List<BoardWritableItemResult> results) {
+		return new BoardWritableListResponse(toWritableItemResponseList(results));
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/repository/BoardConfigQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/repository/BoardConfigQueryRepository.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.springframework.stereotype.Repository;
 
+import net.causw.app.main.domain.community.board.entity.Board;
 import net.causw.app.main.domain.community.board.entity.BoardConfig;
 import net.causw.app.main.domain.community.board.entity.BoardReadScope;
 import net.causw.app.main.domain.community.board.entity.BoardVisibility;
@@ -15,6 +16,7 @@ import net.causw.app.main.domain.community.board.entity.QBoardAdmin;
 import net.causw.app.main.domain.community.board.entity.QBoardConfig;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -71,36 +73,46 @@ public class BoardConfigQueryRepository {
 	}
 
 	/**
-	 * 사용자에게 쓰기 권한이 있는 게시판 ID 목록을 조회합니다.(VISIBLE 체크 포함)
-	 * ONLY_ADMIN 쓰기 범위를 체크할 때 board 하나 당 하나의 쿼리가 나가는 N+1 방지를 위해 join으로 처리했습니다.
-	 * board와 boardConfig를 join하여 board의 visibility와 writeScope를 가져옵니다.
-	 * writeScope가 {@code ALL_USER}일 경우는 visible할 경우 포함시키고,
-	 * writeScope가 {@code ONLY_ADMIN}일 경우는 board와 boardAdmin의 left join을 통해 해당 board의 admin에 userId가 포함되는지 체크합니다.
+	 * 사용자에게 쓰기 권한이 있는 게시판 목록을 조회합니다.(VISIBLE, isDeleted 체크 포함, 표시 순서에 따라 정렬 포함)
+	 * ONLY_ADMIN 쓰기 범위를 체크할 때 board 하나 당 하나의 쿼리가 나가는 N+1 방지를 위해
+	 * WriteScope가 {@code ONLY_ADMIN}일 경우에만 exists()를 통해 쓰기 가능 여부를 체크하도록 하였습니다.
+	 * board와 boardConfig를 join하여 board의 visibility와 IsDeleted, writeScope를 가져옵니다.
+	 * IsDeleted가 false이고, visable 할 때,
+	 * writeScope가 {@code ALL_USER}일 경우 리스트에 포함시키고,
+	 * writeScope가 {@code ONLY_ADMIN}일 경우는 boardAdmin에 해당 boardId, userId가 exist하는지 체크합니다.
 	 *
 	 * @param userId 대상이 되는 user의 Id
-	 * @return 게시판 ID 목록
+	 * @return 쓰기 가능한 게시판 목록
 	 */
-	public List<String> findWritableBoardsByUserId(String userId) {
+	public List<Board> findWritableBoardsByUserId(String userId) {
 		QBoard board = QBoard.board;
 		QBoardConfig boardConfig = QBoardConfig.boardConfig;
 		QBoardAdmin boardAdmin = QBoardAdmin.boardAdmin;
 
 		return jpaQueryFactory
-			.select(board.id)
-			.from(board)
+			.selectFrom(board)
 			// 게시판 설정 정보와 Inner Join
 			.join(boardConfig).on(board.id.eq(boardConfig.boardId))
-			// 관리자 테이블과 Left Join
-			.leftJoin(boardAdmin).on(
-				board.id.eq(boardAdmin.boardId)
-					.and(boardAdmin.userId.eq(userId)))
-			// 필터링 조건
+			// 필터링 조건(isDeleted, visibility, writeScope 체크)
 			.where(
+				board.isDeleted.isFalse(),
 				visible(boardConfig),
+				// ALL_USER 이거나 ONLY_ADMIN이고 boardAdmin에 boardId와 userId 컬럼이 존재할 경우
 				boardConfig.writeScope.eq(BoardWriteScope.ALL_USER)
 					.or(
 						boardConfig.writeScope.eq(BoardWriteScope.ONLY_ADMIN)
-							.and(boardAdmin.userId.isNotNull())))
+							.and(
+								JPAExpressions.selectOne()
+									.from(boardAdmin)
+									.where(
+										boardAdmin.boardId.eq(board.id),
+										boardAdmin.userId.eq(userId)
+									)
+									.exists()
+							)
+					)
+			)
+			.orderBy(boardConfig.displayOrder.asc())
 			.fetch();
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/repository/BoardConfigQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/repository/BoardConfigQueryRepository.java
@@ -9,6 +9,9 @@ import org.springframework.stereotype.Repository;
 import net.causw.app.main.domain.community.board.entity.BoardConfig;
 import net.causw.app.main.domain.community.board.entity.BoardReadScope;
 import net.causw.app.main.domain.community.board.entity.BoardVisibility;
+import net.causw.app.main.domain.community.board.entity.BoardWriteScope;
+import net.causw.app.main.domain.community.board.entity.QBoard;
+import net.causw.app.main.domain.community.board.entity.QBoardAdmin;
 import net.causw.app.main.domain.community.board.entity.QBoardConfig;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -64,6 +67,43 @@ public class BoardConfigQueryRepository {
 			.from(boardConfig)
 			.where(visible(boardConfig)
 				.and(boardConfig.readScope.in(boardReadScopes)))
+			.fetch();
+	}
+
+	/**
+	 * 사용자에게 쓰기 권한이 있는 게시판 ID 목록을 조회합니다.(VISIBLE 체크 포함)
+	 * ONLY_ADMIN 쓰기 범위를 체크할 때 board 하나 당 하나의 쿼리가 나가는 N+1 방지를 위해 join으로 처리했습니다.
+	 * board와 boardConfig를 join하여 board의 visibility와 writeScope를 가져옵니다.
+	 * writeScope가 {@code ALL_USER}일 경우는 visible할 경우 포함시키고,
+	 * writeScope가 {@code ONLY_ADMIN}일 경우는 board와 boardAdmin의 left join을 통해 해당 board의 admin에 userId가 포함되는지 체크합니다.
+	 *
+	 * @param userId 대상이 되는 user의 Id
+	 * @return 게시판 ID 목록
+	 */
+	public List<String> findWritableBoardsByUserId(String userId) {
+		QBoard board = QBoard.board;
+		QBoardConfig boardConfig = QBoardConfig.boardConfig;
+		QBoardAdmin boardAdmin = QBoardAdmin.boardAdmin;
+
+		return jpaQueryFactory
+			.select(board.id)
+			.from(board)
+			// 게시판 설정 정보와 Inner Join
+			.join(boardConfig).on(board.id.eq(boardConfig.boardId))
+			// 관리자 테이블과 Left Join
+			.leftJoin(boardAdmin).on(
+				board.id.eq(boardAdmin.boardId)
+					.and(boardAdmin.userId.eq(userId))
+			)
+			// 필터링 조건
+			.where(
+				visible(boardConfig),
+				boardConfig.writeScope.eq(BoardWriteScope.ALL_USER)
+					.or(
+						boardConfig.writeScope.eq(BoardWriteScope.ONLY_ADMIN)
+							.and(boardAdmin.userId.isNotNull())
+					)
+			)
 			.fetch();
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/repository/BoardConfigQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/repository/BoardConfigQueryRepository.java
@@ -93,17 +93,14 @@ public class BoardConfigQueryRepository {
 			// 관리자 테이블과 Left Join
 			.leftJoin(boardAdmin).on(
 				board.id.eq(boardAdmin.boardId)
-					.and(boardAdmin.userId.eq(userId))
-			)
+					.and(boardAdmin.userId.eq(userId)))
 			// 필터링 조건
 			.where(
 				visible(boardConfig),
 				boardConfig.writeScope.eq(BoardWriteScope.ALL_USER)
 					.or(
 						boardConfig.writeScope.eq(BoardWriteScope.ONLY_ADMIN)
-							.and(boardAdmin.userId.isNotNull())
-					)
-			)
+							.and(boardAdmin.userId.isNotNull())))
 			.fetch();
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/repository/BoardConfigQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/repository/BoardConfigQueryRepository.java
@@ -106,12 +106,8 @@ public class BoardConfigQueryRepository {
 									.from(boardAdmin)
 									.where(
 										boardAdmin.boardId.eq(board.id),
-										boardAdmin.userId.eq(userId)
-									)
-									.exists()
-							)
-					)
-			)
+										boardAdmin.userId.eq(userId))
+									.exists())))
 			.orderBy(boardConfig.displayOrder.asc())
 			.fetch();
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/service/implementation/BoardConfigReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/service/implementation/BoardConfigReader.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
+import net.causw.app.main.domain.community.board.entity.Board;
 import net.causw.app.main.domain.community.board.entity.BoardConfig;
 import net.causw.app.main.domain.community.board.entity.BoardReadScope;
 import net.causw.app.main.domain.community.board.repository.BoardAdminQueryRepository;
@@ -104,13 +105,13 @@ public class BoardConfigReader {
 	}
 
 	/**
-	 * 사용자 ID에 따라 접근 가능한 게시판 ID 목록을 조회합니다.
+	 * 사용자 ID에 따라 쓰기 가능한 게시판 목록을 조회합니다.
 	 * VISIBLE이고 사용자의 WriteScope에 맞는 게시판만 조회합니다.
 	 *
 	 * @param userId 사용자 ID
-	 * @return 게시판 ID 목록
+	 * @return 쓰기 가능한 게시판 목록
 	 */
-	public List<String> getWritableBoardIdsByUserId(String userId) {
+	public List<Board> getWritableBoardIdsByUserId(String userId) {
 		return boardConfigQueryRepository.findWritableBoardsByUserId(userId);
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/service/implementation/BoardConfigReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/service/implementation/BoardConfigReader.java
@@ -102,4 +102,15 @@ public class BoardConfigReader {
 		Set<BoardReadScope> scopes = new HashSet<>(BoardReadScope.fromAcademicStatus(academicStatus));
 		return boardConfigQueryRepository.findBoardsByReadScopes(scopes);
 	}
+
+	/**
+	 * 사용자 ID에 따라 접근 가능한 게시판 ID 목록을 조회합니다.
+	 * VISIBLE이고 사용자의 WriteScope에 맞는 게시판만 조회합니다.
+	 *
+	 * @param userId 사용자 ID
+	 * @return 게시판 ID 목록
+	 */
+	public List<String> getWritableBoardIdsByUserId(String userId) {
+		return boardConfigQueryRepository.findWritableBoardsByUserId(userId);
+	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/service/v2/BoardService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/service/v2/BoardService.java
@@ -58,12 +58,8 @@ public class BoardService {
 			return List.of();
 		}
 
-		List<String> boardIds = boardConfigReader.getWritableBoardIdsByUserId(userId);
-		if (boardIds.isEmpty()) {
-			return List.of();
-		}
+		List<Board> boards = boardConfigReader.getWritableBoardIdsByUserId(userId);
 
-		List<Board> boards = boardReader.findAllByIdsNotDeleted(boardIds);
 		return boards.stream()
 			.map(b -> new BoardWritableItemResult(b.getId(), b.getName()))
 			.toList();

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/service/v2/BoardService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/service/v2/BoardService.java
@@ -9,6 +9,8 @@ import net.causw.app.main.domain.community.board.entity.Board;
 import net.causw.app.main.domain.community.board.service.implementation.BoardConfigReader;
 import net.causw.app.main.domain.community.board.service.implementation.BoardReader;
 import net.causw.app.main.domain.community.board.service.v2.dto.BoardReadableItemResult;
+import net.causw.app.main.domain.community.board.service.v2.dto.BoardWritableItemResult;
+import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.AcademicStatus;
 import net.causw.app.main.domain.user.account.service.implementation.UserReader;
 
 import lombok.RequiredArgsConstructor;
@@ -38,6 +40,32 @@ public class BoardService {
 		List<Board> boards = boardReader.findAllByIdsNotDeleted(boardIds);
 		return boards.stream()
 			.map(b -> new BoardReadableItemResult(b.getId(), b.getName()))
+			.toList();
+	}
+
+	/**
+	 * 특정 사용자의 쓰기 권한이 있는 게시판의 id, name 목록을 표시 순서대로 반환합니다.
+	 * 사용자의 학적 상태가 졸업 또는 재학일 경우만 해당됩니다.
+	 *
+	 * @param userId 사용자 ID
+	 * @return 읽기 가능한 게시판 목록 (id, name)
+	 */
+	public List<BoardWritableItemResult> getWritableBoards(String userId) {
+
+		AcademicStatus academicStatus = userReader.findUserById(userId).getAcademicStatus();
+		//졸업, 재학 academicStatus만 허용
+		if (!(academicStatus == AcademicStatus.ENROLLED) && !(academicStatus == AcademicStatus.GRADUATED)) {
+			return List.of();
+		}
+
+		List<String> boardIds = boardConfigReader.getWritableBoardIdsByUserId(userId);
+		if (boardIds.isEmpty()) {
+			return List.of();
+		}
+
+		List<Board> boards = boardReader.findAllByIdsNotDeleted(boardIds);
+		return boards.stream()
+			.map(b -> new BoardWritableItemResult(b.getId(), b.getName()))
 			.toList();
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/service/v2/BoardService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/service/v2/BoardService.java
@@ -48,13 +48,13 @@ public class BoardService {
 	 * 사용자의 학적 상태가 졸업 또는 재학일 경우만 해당됩니다.
 	 *
 	 * @param userId 사용자 ID
-	 * @return 읽기 가능한 게시판 목록 (id, name)
+	 * @return 쓰기 가능한 게시판 목록 (id, name)
 	 */
 	public List<BoardWritableItemResult> getWritableBoards(String userId) {
 
 		AcademicStatus academicStatus = userReader.findUserById(userId).getAcademicStatus();
 		//졸업, 재학 academicStatus만 허용
-		if (!(academicStatus == AcademicStatus.ENROLLED) && !(academicStatus == AcademicStatus.GRADUATED)) {
+		if (academicStatus != AcademicStatus.ENROLLED && academicStatus != AcademicStatus.GRADUATED) {
 			return List.of();
 		}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/service/v2/dto/BoardWritableItemResult.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/service/v2/dto/BoardWritableItemResult.java
@@ -1,0 +1,9 @@
+package net.causw.app.main.domain.community.board.service.v2.dto;
+
+/**
+ * 사용자가 쓰기 가능한 게시판 한 건 (id, name).
+ */
+public record BoardWritableItemResult(
+	String id,
+	String name) {
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/academic/enums/userAcademicRecord/AcademicStatus.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/academic/enums/userAcademicRecord/AcademicStatus.java
@@ -25,7 +25,6 @@ public enum AcademicStatus {
 	@Deprecated
 	PROFESSOR("교수"); // 교수
 
-
 	private final String value;
 
 	public static AcademicStatus fromString(String academicStatus) {

--- a/app-main/src/main/java/net/causw/app/main/domain/user/academic/enums/userAcademicRecord/AcademicStatus.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/academic/enums/userAcademicRecord/AcademicStatus.java
@@ -9,13 +9,22 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum AcademicStatus {
 	ENROLLED("재학"), // 재학
-	LEAVE_OF_ABSENCE("휴학"), // 휴학
 	GRADUATED("졸업"), // 졸업
+	UNDETERMINED("미정"), // 미정 (학적상태가 인증 필요)
+	/**
+	 * @deprecated V1에서 사용하던 status "휴학", "중퇴", "정학", "퇴학", "교수"는 V2에서 사용되지 않음
+	 */
+	@Deprecated
+	LEAVE_OF_ABSENCE("휴학"), // 휴학
+	@Deprecated
 	DROPPED_OUT("중퇴"), // 중퇴
+	@Deprecated
 	SUSPEND("정학"), // 정학
+	@Deprecated
 	EXPEL("퇴학"), // 퇴학
-	PROFESSOR("교수"), // 교수
-	UNDETERMINED("미정"); // 미정 (학적상태가 인증 필요)
+	@Deprecated
+	PROFESSOR("교수"); // 교수
+
 
 	private final String value;
 


### PR DESCRIPTION
### 🚩 관련사항
Close #1278 


### 📢 전달사항
- N+1 때문에 쿼리 한번에 너무 많은 것을 맡겨놓긴 했는데 더 좋은 방법이 있는지 봐주세요!
- 더 필터링해야 할 user 조건이 있는지 봐주세요!


### 📸 스크린샷
<img width="1220" height="926" alt="image" src="https://github.com/user-attachments/assets/6a89a2f5-9586-4f9e-91ed-b761abe3c872" />



### 📃 진행사항
- [x] 사용자의 역할/학적 상태 기반으로 WriteScope 검증 로직 구현
- [x] 사용 가능한(visible, deleted false) 상태인 게시판만 포함되도록 필터링
- [x] 응답 DTO 정의 (boardId, boardName 등)
- [x] Controller / Service / Reader 계층 구현
- [ ] 테스트 코드 작성
- [ ] API 문서(Swagger) 작성


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 