### PR TITLE
fix: swagger ui 허용되어있을때에만 SwaggerUiConfigProperties 빈 주입받도록 변경

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/core/config/swagger/SwaggerConfig.java
+++ b/app-main/src/main/java/net/causw/app/main/core/config/swagger/SwaggerConfig.java
@@ -7,6 +7,7 @@ import org.springdoc.core.properties.SwaggerUiOAuthProperties;
 import org.springdoc.core.providers.ObjectMapperProvider;
 import org.springdoc.webmvc.ui.SwaggerIndexTransformer;
 import org.springdoc.webmvc.ui.SwaggerWelcomeCommon;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -111,6 +112,7 @@ public class SwaggerConfig {
 	}
 
 	@Bean
+	@ConditionalOnProperty(name = "springdoc.swagger-ui.enabled", havingValue = "true", matchIfMissing = true)
 	public SwaggerIndexTransformer refreshBearerSwaggerIndexTransformer(
 		SwaggerUiConfigProperties swaggerUiConfig,
 		SwaggerUiOAuthProperties swaggerUiOAuthProperties,


### PR DESCRIPTION
### 🚩 관련사항

#1292

### 📢 전달사항

이번 PR은 실서버 배포 과정에서 발견된 두 가지 버그 수정과 Flyway 마이그레이션 파일명 정리를 포함합니다.

**1. prod 환경 애플리케이션 구동 실패 수정 (SwaggerConfig)**

`application-prod.yml`에서 `springdoc.swagger-ui.enabled: false`로 설정되면, springdoc이 `SwaggerUiConfigProperties` 빈을 등록하지 않습니다.
그런데 `SwaggerConfig.refreshBearerSwaggerIndexTransformer()`가 이 빈을 파라미터로 주입받으려 해서 애플리케이션 자체가 뜨지 않는 문제가 있었습니다.

`@ConditionalOnProperty(name = "springdoc.swagger-ui.enabled", havingValue = "true", matchIfMissing = true)`를 추가하여,
Swagger UI가 비활성화된 환경에서는 해당 빈을 생성하지 않도록 수정했습니다.

### 📸 스크린샷

N/A

### 📃 진행사항

- [x] prod 환경에서 Swagger UI 비활성화 시 `SwaggerUiConfigProperties` 빈 주입 실패 수정

### ⚙️ 기타사항

개발기간: 2026-05-03 ~ 2026-05-04