### PR TITLE
Feat: 유저 탈퇴 시 프로필 이미지 삭제 로직 추가

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/core/batch/BatchScheduler.java
+++ b/app-main/src/main/java/net/causw/app/main/core/batch/BatchScheduler.java
@@ -15,6 +15,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import net.causw.app.main.domain.community.ceremony.service.implementation.CeremonyWriter;
 import net.causw.app.main.domain.user.account.entity.user.User;
 import net.causw.app.main.domain.user.account.repository.user.UserRepository;
+import net.causw.app.main.domain.user.account.service.UserProfileImageService;
 import net.causw.app.main.domain.user.account.service.implementation.AdmissionWriter;
 import net.causw.app.main.domain.user.account.service.implementation.SocialAccountWriter;
 import net.causw.app.main.domain.user.account.service.implementation.UserInfoWriter;
@@ -44,6 +45,7 @@ public class BatchScheduler {
 	private final SocialAccountWriter socialAccountWriter;
 	private final UserWriter userWriter;
 	private final AdmissionWriter admissionWriter;
+	private final UserProfileImageService userProfileImageService;
 
 	@Resource(name = "cleanUpUnusedFilesJob")
 	private Job cleanUpUnusedFilesJob;
@@ -104,6 +106,7 @@ public class BatchScheduler {
 					break;
 				}
 
+				userProfileImageService.cleanupProfileImagesForBatch(withdrawnUsers);
 				userInfoWriter.deleteUserInfoByUsers(withdrawnUsers);
 				ceremonyWriter.deleteCeremonyByUsers(withdrawnUsers);
 				socialAccountWriter.deleteSocialAccountsByUsers(withdrawnUsers);

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/file/repository/UserProfileImageRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/file/repository/UserProfileImageRepository.java
@@ -18,7 +18,5 @@ public interface UserProfileImageRepository extends JpaRepository<UserProfileIma
 	@EntityGraph(attributePaths = {"uuidFile"})
 	List<UserProfileImage> findByUserIdIn(List<String> userIds);
 
-	void deleteByUserId(String userId);
-
 	void deleteById(String id);
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/file/repository/UserProfileImageRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/file/repository/UserProfileImageRepository.java
@@ -19,4 +19,6 @@ public interface UserProfileImageRepository extends JpaRepository<UserProfileIma
 	List<UserProfileImage> findByUserIdIn(List<String> userIds);
 
 	void deleteByUserId(String userId);
+
+	void deleteById(String id);
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/file/service/v2/implementation/UserProfileImageWriter.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/file/service/v2/implementation/UserProfileImageWriter.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import net.causw.app.main.domain.asset.file.entity.UuidFile;
 import net.causw.app.main.domain.asset.file.entity.joinEntity.UserProfileImage;
 import net.causw.app.main.domain.asset.file.repository.UserProfileImageRepository;
+import net.causw.app.main.domain.asset.file.service.v2.UuidFileService;
 import net.causw.app.main.domain.user.account.entity.user.User;
 
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,8 @@ import lombok.RequiredArgsConstructor;
 public class UserProfileImageWriter {
 
 	private final UserProfileImageRepository userProfileImageRepository;
+	private final UserProfileImageReader userProfileImageReader;
+	private final UuidFileService uuidFileService;
 
 	/**
 	 * 프로필 이미지를 저장합니다.

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/file/service/v2/implementation/UserProfileImageWriter.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/file/service/v2/implementation/UserProfileImageWriter.java
@@ -58,4 +58,13 @@ public class UserProfileImageWriter {
 	public void deleteByUserId(String userId) {
 		userProfileImageRepository.deleteByUserId(userId);
 	}
+
+	/**
+	 * 프로필 이미지 엔티티의 ID(PK)를 기반으로 레코드를 삭제합니다.
+	 *
+	 * @param id 프로필 이미지의 식별자 (PK)
+	 */
+	public void deleteById(String id) {
+		userProfileImageRepository.deleteById(id);
+	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/file/service/v2/implementation/UserProfileImageWriter.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/file/service/v2/implementation/UserProfileImageWriter.java
@@ -58,13 +58,4 @@ public class UserProfileImageWriter {
 	public void deleteByUserId(String userId) {
 		userProfileImageRepository.deleteByUserId(userId);
 	}
-
-	/**
-	 * 프로필 이미지 엔티티의 ID(PK)를 기반으로 레코드를 삭제합니다.
-	 *
-	 * @param id 프로필 이미지의 식별자 (PK)
-	 */
-	public void deleteById(String id) {
-		userProfileImageRepository.deleteById(id);
-	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/file/service/v2/implementation/UserProfileImageWriter.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/file/service/v2/implementation/UserProfileImageWriter.java
@@ -6,7 +6,6 @@ import org.springframework.transaction.annotation.Transactional;
 import net.causw.app.main.domain.asset.file.entity.UuidFile;
 import net.causw.app.main.domain.asset.file.entity.joinEntity.UserProfileImage;
 import net.causw.app.main.domain.asset.file.repository.UserProfileImageRepository;
-import net.causw.app.main.domain.asset.file.service.v2.UuidFileService;
 import net.causw.app.main.domain.user.account.entity.user.User;
 
 import lombok.RequiredArgsConstructor;
@@ -20,8 +19,6 @@ import lombok.RequiredArgsConstructor;
 public class UserProfileImageWriter {
 
 	private final UserProfileImageRepository userProfileImageRepository;
-	private final UserProfileImageReader userProfileImageReader;
-	private final UuidFileService uuidFileService;
 
 	/**
 	 * 프로필 이미지를 저장합니다.
@@ -51,14 +48,5 @@ public class UserProfileImageWriter {
 	 */
 	public void delete(UserProfileImage userProfileImage) {
 		userProfileImageRepository.delete(userProfileImage);
-	}
-
-	/**
-	 * 유저 ID에 해당하는 프로필 이미지를 삭제합니다.
-	 *
-	 * @param userId 유저 ID
-	 */
-	public void deleteByUserId(String userId) {
-		userProfileImageRepository.deleteByUserId(userId);
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/event/UserProfileImageDeletionEventListener.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/event/UserProfileImageDeletionEventListener.java
@@ -1,0 +1,29 @@
+package net.causw.app.main.domain.user.account.event;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import net.causw.app.main.shared.storage.v2.StorageClient;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserProfileImageDeletionEventListener {
+
+	private final StorageClient storageClient;
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void deleteProfileImageFile(UserProfileImageDeletionRequestedEvent event) {
+		try {
+			storageClient.delete(event.fileKey());
+
+			log.info("[User Withdraw] 프로필 이미지 파일 삭제 완료. fileKey: {}", event.fileKey());
+		} catch (Exception e) {
+			log.error("[User Withdraw] 프로필 이미지 파일 삭제 실패. fileKey: {}", event.fileKey(), e);
+		}
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/event/UserProfileImageDeletionRequestedEvent.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/event/UserProfileImageDeletionRequestedEvent.java
@@ -1,0 +1,10 @@
+package net.causw.app.main.domain.user.account.event;
+
+/**
+ * 탈퇴 처리 시 커스텀 프로필 이미지 파일 삭제를 요청하는 이벤트입니다.
+ *
+ * @param fileKey 삭제할 파일의 스토리지 키
+ */
+public record UserProfileImageDeletionRequestedEvent(
+	String fileKey) {
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/event/UserWithdrawalEvent.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/event/UserWithdrawalEvent.java
@@ -1,0 +1,9 @@
+package net.causw.app.main.domain.user.account.event;
+
+/**
+ * 유저 탈퇴 시 발생하는 이벤트 객체
+ * S3 삭제에 필요한 파일 키 정보를 담고 있습니다.
+ */
+public record UserWithdrawalEvent(
+	String fileKey) {
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/event/UserWithdrawalEvent.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/event/UserWithdrawalEvent.java
@@ -1,9 +1,0 @@
-package net.causw.app.main.domain.user.account.event;
-
-/**
- * 유저 탈퇴 시 발생하는 이벤트 객체
- * S3 삭제에 필요한 파일 키 정보를 담고 있습니다.
- */
-public record UserWithdrawalEvent(
-	String fileKey) {
-}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAccountService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAccountService.java
@@ -63,6 +63,7 @@ public class UserAccountService {
 	private final UserTermsAgreementReader userTermsAgreementReader;
 	private final UserTermsAgreementWriter userTermsAgreementWriter;
 	private final UserInfoReader userInfoReader;
+	private final UserProfileImageService userProfileImageService;
 
 	/**
 	 * 소셜 로그인을 통해 생성된 임시 유저(GUEST)의 추가 정보를 등록하고 회원가입 절차를 완료합니다.
@@ -268,6 +269,7 @@ public class UserAccountService {
 	 * - 사용자 상태 검증 (이미 탈퇴했거나 추방된 사용자인지 확인)
 	 * - 연동된 모든 소셜 계정의 외부 연동(Unlink) 및 리프레시 토큰 제거
 	 * - 현재 요청에 사용된 Access/Refresh 토큰 즉시 무효화
+	 * - 프로필 이미지 삭제 처리
 	 * - 사용 중인 사물함이 존재할 경우 자동 반납 처리
 	 * - 등록된 모든 FCM 푸시 토큰 제거
 	 * - 사용자 정보 소프트 딜리트(Soft Delete) 수행
@@ -306,6 +308,13 @@ public class UserAccountService {
 		// 현재 access / refresh token 무효화
 		authTokenManager.invalidateTokens(accessToken, refreshToken);
 		// 부가 처리
+		try {
+			userProfileImageService.deleteByUserId(userId);
+			log.info("[User Withdraw] 프로필 이미지 삭제 완료. userId: {}", userId);
+		} catch (Exception e) {
+			log.error("[User Withdraw] 프로필 이미지 삭제 실패. userId: {}, Error: {}", userId, e.getMessage());
+		}
+
 		lockerReader.findByUserId(user.getId())
 			.ifPresent(locker -> lockerWriter.returnLocker(locker, user));
 		fcmUtils.clearFcmTokens(user);

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAccountService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAccountService.java
@@ -299,7 +299,7 @@ public class UserAccountService {
 		socialAccounts.forEach(socialAccount -> {
 			try {
 				socialAccountUnlinkManager.unlink(socialAccount);
-			} catch (Exception e) {
+			} catch (RuntimeException e) {
 				log.error("[User Withdraw] 소셜 연동 해제 실패. SocialType: {}, UserID: {}, Error: {}",
 					socialAccount.getSocialType(), user.getId(), e.getMessage());
 			}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAccountService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAccountService.java
@@ -307,14 +307,11 @@ public class UserAccountService {
 
 		// 현재 access / refresh token 무효화
 		authTokenManager.invalidateTokens(accessToken, refreshToken);
-		// 부가 처리
-		try {
-			userProfileImageService.deleteByUserId(userId);
-			log.info("[User Withdraw] 프로필 이미지 삭제 완료. userId: {}", userId);
-		} catch (RuntimeException e) {
-			log.error("[User Withdraw] 프로필 이미지 삭제 실패. userId: {}, Error: {}", userId, e.getMessage());
-		}
 
+		// 프로필 이미지 삭제
+		userProfileImageService.prepareDeletionForWithdrawal(userId);
+
+		// 부가 처리
 		lockerReader.findByUserId(user.getId())
 			.ifPresent(locker -> lockerWriter.returnLocker(locker, user));
 		fcmUtils.clearFcmTokens(user);

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAccountService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAccountService.java
@@ -308,8 +308,8 @@ public class UserAccountService {
 		// 현재 access / refresh token 무효화
 		authTokenManager.invalidateTokens(accessToken, refreshToken);
 
-		// 프로필 이미지 삭제
-		userProfileImageService.prepareDeletionForWithdrawal(userId);
+		// 커스텀 프로필 이미지 파일 삭제 요청
+		userProfileImageService.requestProfileImageDeletionForWithdrawal(userId);
 
 		// 부가 처리
 		lockerReader.findByUserId(user.getId())

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAccountService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAccountService.java
@@ -311,7 +311,7 @@ public class UserAccountService {
 		try {
 			userProfileImageService.deleteByUserId(userId);
 			log.info("[User Withdraw] 프로필 이미지 삭제 완료. userId: {}", userId);
-		} catch (Exception e) {
+		} catch (RuntimeException e) {
 			log.error("[User Withdraw] 프로필 이미지 삭제 실패. userId: {}, Error: {}", userId, e.getMessage());
 		}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserProfileImageService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserProfileImageService.java
@@ -112,27 +112,6 @@ public class UserProfileImageService {
 	}
 
 	/**
-	 * 유저 ID를 기반으로 프로필 이미지와 관련된 모든 자산을 즉시 삭제합니다.
-	 *
-	 * @param userId 삭제할 유저의 ID
-	 */
-	@Transactional
-	public void deleteByUserId(String userId) {
-		userProfileImageReader.findByUserId(userId).ifPresent(profileImage -> {
-			UuidFile uuidFile = profileImage.getUuidFile();
-
-			userProfileImageWriter.delete(profileImage);
-
-			if (uuidFile != null) {
-				uuidFileService.deleteFile(uuidFile.getId());
-			}
-
-			log.info("[Cleanup] 프로필 이미지 자산 삭제 완료. userId: {}, fileId: {}",
-				userId, (uuidFile != null ? uuidFile.getId() : "null"));
-		});
-	}
-
-	/**
 	 * [D-Day] 탈퇴 시 실시간 처리
 	 */
 	public void prepareDeletionForWithdrawal(String userId) {

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserProfileImageService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserProfileImageService.java
@@ -116,7 +116,7 @@ public class UserProfileImageService {
 		userProfileImageReader.findByUserId(userId).ifPresent(profileImage -> {
 			UuidFile uuidFile = profileImage.getUuidFile();
 
-			userProfileImageWriter.deleteByUserId(userId);
+			userProfileImageWriter.deleteById(profileImage.getId());
 
 			if (uuidFile != null) {
 				uuidFileService.deleteFile(uuidFile.getId());

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserProfileImageService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserProfileImageService.java
@@ -1,5 +1,8 @@
 package net.causw.app.main.domain.user.account.service;
 
+import java.util.List;
+
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -13,6 +16,7 @@ import net.causw.app.main.domain.asset.file.service.v2.implementation.UserProfil
 import net.causw.app.main.domain.user.account.api.v2.dto.response.ProfileImageResponse;
 import net.causw.app.main.domain.user.account.entity.user.User;
 import net.causw.app.main.domain.user.account.enums.user.ProfileImageType;
+import net.causw.app.main.domain.user.account.event.UserWithdrawalEvent;
 import net.causw.app.main.domain.user.account.service.implementation.UserReader;
 import net.causw.app.main.domain.user.account.service.implementation.UserWriter;
 import net.causw.app.main.shared.exception.errorcode.UserErrorCode;
@@ -30,6 +34,7 @@ public class UserProfileImageService {
 	private final UuidFileService uuidFileService;
 	private final UserProfileImageReader userProfileImageReader;
 	private final UserProfileImageWriter userProfileImageWriter;
+	private final ApplicationEventPublisher applicationEventPublisher;
 
 	/**
 	 * 프로필 이미지를 기본 이미지로 변경합니다.
@@ -125,5 +130,33 @@ public class UserProfileImageService {
 			log.info("[Cleanup] 프로필 이미지 자산 삭제 완료. userId: {}, fileId: {}",
 				userId, (uuidFile != null ? uuidFile.getId() : "null"));
 		});
+	}
+
+	/**
+	 * [D-Day] 탈퇴 시 실시간 처리
+	 */
+	public void prepareDeletionForWithdrawal(String userId) {
+		userProfileImageReader.findByUserId(userId).ifPresent(profileImage -> {
+			UuidFile uuidFile = uuidFileService.findUuidFileById(profileImage.getUuidFile().getId());
+
+			// S3 Key만 추출해서 이벤트 발행 (실시간 S3 삭제 시도용)
+			applicationEventPublisher.publishEvent(new UserWithdrawalEvent(uuidFile.getFileKey()));
+		});
+	}
+
+	/**
+	 * [D+30] 배치 스케줄러가 호출하는 최종 정리 로직
+	 */
+	public void cleanupProfileImagesForBatch(List<User> users) {
+		for (User user : users) {
+			userProfileImageReader.findByUserId(user.getId()).ifPresent(profileImage -> {
+				try {
+					uuidFileService.deleteFile(profileImage.getUuidFile().getId());
+					userProfileImageWriter.delete(profileImage);
+				} catch (Exception e) {
+					log.error("[유저 정리 배치] 실패. UserID: {}", user.getId(), e);
+				}
+			});
+		}
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserProfileImageService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserProfileImageService.java
@@ -112,9 +112,14 @@ public class UserProfileImageService {
 	}
 
 	/**
-	 * [D-Day] 탈퇴 시 실시간 처리
+	 * 탈퇴 처리 시 커스텀 프로필 이미지 파일 삭제를 요청합니다.
+	 * <p>
+	 * 프로필 이미지 연결 정보와 파일 메타데이터는 D+30 배치에서 최종 삭제합니다.
+	 * </p>
+	 *
+	 * @param userId 탈퇴 처리할 유저 ID
 	 */
-	public void prepareDeletionForWithdrawal(String userId) {
+	public void requestProfileImageDeletionForWithdrawal(String userId) {
 		userProfileImageReader.findByUserId(userId).ifPresent(profileImage -> {
 			UuidFile uuidFile = uuidFileService.findUuidFileById(profileImage.getUuidFile().getId());
 
@@ -124,7 +129,13 @@ public class UserProfileImageService {
 	}
 
 	/**
-	 * [D+30] 배치 스케줄러가 호출하는 최종 정리 로직
+	 * 탈퇴 후 30일이 지난 유저들의 프로필 이미지 정보를 최종 삭제합니다.
+	 * <p>
+	 * 커스텀 프로필 이미지 파일, 파일 메타데이터, 프로필 이미지 연결 정보를 삭제합니다.
+	 * 각 유저별 삭제 실패는 로그로 기록하고 다음 유저 처리를 계속 진행합니다.
+	 * </p>
+	 *
+	 * @param users 프로필 이미지 정보를 정리할 탈퇴 후 30일 경과 유저 목록
 	 */
 	public void cleanupProfileImagesForBatch(List<User> users) {
 		for (User user : users) {

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserProfileImageService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserProfileImageService.java
@@ -18,9 +18,11 @@ import net.causw.app.main.domain.user.account.service.implementation.UserWriter;
 import net.causw.app.main.shared.exception.errorcode.UserErrorCode;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserProfileImageService {
 
 	private final UserReader userReader;
@@ -102,5 +104,26 @@ public class UserProfileImageService {
 		}
 
 		return ProfileImageResponse.of(ProfileImageType.CUSTOM, newUuidFile.getFileUrl());
+	}
+
+	/**
+	 * 유저 ID를 기반으로 프로필 이미지와 관련된 모든 자산을 즉시 삭제합니다.
+	 *
+	 * @param userId 삭제할 유저의 ID
+	 */
+	@Transactional
+	public void deleteByUserId(String userId) {
+		userProfileImageReader.findByUserId(userId).ifPresent(profileImage -> {
+			UuidFile uuidFile = profileImage.getUuidFile();
+
+			userProfileImageWriter.deleteByUserId(userId);
+
+			if (uuidFile != null) {
+				uuidFileService.deleteFile(uuidFile.getId());
+			}
+
+			log.info("[Cleanup] 프로필 이미지 자산 삭제 완료. userId: {}, fileId: {}",
+				userId, (uuidFile != null ? uuidFile.getId() : "null"));
+		});
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserProfileImageService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserProfileImageService.java
@@ -16,7 +16,7 @@ import net.causw.app.main.domain.asset.file.service.v2.implementation.UserProfil
 import net.causw.app.main.domain.user.account.api.v2.dto.response.ProfileImageResponse;
 import net.causw.app.main.domain.user.account.entity.user.User;
 import net.causw.app.main.domain.user.account.enums.user.ProfileImageType;
-import net.causw.app.main.domain.user.account.event.UserWithdrawalEvent;
+import net.causw.app.main.domain.user.account.event.UserProfileImageDeletionRequestedEvent;
 import net.causw.app.main.domain.user.account.service.implementation.UserReader;
 import net.causw.app.main.domain.user.account.service.implementation.UserWriter;
 import net.causw.app.main.shared.exception.errorcode.UserErrorCode;
@@ -121,10 +121,15 @@ public class UserProfileImageService {
 	 */
 	public void requestProfileImageDeletionForWithdrawal(String userId) {
 		userProfileImageReader.findByUserId(userId).ifPresent(profileImage -> {
-			UuidFile uuidFile = uuidFileService.findUuidFileById(profileImage.getUuidFile().getId());
+			UuidFile uuidFile = profileImage.getUuidFile();
+
+			if (uuidFile == null) {
+				log.warn("[User Withdraw] 프로필 이미지 파일 정보가 없어 삭제 요청을 건너뜁니다. userId: {}", userId);
+				return;
+			}
 
 			// S3 Key만 추출해서 이벤트 발행 (실시간 S3 삭제 시도용)
-			applicationEventPublisher.publishEvent(new UserWithdrawalEvent(uuidFile.getFileKey()));
+			applicationEventPublisher.publishEvent(new UserProfileImageDeletionRequestedEvent(uuidFile.getFileKey()));
 		});
 	}
 
@@ -141,8 +146,13 @@ public class UserProfileImageService {
 		for (User user : users) {
 			userProfileImageReader.findByUserId(user.getId()).ifPresent(profileImage -> {
 				try {
-					uuidFileService.deleteFile(profileImage.getUuidFile().getId());
+					UuidFile uuidFile = profileImage.getUuidFile();
+
 					userProfileImageWriter.delete(profileImage);
+
+					if (uuidFile != null) {
+						uuidFileService.deleteFile(uuidFile.getId());
+					}
 				} catch (Exception e) {
 					log.error("[유저 정리 배치] 실패. UserID: {}", user.getId(), e);
 				}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserProfileImageService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserProfileImageService.java
@@ -116,7 +116,7 @@ public class UserProfileImageService {
 		userProfileImageReader.findByUserId(userId).ifPresent(profileImage -> {
 			UuidFile uuidFile = profileImage.getUuidFile();
 
-			userProfileImageWriter.deleteById(profileImage.getId());
+			userProfileImageWriter.delete(profileImage);
 
 			if (uuidFile != null) {
 				uuidFileService.deleteFile(uuidFile.getId());

--- a/app-main/src/test/java/net/causw/app/main/core/security/batch/BatchSchedulerTest.java
+++ b/app-main/src/test/java/net/causw/app/main/core/security/batch/BatchSchedulerTest.java
@@ -22,6 +22,7 @@ import net.causw.app.main.core.batch.BatchScheduler;
 import net.causw.app.main.domain.community.ceremony.service.implementation.CeremonyWriter;
 import net.causw.app.main.domain.user.account.entity.user.User;
 import net.causw.app.main.domain.user.account.repository.user.UserRepository;
+import net.causw.app.main.domain.user.account.service.UserProfileImageService;
 import net.causw.app.main.domain.user.account.service.implementation.AdmissionWriter;
 import net.causw.app.main.domain.user.account.service.implementation.SocialAccountWriter;
 import net.causw.app.main.domain.user.account.service.implementation.UserInfoWriter;
@@ -55,6 +56,8 @@ public class BatchSchedulerTest {
 	private UserWriter userWriter;
 	@Mock
 	private Job cleanUpUnusedFilesJob;
+	@Mock
+	private UserProfileImageService userProfileImageService;
 
 	@Test
 	@DisplayName("유예기간 지난 탈퇴 유저가 있으면 후처리 writer들을 순서대로 호출한다")
@@ -77,6 +80,7 @@ public class BatchSchedulerTest {
 		verify(userRepository).findAllByDeletedAtIsNotNullAndDeletedAtBefore(
 			any(LocalDateTime.class),
 			any(Pageable.class));
+		verify(userProfileImageService, times(1)).cleanupProfileImagesForBatch(anyList());
 		verify(userInfoWriter).deleteUserInfoByUsers(withdrawnUsers);
 		verify(ceremonyWriter).deleteCeremonyByUsers(withdrawnUsers);
 		verify(socialAccountWriter).deleteSocialAccountsByUsers(withdrawnUsers);

--- a/app-main/src/test/java/net/causw/app/main/domain/user/account/service/UserAccountServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/user/account/service/UserAccountServiceTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -247,7 +246,7 @@ class UserAccountServiceTest {
 		assertEquals(now, result.deletedAt());
 
 		// verify
-		verify(userProfileImageService).prepareDeletionForWithdrawal(userId);
+		verify(userProfileImageService).requestProfileImageDeletionForWithdrawal(userId);
 		verify(userReader).findUserById(userId);
 		verify(socialAccountReader).findAllByUserId(userId);
 		verify(socialAccountUnlinkManager).unlink(socialAccount);
@@ -282,7 +281,7 @@ class UserAccountServiceTest {
 		// then
 		assertNotNull(result);
 		assertEquals(now, result.deletedAt());
-		verify(userProfileImageService).prepareDeletionForWithdrawal(userId);
+		verify(userProfileImageService).requestProfileImageDeletionForWithdrawal(userId);
 		verify(lockerWriter, never()).returnLocker(any(), any());
 		verify(userWriter).withdraw(user);
 	}

--- a/app-main/src/test/java/net/causw/app/main/domain/user/account/service/UserAccountServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/user/account/service/UserAccountServiceTest.java
@@ -107,6 +107,9 @@ class UserAccountServiceTest {
 	@Mock
 	private FcmUtils fcmUtils;
 
+	@Mock
+	private UserProfileImageService userProfileImageService;
+
 	private final String userId = "test-uuid";
 	private final String nickname = "푸앙";
 	private final String phoneNumber = "01012345678";
@@ -244,6 +247,7 @@ class UserAccountServiceTest {
 		assertEquals(now, result.deletedAt());
 
 		// verify
+		verify(userProfileImageService).prepareDeletionForWithdrawal(userId);
 		verify(userReader).findUserById(userId);
 		verify(socialAccountReader).findAllByUserId(userId);
 		verify(socialAccountUnlinkManager).unlink(socialAccount);
@@ -261,20 +265,24 @@ class UserAccountServiceTest {
 		// given
 		String accessToken = "access-token";
 		String refresh = "refresh-token";
+		LocalDateTime now = LocalDateTime.now();
 
 		User user = mock(User.class);
 		when(userReader.findUserById(userId)).thenReturn(user);
 		when(user.getId()).thenReturn(userId);
 		when(user.isDeleted()).thenReturn(false);
 		when(user.getState()).thenReturn(UserState.ACTIVE);
+
 		when(socialAccountReader.findAllByUserId(userId)).thenReturn(List.of());
 		when(lockerReader.findByUserId(userId)).thenReturn(Optional.empty());
+		when(user.getDeletedAt()).thenReturn(now);
 
-		when(user.getDeletedAt()).thenReturn(LocalDateTime.now());
-
-		userAccountService.withdraw(userId, accessToken, refresh);
+		UserWithdrawResponse result = userAccountService.withdraw(userId, accessToken, refresh);
 
 		// then
+		assertNotNull(result);
+		assertEquals(now, result.deletedAt());
+		verify(userProfileImageService).prepareDeletionForWithdrawal(userId);
 		verify(lockerWriter, never()).returnLocker(any(), any());
 		verify(userWriter).withdraw(user);
 	}


### PR DESCRIPTION
### 🚩 관련사항
Closes #1285 
- 회원 탈퇴: #1213 


### 📢 전달사항
1. **프로필 이미지 자산 즉시 삭제 (UserProfileImageService)**
- 탈퇴 시 UserProfileImage(Join Entity)뿐만 아니라 UuidFile(메타데이터)과 실제 물리 파일까지 즉시 삭제하여 개인정보 보호 및 스토리지 효율성을 높였습니다.
- 삭제 순서: 참조 무결성을 고려하여 Join Entity -> UuidFile -> Physical File 순으로 정리를 수행합니다.

### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [x] UserProfileImageService: 유저 ID 기반 관계 및 물리 파일 즉시 삭제 기능 구현


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 2026.05.05.