### PR TITLE
infra: CD 아티팩트 경로 불일치 및 SCP 전송 오류 수정

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -71,8 +71,9 @@ jobs:
           key: ${{ secrets.EC2_KEY_DEV }}
           host: ${{ secrets.EC2_HOST_DEV }}
           username: ${{ secrets.EC2_USER_DEV }}
-          source: "*.jar,.env"
+          source: "app-main/build/libs/*.jar,.env"
           target: "/home/ubuntu/app/app-main"
+          strip_components: 3
 
       # Redis Server 구동
       - name: Start redis-server

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -40,7 +40,7 @@ jobs:
           ./gradlew :app-main:flywayMigrate
 
       # Build -> jar 파일 생성
-      - name: Build app-main
+      - name: Build app-main module
         run: ./gradlew clean :app-main:bootJar -x test
 
       - name: Upload Build artifacts
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Download artifacts
+      - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           name: app-main-artifact
@@ -71,8 +71,9 @@ jobs:
           key: ${{ secrets.EC2_KEY_PROD }}
           host: ${{ secrets.EC2_HOST_PROD }}
           username: ${{ secrets.EC2_USER_PROD }}
-          source: "*.jar,.env"
+          source: "app-main/build/libs/*.jar,.env"
           target: "/home/ubuntu/app/app-main"
+          strip_components: 3
 
       # Redis Server 구동
       - name: Start redis-server


### PR DESCRIPTION
### 🚩 관련사항
#1303 

### 📢 전달사항
**[문제 상황]**
* 빌드 결과물에 `.env` 파일을 포함하면서 `upload-artifact`가 여러 경로의 파일을 취합할 때, 파일들의 공통 부모 디렉토리를 기준으로 압축 구조를 생성하는 특성이 발생했습니다.
* 이로 인해 `.jar` 파일이 아티팩트 루트가 아닌 `app-main/build/libs/` 하위 깊숙이 위치하게 되었고, 이를 찾지 못한 `scp-action`에서 전송할 파일이 없다며 에러(exit status 2)를 내보냈습니다.

**[해결 방안]**
* **효율적 경로 제어:** `cp`나 `mv` 같은 추가적인 파일 연산을 지양하고, `scp-action`의 `strip_components` 옵션을 활용했습니다.
* **경로 껍질 벗기기:** 전송 소스를 `app-main/build/libs/*.jar`로 명시하고, `strip_components: 3` 설정을 통해 EC2 타겟 디렉토리에 전송될 때 앞단의 `app-main/build/libs/` 경로를 제거하고 알맹이(`*.jar`)만 저장되도록 교정했습니다.
* **일관성 유지:** `.env` 파일은 루트에 위치하므로 경로가 없어 `strip_components`의 영향을 받지 않고 안전하게 함께 전송됩니다.


### 📸 스크린샷
x

### 📃 진행사항
- [x] `upload-artifact` 경로 지정 방식 최적화 (불필요한 루트 복사 제거)
- [x] `scp-action` 내 `strip_components: 3` 옵션 적용으로 전송 구조 교정
- [x] Dev/Main CD 워크플로우 동일 로직 적용 및 배포 테스트 완료

### ⚙️ 기타사항


개발기간: 0.5d