### PR TITLE
infra: cd workflow 아티팩트 폴더 업로드 방식으로 수정

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -43,19 +43,19 @@ jobs:
       - name: Build app-main module
         run: ./gradlew clean :app-main:bootJar -x test
 
-      # JAR 파일을 아티팩트로 업로드
-      - name: Upload JAR artifcat
+      # 배포 아티팩트 한 폴더로 모으기
+      - name: Prepare Deployment Artifacts
+        run: |
+          mkdir deploy-artifacts
+          cp app-main/build/libs/*.jar deploy-artifacts/
+          cp .env deploy-artifacts/
+
+      # 폴더를 아티팩트로 업로드
+      - name: Upload Deployment Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: app-main-artifact
-          path: "app-main/build/libs/*.jar"
-
-      # env 파일을 아티팩트로 업로드
-      - name: Upload ENV artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: env-artifact
-          path: .env
+          path: deploy-artifacts
 
 
   app-main-deploy:
@@ -64,17 +64,10 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      # JAR 파일 아티팩트 다운로드
-      - name: Download JAR artifact
+      - name: Download Deployment Artifacts
         uses: actions/download-artifact@v4
         with:
           name: app-main-artifact
-
-      # env 파일 아티팩트 다운로드
-      - name: Download ENV artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: env-artifact
 
       # app-main JAR, env 파일 EC2에 전송
       - name: SCP app-main JAR and .env to EC2
@@ -84,7 +77,7 @@ jobs:
           key: ${{ secrets.EC2_KEY_DEV }}
           host: ${{ secrets.EC2_HOST_DEV }}
           username: ${{ secrets.EC2_USER_DEV }}
-          source: "app-main/build/libs/*.jar,.env"
+          source: "*.jar,.env"
           target: "/home/ubuntu/app/app-main"
 
       # Redis Server 구동

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -43,19 +43,19 @@ jobs:
       - name: Build app-main module
         run: ./gradlew clean :app-main:bootJar -x test
 
-      # JAR 파일을 아티팩트로 업로드
-      - name: Upload JAR artifcat
+      # 배포 아티팩트 한 폴더로 모으기
+      - name: Prepare Deployment Artifacts
+        run: |
+          mkdir deploy-artifacts
+          cp app-main/build/libs/*.jar deploy-artifacts/
+          cp .env deploy-artifacts/
+
+      # 폴더를 아티팩트로 업로드
+      - name: Upload Deployment Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: app-main-artifact
-          path: "app-main/build/libs/*.jar"
-
-      # env 파일을 아티팩트로 업로드
-      - name: Upload ENV artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: env-artifact
-          path: .env
+          path: deploy-artifacts
 
 
   app-main-deploy:
@@ -64,17 +64,10 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      # JAR 파일 아티팩트 다운로드
-      - name: Download JAR artifact
+      - name: Download Deployment Artifacts
         uses: actions/download-artifact@v4
         with:
           name: app-main-artifact
-
-      # env 파일 아티팩트 다운로드
-      - name: Download ENV artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: env-artifact
 
       # app-main JAR, env 파일 EC2에 전송
       - name: SCP app-main JAR and .env to EC2


### PR DESCRIPTION
### 🚩 관련사항
#1308 


### 📢 전달사항
**CD 배포 아티팩트 패키징 구조 개선 (Staging 폴더 도입)**
- **문제점:** 기존 CD 파이프라인에서 `.env`와 `.jar`를 각각 분리하여 업로드할 때, 워크스페이스 루트의 단일 숨김 파일(`.env`)이 제대로 업로드되지 않아 다운로드 스텝에서 에러가 발생했습니다.
- **해결책:** 배포에 필요한 파일들을 하나의 임시 폴더(`deploy-artifacts/`)로 복사하여 모은 뒤, 이 폴더를 통째로 하나의 아티팩트로 업로드하도록 구조를 변경했습니다.
- **효과:** `upload-artifact`의 경로 꼬임 및 숨김 파일 누락 버그를 완벽하게 회피했으며, SCP 전송 스텝에서 경로 깎기 등의 위험한 옵션 없이 직관적이고 안정적인 배포가 보장됩니다.


### 📸 스크린샷
x


### 📃 진행사항
- [x] 배포용 임시 폴더(`deploy-artifacts`) 생성 및 파일 취합 스텝 추가
- [x] 아티팩트 업로드/다운로드 스텝을 단일 폴더 기준으로 통합


### ⚙️ 기타사항

개발기간: 0.5d