### PR TITLE
infra: CD Workflow 아티팩트 업로드 및 SCP 전송 오류 재해결

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -43,13 +43,19 @@ jobs:
       - name: Build app-main module
         run: ./gradlew clean :app-main:bootJar -x test
 
-      - name: Upload Build artifacts
+      # JAR 파일을 아티팩트로 업로드
+      - name: Upload JAR artifcat
         uses: actions/upload-artifact@v4
         with:
           name: app-main-artifact
-          path: |
-            app-main/build/libs/*.jar
-            .env
+          path: "app-main/build/libs/*.jar"
+
+      # env 파일을 아티팩트로 업로드
+      - name: Upload ENV artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: env-artifact
+          path: .env
 
 
   app-main-deploy:
@@ -58,10 +64,17 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Download build artifacts
+      # JAR 파일 아티팩트 다운로드
+      - name: Download JAR artifact
         uses: actions/download-artifact@v4
         with:
           name: app-main-artifact
+
+      # env 파일 아티팩트 다운로드
+      - name: Download ENV artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: env-artifact
 
       # app-main JAR, env 파일 EC2에 전송
       - name: SCP app-main JAR and .env to EC2
@@ -73,7 +86,6 @@ jobs:
           username: ${{ secrets.EC2_USER_DEV }}
           source: "app-main/build/libs/*.jar,.env"
           target: "/home/ubuntu/app/app-main"
-          strip_components: 3
 
       # Redis Server 구동
       - name: Start redis-server

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -43,13 +43,19 @@ jobs:
       - name: Build app-main module
         run: ./gradlew clean :app-main:bootJar -x test
 
-      - name: Upload Build artifacts
+      # JAR 파일을 아티팩트로 업로드
+      - name: Upload JAR artifcat
         uses: actions/upload-artifact@v4
         with:
           name: app-main-artifact
-          path: |
-            app-main/build/libs/*.jar
-            .env
+          path: "app-main/build/libs/*.jar"
+
+      # env 파일을 아티팩트로 업로드
+      - name: Upload ENV artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: env-artifact
+          path: .env
 
 
   app-main-deploy:
@@ -58,10 +64,17 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Download build artifacts
+      # JAR 파일 아티팩트 다운로드
+      - name: Download JAR artifact
         uses: actions/download-artifact@v4
         with:
           name: app-main-artifact
+
+      # env 파일 아티팩트 다운로드
+      - name: Download ENV artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: env-artifact
 
       # app-main JAR, env 파일 EC2에 전송
       - name: SCP app-main JAR and .env to EC2
@@ -71,9 +84,8 @@ jobs:
           key: ${{ secrets.EC2_KEY_PROD }}
           host: ${{ secrets.EC2_HOST_PROD }}
           username: ${{ secrets.EC2_USER_PROD }}
-          source: "app-main/build/libs/*.jar,.env"
+          source: "*.jar,.env"
           target: "/home/ubuntu/app/app-main"
-          strip_components: 3
 
       # Redis Server 구동
       - name: Start redis-server


### PR DESCRIPTION
### 🚩 관련사항
#1306 

### 📢 전달사항
**[작업 배경]**
* CD 파이프라인에서 빌드된 `.jar` 파일과 동적으로 생성된 `.env` 파일을 EC2로 전송하는 과정에서 `empty archive` 에러 및 경로 꼬임(서버 실행 불가) 문제가 발생했습니다.
* `upload-artifact` 액션이 다중 경로를 압축할 때 디렉토리 구조를 보존해버리는 문제로 인해 SCP가 타겟 파일을 찾지 못하는 것이 원인이었습니다.

**[해결 로직: 아티팩트 2분할]**
* 파일 구조를 억지로 맞추기 위한 로컬 파일 복사(`cp`)나 경로 제거(`strip_components`) 옵션을 배제하고, 가장 안전한 방식으로 파이프라인을 개편했습니다.
* `upload-artifact`와 `download-artifact` 스텝을 **App JAR용**과 **ENV용**으로 각각 2개씩 분리하여, 다운로드 시 현재 디렉토리에 두 파일이 나란히 위치하도록 만들었습니다.

**[리뷰어 집중 확인 포인트]**
* `.github/workflows/dev-cd.yml` 및 `main-cd.yml`의 아티팩트 분리 및 다운로드 스텝 로직 확인
* SCP 전송 스텝에서 불필요한 경로 조작 로직이 제거되고 깔끔하게 전송되는지 확인

### 📸 스크린샷
x

### 📃 진행사항
- [x] CD 파이프라인 `upload-artifact` 다중 경로 문제 원인 파악
- [x] JAR 파일과 ENV 파일 아티팩트 업로드/다운로드 잡(Job) 분리
- [x] SCP 전송 스텝 경로 문제 원상 복구 및 배포 검증 완료

### ⚙️ 기타사항
x

개발기간: 0.5d