### PR TITLE
infra: CD Workflow 간소화 및 아티팩트 저장기간 설정

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -43,18 +43,11 @@ jobs:
       - name: Build app-main module
         run: ./gradlew clean :app-main:bootJar -x test
 
-      # 배포 아티팩트 한 폴더로 모으기
-      - name: Prepare Deployment Artifacts
-        run: |
-          mkdir deploy-artifacts
-          cp app-main/build/libs/*.jar deploy-artifacts/
-
-      # 폴더를 아티팩트로 업로드
-      - name: Upload Deployment Artifacts
+      - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: app-main-artifact
-          path: deploy-artifacts
+          path: "app-main/build/libs/*.jar"
 
 
   app-main-deploy:

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Download Deployment Artifacts
+      - name: Download Build Artifacts
         uses: actions/download-artifact@v4
         with:
           name: app-main-artifact

--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           name: app-main-artifact
           path: "app-main/build/libs/*.jar"
+          retention-days: 7
 
 
   app-main-deploy:

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -43,18 +43,11 @@ jobs:
       - name: Build app-main module
         run: ./gradlew clean :app-main:bootJar -x test
 
-      # 배포 아티팩트 한 폴더로 모으기
-      - name: Prepare Deployment Artifacts
-        run: |
-          mkdir deploy-artifacts
-          cp app-main/build/libs/*.jar deploy-artifacts/
-
-      # 폴더를 아티팩트로 업로드
-      - name: Upload Deployment Artifacts
+      - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: app-main-artifact
-          path: deploy-artifacts
+          path: "app-main/build/libs/*.jar"
 
 
   app-main-deploy:

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Download Deployment Artifacts
+      - name: Download Build Artifacts
         uses: actions/download-artifact@v4
         with:
           name: app-main-artifact

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           name: app-main-artifact
           path: "app-main/build/libs/*.jar"
+          retention-days: 7
 
 
   app-main-deploy:


### PR DESCRIPTION
### 🚩 관련사항
#1314


### 📢 전달사항
**[작업 배경 및 목적]**
* 이전 PR에서 `.env` 파일을 GitHub Secret을 통해 EC2로 직접 주입하는 방식으로 개선함에 따라, 빌드 단계에서 `.env`와 `.jar`를 하나의 폴더로 묶어 아티팩트로 만들던 과정(Staging)이 더 이상 필요해지지 않았습니다.
* 이에 따라 불필요한 파일 복사 스텝을 제거하여 CD 워크플로우를 간소화하고, 빌드 결과물이 무분별하게 쌓이는 것을 방지하고자 아티팩트 보관 기한을 설정했습니다.

**[주요 변경 사항]**
1. **워크플로우 스텝 간소화:** 
   - `mkdir deploy-artifacts` 및 `cp` 명령어를 사용하는 파일 취합 단계를 제거했습니다.
   - `upload-artifact` 스텝에서 바로 빌드된 JAR 파일만 업로드하도록 구조를 단순화했습니다.
   - YAML 파싱 오류를 방지하기 위해 와일드카드(`*`)가 포함된 경로를 따옴표(`"app-main/build/libs/*.jar"`)로 명확히 감쌌습니다.
2. **아티팩트 보관 기한(`retention-days`) 설정:**
   - 깃허브 액션에 쌓이는 빌드 결과물(약 150MB)을 효율적으로 관리하고 보안을 챙기기 위해, 아티팩트 보관 기한을 기본값(90일)에서 **7일**로 단축했습니다.
   - 7일은 배포 후 장애 발생 시 디버깅 및 롤백을 수행하기에 충분한 기간입니다.


### 📸 스크린샷
x


### 📃 진행사항
- [x] 불필요한 배포 파일 취합(Staging 폴더) 스텝 제거
- [x] `upload-artifact` 경로 패턴 지정 및 따옴표(`""`) 적용
- [x] 스토리지 관리를 위한 `retention-days: 7` 속성 추가
- [x] `dev-cd.yml` 및 `main-cd.yml` 동일 사양 적용


### ⚙️ 기타사항

개발기간: 2026.05.06
