### PR TITLE
infra: .env 파일 직접 생성을 통해 배포 보안 강화 (#1310)

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -48,7 +48,6 @@ jobs:
         run: |
           mkdir deploy-artifacts
           cp app-main/build/libs/*.jar deploy-artifacts/
-          cp .env deploy-artifacts/
 
       # 폴더를 아티팩트로 업로드
       - name: Upload Deployment Artifacts
@@ -69,16 +68,30 @@ jobs:
         with:
           name: app-main-artifact
 
-      # app-main JAR, env 파일 EC2에 전송
-      - name: SCP app-main JAR and .env to EC2
+      # app-main JAR EC2에 전송
+      - name: SCP app-main JAR to EC2
         if: github.actor != 'nektos/act'
         uses: appleboy/scp-action@master
         with:
           key: ${{ secrets.EC2_KEY_DEV }}
           host: ${{ secrets.EC2_HOST_DEV }}
           username: ${{ secrets.EC2_USER_DEV }}
-          source: "*.jar,.env"
+          source: "*.jar"
           target: "/home/ubuntu/app/app-main"
+
+      # .env를 Secret에서 직접 EC2에 생성
+      - name: Write .env to EC2
+        if: github.actor != 'nektos/act'
+        uses: appleboy/ssh-action@master
+        env:
+          ENV_CONTENT: ${{ secrets.ENV_DEV }}
+        with:
+          key: ${{ secrets.EC2_KEY_DEV }}
+          host: ${{ secrets.EC2_HOST_DEV }}
+          username: ${{ secrets.EC2_USER_DEV }}
+          envs: ENV_CONTENT
+          script: |
+            printf '%s' "$ENV_CONTENT" > /home/ubuntu/app/app-main/.env
 
       # Redis Server 구동
       - name: Start redis-server
@@ -104,6 +117,7 @@ jobs:
             sleep 15
             APP_MAIN_JAR=$(ls -t /home/ubuntu/app/app-main/*.jar | head -n 1)
             sudo mkdir -p /var/log/spring-boot/app-main
+            cd /home/ubuntu/app/app-main
             sudo nohup java -DLOG_DIR=/var/log/spring-boot/app-main -jar "$APP_MAIN_JAR" 1>/dev/null 2>&1 &
 
 

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -48,7 +48,6 @@ jobs:
         run: |
           mkdir deploy-artifacts
           cp app-main/build/libs/*.jar deploy-artifacts/
-          cp .env deploy-artifacts/
 
       # 폴더를 아티팩트로 업로드
       - name: Upload Deployment Artifacts
@@ -69,16 +68,30 @@ jobs:
         with:
           name: app-main-artifact
 
-      # app-main JAR, env 파일 EC2에 전송
-      - name: SCP app-main JAR and .env to EC2
+      # app-main JAR EC2에 전송
+      - name: SCP app-main JAR to EC2
         if: github.actor != 'nektos/act'
         uses: appleboy/scp-action@master
         with:
           key: ${{ secrets.EC2_KEY_PROD }}
           host: ${{ secrets.EC2_HOST_PROD }}
           username: ${{ secrets.EC2_USER_PROD }}
-          source: "*.jar,.env"
+          source: "*.jar"
           target: "/home/ubuntu/app/app-main"
+
+      # .env를 Secret에서 직접 EC2에 생성
+      - name: Write .env to EC2
+        if: github.actor != 'nektos/act'
+        uses: appleboy/ssh-action@master
+        env:
+          ENV_CONTENT: ${{ secrets.ENV_PROD }}
+        with:
+          key: ${{ secrets.EC2_KEY_PROD }}
+          host: ${{ secrets.EC2_HOST_PROD }}
+          username: ${{ secrets.EC2_USER_PROD }}
+          envs: ENV_CONTENT
+          script: |
+            printf '%s' "$ENV_CONTENT" > /home/ubuntu/app/app-main/.env
 
       # Redis Server 구동
       - name: Start redis-server
@@ -104,6 +117,7 @@ jobs:
             sleep 15
             APP_MAIN_JAR=$(ls -t /home/ubuntu/app/app-main/*.jar | head -n 1)
             sudo mkdir -p /var/log/spring-boot/app-main
+            cd /home/ubuntu/app/app-main
             sudo nohup java -DLOG_DIR=/var/log/spring-boot/app-main -jar "$APP_MAIN_JAR" 1>/dev/null 2>&1 &
 
 


### PR DESCRIPTION
### 🚩 관련사항

Close #1310

### 📢 전달사항

CD 워크플로우(`dev-cd.yml`, `main-cd.yml`)에서 `.env` 파일이 EC2에 제대로 전달되지 않는 문제와, 전달되더라도 `spring-dotenv`가 파일을 탐색하지 못하는 문제를 함께 수정했습니다.

**문제 1 — `.env` EC2 전달 실패**

기존에는 `.env`를 artifact에 포함시킨 후 `appleboy/scp-action`의 `source: "*.jar,.env"` 패턴으로 전송했는데, scp-action이 dotfile(`.`으로 시작하는 파일)을 glob 처리 시 누락하는 문제로 `.env`가 실제로 EC2에 전달되지 않았습니다.

이를 해결하기 위해 `.env` 전달 방식을 artifact → SSH 직접 주입으로 변경했습니다. GitHub Secret(`ENV_DEV` / `ENV_PROD`)을 `appleboy/ssh-action`의 `envs`로 넘겨 EC2에서 `printf '%s' "$ENV_CONTENT" > /home/ubuntu/app/app-main/.env`로 직접 생성합니다. 매 배포마다 overwrite되므로 Secret 변경 후 재배포 시 즉시 반영됩니다.

**문제 2 — spring-dotenv working directory 불일치**

앱에서 사용하는 `spring-dotenv`(`me.paulschwarz:spring-dotenv:4.0.0`)는 JVM의 `user.dir`(프로세스 실행 시 working directory)를 기준으로 `.env`를 탐색합니다. 기존 코드는 `cd` 없이 `nohup java -jar`를 실행해 SSH 세션의 기본 디렉토리(`/home/ubuntu`)에서 실행되었으므로, `.env`가 있는 `/home/ubuntu/app/app-main`을 탐색하지 못했습니다.

`nohup java -jar` 실행 전 `cd /home/ubuntu/app/app-main`을 추가해 working directory를 맞췄습니다.

### 📸 스크린샷

N/A

### 📃 진행사항

- [x] `dev-cd.yml` — artifact에서 `.env` 제거
- [x] `dev-cd.yml` — SCP source를 `*.jar`만으로 변경
- [x] `dev-cd.yml` — SSH로 Secret → EC2 `.env` 직접 생성 step 추가
- [x] `dev-cd.yml` — java 실행 전 `cd /home/ubuntu/app/app-main` 추가
- [x] `main-cd.yml` — 위 변경사항 동일하게 적용

### ⚙️ 기타사항

개발기간: 2026-05-05 ~ 2026-05-05
