### PR TITLE
infra: CD 워크플로우 Flyway 명령에서 -Penv 파라미터 제거 (#1299)

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -36,8 +36,8 @@ jobs:
       # Flyway 마이그레이션
       - name: Run Flyway repair and migration
         run: |
-          ./gradlew :app-main:flywayRepair -Penv=dev || true
-          ./gradlew :app-main:flywayMigrate -Penv=dev
+          ./gradlew :app-main:flywayRepair || true
+          ./gradlew :app-main:flywayMigrate
 
       # Build -> jar 파일 생성
       - name: Build app-main module

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -36,8 +36,8 @@ jobs:
       # Flyway 마이그레이션
       - name: Run Flyway repair and migration
         run: |
-          ./gradlew :app-main:flywayRepair -Penv=prod || true
-          ./gradlew :app-main:flywayMigrate -Penv=prod
+          ./gradlew :app-main:flywayRepair || true
+          ./gradlew :app-main:flywayMigrate
 
       # Build -> jar 파일 생성
       - name: Build app-main


### PR DESCRIPTION
### 🚩 관련사항
Close #1299

### 📢 전달사항
CD 워크플로우에서 Flyway 마이그레이션 실행 시 사용하던 `-Penv=dev` / `-Penv=prod` 파라미터를 제거했습니다.

기존 워크플로우는 Secret에서 `.env` 파일을 생성한 뒤, Flyway 실행 시 `-Penv={환경}` 옵션을 전달하고 있었습니다. 이 옵션은 Gradle 내부적으로 `.env.dev` / `.env.prod` 파일을 탐색하도록 동작하는데, 워크플로우에서는 `.env` 파일만 생성하므로 대상 파일이 존재하지 않아 마이그레이션이 환경변수를 읽지 못하는 문제가 있었습니다.

`-Penv` 옵션을 제거하면 Gradle이 기본값인 `.env` 파일을 직접 사용하게 되어 문제가 해결됩니다.

- 영향 파일: `.github/workflows/dev-cd.yml`, `.github/workflows/main-cd.yml`

### 📸 스크린샷
N/A

### 📃 진행사항
- [x] `dev-cd.yml` Flyway 명령에서 `-Penv=dev` 파라미터 제거
- [x] `main-cd.yml` Flyway 명령에서 `-Penv=prod` 파라미터 제거

### ⚙️ 기타사항

개발기간: 2026-05-05 ~ 2026-05-05
