### PR TITLE
Fix: 익명 코멘트 프로필 이미지 응답 수정

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/community/comment/api/v2/dto/response/ChildCommentResponseDto.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/comment/api/v2/dto/response/ChildCommentResponseDto.java
@@ -22,14 +22,14 @@ public record ChildCommentResponseDto(
 
 	Integer writerAdmissionYear,
 
-	@Schema(description = "작성자 프로필 이미지 정보 (익명인 경우 null)") ProfileImageDto writerProfileImage,
+	@Schema(description = "작성자 프로필 이미지 정보 (익명/차단/추방/탈퇴 시 GHOST)") ProfileImageDto writerProfileImage,
 
 	Boolean updatable,
 	Boolean deletable,
 
 	@Schema(description = "차단된 컨텐츠 여부", example = "False") Boolean isBlocked,
 
-	@Schema(description = "익명글 여부", example = "False") Boolean isAnonymous,
+	@Schema(description = "익명 대댓글 여부", example = "False") Boolean isAnonymous,
 
 	@Schema(description = "대댓글 작성자 여부", example = "False") Boolean isOwner,
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/comment/api/v2/dto/response/CommentResponseDto.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/comment/api/v2/dto/response/CommentResponseDto.java
@@ -24,14 +24,14 @@ public record CommentResponseDto(
 
 	@Schema(description = "작성자의 입학연도", example = "2022") Integer writerAdmissionYear,
 
-	@Schema(description = "작성자 프로필 이미지 정보 (익명인 경우 null)") ProfileImageDto writerProfileImage,
+	@Schema(description = "작성자 프로필 이미지 정보 (익명/차단/추방/탈퇴 시 GHOST)") ProfileImageDto writerProfileImage,
 
 	Boolean updatable,
 	Boolean deletable,
 
 	@Schema(description = "차단된 컨텐츠 여부", example = "False") Boolean isBlocked,
 
-	@Schema(description = "익명글 여부", example = "False") Boolean isAnonymous,
+	@Schema(description = "익명 댓글 여부", example = "False") Boolean isAnonymous,
 
 	@Schema(description = "댓글 작성자 여부", example = "False") Boolean isOwner,
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/comment/service/dto/CommentAuthorInfo.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/comment/service/dto/CommentAuthorInfo.java
@@ -19,7 +19,7 @@ import net.causw.global.constant.StaticValue;
  * @param writerNickname        작성자 닉네임 (익명 댓글이면 {@code null})
  * @param displayWriterNickname 화면에 표시되는 닉네임 (익명·탈퇴 시 고정 문자열로 치환)
  * @param writerAdmissionYear   작성자 입학연도 (익명 댓글이면 {@code null})
- * @param writerProfileImage    작성자 프로필 이미지 정보 (익명 댓글이면 {@code null}, 차단/추방/탈퇴 시 GHOST)
+	 * @param writerProfileImage    작성자 프로필 이미지 정보 (익명/차단/추방/탈퇴 시 GHOST)
  * @param updatable             현재 조회 유저가 이 댓글을 수정할 수 있는지 여부
  * @param deletable             현재 조회 유저가 이 댓글을 삭제할 수 있는지 여부
  * @param isBlocked             작성자가 현재 조회 유저에 의해 차단됐는지 여부
@@ -70,8 +70,11 @@ public record CommentAuthorInfo(
 		String writerName = null;
 		String writerNickname = null;
 		Integer writerAdmissionYear = null;
-		ProfileImageDto writerProfileImage = null;
-		if (!Boolean.TRUE.equals(isAnonymous) && writer != null) {
+		ProfileImageDto writerProfileImage;
+		if (Boolean.TRUE.equals(isAnonymous) || writer == null) {
+			// 익명 댓글이거나 작성자가 없는 경우 → GHOST 타입, url null
+			writerProfileImage = ProfileImageDto.anonymous();
+		} else {
 			writerName = writer.getName();
 			writerNickname = writer.getNickname();
 			writerAdmissionYear = writer.getAdmissionYear();

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/response/PostListResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/response/PostListResponse.java
@@ -25,7 +25,7 @@ public record PostListResponse(
 		@Schema(description = "크롤링 게시글 여부") boolean isCrawled,
 		@Schema(description = "작성자 닉네임 (익명인 경우 '익명')") String writerNickname,
 
-		@Schema(description = "작성자 프로필 이미지 정보 (익명인 경우 null)") ProfileImageDto writerProfileImage,
+		@Schema(description = "작성자 프로필 이미지 정보 (익명/차단/추방/탈퇴 시 GHOST)") ProfileImageDto writerProfileImage,
 
 		@Schema(description = "생성일시") LocalDateTime createdAt,
 		@Schema(description = "수정일시") LocalDateTime updatedAt,

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/response/PostResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/response/PostResponse.java
@@ -16,7 +16,7 @@ public record PostResponse(
 
 	@Schema(description = "표시될 게시글 작성자 닉네임", example = "[닉네임/비활성 유저/익명]") String displayWriterNickname,
 
-	@Schema(description = "게시글 작성자의 프로필 이미지 정보 (익명인 경우 null)") ProfileImageDto writerProfileImage,
+	@Schema(description = "게시글 작성자의 프로필 이미지 정보 (익명/차단/추방/탈퇴 시 GHOST)") ProfileImageDto writerProfileImage,
 
 	@Schema(description = "첨부파일", example = "첨부파일 url 작성") List<String> fileUrlList,
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/dto/PostListResult.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/dto/PostListResult.java
@@ -24,7 +24,7 @@ public record PostListResult(
 		boolean isDeleted,
 		boolean isCrawled,
 		String writerNickname, // 익명인 경우 "익명", 아니면 실제 닉네임
-		ProfileImageDto writerProfileImage, // 익명인 경우 null
+		ProfileImageDto writerProfileImage, // 익명/차단/추방/탈퇴 시 GHOST
 		LocalDateTime createdAt,
 		LocalDateTime updatedAt,
 		List<String> postImageUrls,


### PR DESCRIPTION
### 🚩 관련사항
Closes: #1296 


### 📢 전달사항
익명게시글과 익명댓글의 프로필 이미지 응답형식이 일치하지 않았던 문제를 수정했습니다.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [x] 응답 수정


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 