### PR TITLE
Fix: 접근 가능한 게시판이 없을 때 전체 게시글이 노출되는 권한 우회 수정

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/repository/query/PostQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/repository/query/PostQueryRepository.java
@@ -96,6 +96,12 @@ public class PostQueryRepository {
 		String cursorId,
 		int size,
 		String keyword) {
+		// 빈 리스트가 전달된 경우 "조회 가능한 게시판이 한 개도 없음"을 의미하므로 즉시 빈 결과 반환.
+		// (null은 docstring 계약상 "전체 게시판"이므로 별도 처리하지 않음)
+		if (boardIds != null && boardIds.isEmpty()) {
+			return new SliceImpl<>(List.of(), Pageable.ofSize(size), false);
+		}
+
 		QPost post = QPost.post;
 		QUser writer = new QUser("writer");
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/PostService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/PostService.java
@@ -181,6 +181,11 @@ public class PostService {
 			boardIds = boardConfigReader.getAccessibleBoardIdsByAcademicStatus(viewer.getAcademicStatus());
 		}
 
+		// 접근 가능한 게시판이 없으면 게시글 조회를 건너뛰고 빈 결과를 반환
+		if (boardIds.isEmpty()) {
+			return PostListResult.of(List.of(), null);
+		}
+
 		// 게시글 조회 (Slice 사용)
 		Slice<PostCursorResult> slice = postReader.findPostsWithCursor(
 			boardIds,

--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/v1/CrawledToPostTransferService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/v1/CrawledToPostTransferService.java
@@ -90,12 +90,12 @@ public class CrawledToPostTransferService {
 			existingPost.update(title, contentHtml, existingPost.getForm(), existingPost.getPostAttachImageList());
 			postRepository.save(existingPost);
 		} else {
-			// 새 Post 생성
+			// 새 Post 생성 (크롤링 게시판은 익명 게시판이 아니므로 isAnonymous=false)
 			Post newPost = Post.of(
 				title,
 				contentHtml,
 				adminUser,
-				true,
+				false,
 				false,
 				board,
 				null,

--- a/app-main/src/test/java/net/causw/app/main/domain/community/post/service/v2/PostServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/community/post/service/v2/PostServiceTest.java
@@ -843,6 +843,28 @@ public class PostServiceTest {
 			verify(boardConfigReader, times(1)).getAccessibleBoardIdsByAcademicStatus(AcademicStatus.ENROLLED);
 		}
 
+		@DisplayName("접근 가능한 게시판이 없으면 게시글 조회 없이 빈 결과 반환")
+		@Test
+		void getPosts_shouldReturnEmpty_whenNoAccessibleBoards() {
+			// given
+			PostListQuery query = PostListQuery.of(viewer, null, null, 20, null);
+
+			given(boardConfigReader.getAccessibleBoardIdsByAcademicStatus(AcademicStatus.ENROLLED))
+				.willReturn(List.of());
+
+			// when
+			PostListResult result = postService.getPosts(query);
+
+			// then
+			assertAll(
+				() -> assertThat(result).isNotNull(),
+				() -> assertThat(result.posts()).isEmpty(),
+				() -> assertThat(result.nextCursor()).isNull());
+
+			verify(boardConfigReader, times(1)).getAccessibleBoardIdsByAcademicStatus(AcademicStatus.ENROLLED);
+			verify(postReader, never()).findPostsWithCursor(anyList(), any(), any(), anyInt(), any());
+		}
+
 		@DisplayName("숨겨진 게시판은 관리자만 조회 가능")
 		@Test
 		void getPosts_shouldFail_whenBoardIsHidden() {


### PR DESCRIPTION
### 🚩 관련사항
#1277

### 📢 전달사항
`GET /api/v2/posts` 호출 시 발견된 두 가지 결함을 함께 수정했습니다. 두 이슈는 발생 원인이 서로 다르므로 커밋을 분리했습니다.

#### 1. `boardIds` 미지정 시 권한 우회 (전체 게시글 노출)
- 증상: `boardIds` 파라미터 없이 호출했을 때, 사용자가 접근 권한이 없는(혹은 모든 게시판이 `HIDDEN`) 게시판의 글까지 피드에 노출.
- 원인: `PostQueryRepository.findPostsWithCursor`의 게시판 조건 분기가 **빈 리스트** 입력에 대해 JavaDoc 계약(`null=전체, []=조회 안함`)과 달리 `NO_CONDITION`으로 떨어져 전체 게시글이 조회되었습니다.
  ```java
  BooleanExpression boardCondition = NO_CONDITION;
  if (boardIds != null && !boardIds.isEmpty()) {
      boardCondition = post.board.id.in(boardIds);
  }
  ```
- `PostService.getPosts()`는 `boardIds`가 비어있는 경우(`getAccessibleBoardIdsByAcademicStatus`가 빈 리스트를 반환) 그대로 저장소까지 흘려보내, "접근 가능한 게시판 없음" 신호가 "모든 게시판 허용"으로 오역되었습니다.
- 수정:
  - 1차 방어선 — `PostQueryRepository.findPostsWithCursor`: `boardIds`가 non-null + empty이면 즉시 빈 `Slice` 반환 (docstring 계약과 코드 일치).
  - 2차 방어선 — `PostService.getPosts`: 접근 가능한 게시판이 없으면 DB 호출 없이 빈 결과 short-circuit.
  - 회귀 방지를 위해 `PostServiceTest`에 `getPosts_shouldReturnEmpty_whenNoAccessibleBoards` 케이스 추가.

#### 2. 크롤링 게시글이 익명 게시글로 노출되는 문제
- 증상: 크롤링 게시판(`소프트웨어학부 학부 공지`) 글이 응답에서 `isAnonymous=true`로 내려오고, 작성자 정보가 익명 처리됨.
- 원인: `CrawledToPostTransferService.processUpdatedNotice()`에서 새 게시글 생성 시 `Post.of(...)`의 4번째 인자(`isAnonymous`)가 `true`로 잘못 전달되어 모든 신규 크롤링 게시글이 익명으로 저장되었습니다. 크롤링 게시판은 익명 게시판이 아닙니다.
- 수정: `isAnonymous` 인자를 `false`로 변경.

#### 집중 리뷰 포인트
- `PostQueryRepository.findPostsWithCursor`의 빈 리스트 short-circuit이 다른 호출 경로의 동작에 영향을 주지 않는지(현재 `null`은 여전히 "전체"로 동작).
- `PostService.getPosts`의 short-circuit 위치가 키워드/커서 등 다른 입력과 무관하게 일관된 빈 응답을 보장하는지.
- 크롤링 게시글의 `isAnonymous=false` 변경이 알림/매핑 흐름에 의도치 않은 영향을 주지 않는지.

### 📸 스크린샷
N/A (백엔드 동작 변경)

### 📃 진행사항
- [x] `PostQueryRepository.findPostsWithCursor` 빈 `boardIds` 처리 수정
- [x] `PostService.getPosts` 접근 가능한 게시판이 없을 때 short-circuit
- [x] `PostServiceTest`에 회귀 방지 테스트 추가
- [x] `CrawledToPostTransferService` 크롤링 게시글의 `isAnonymous` 인자를 `false`로 수정
- [x] `PostServiceTest`, `CrawledToPostTransferServiceTest` 통과 확인
- [ ] 기존에 `isAnonymous=true`로 잘못 적재된 크롤링 게시글 데이터 보정(예: Flyway 마이그레이션) — 운영 데이터 영향 범위 검토가 필요해 본 PR 범위에서 제외하고, 별도 운영 작업으로 진행 예정

### ⚙️ 기타사항
- 동작 호환성: `findPostsWithCursor`에서 `null`은 여전히 "전체 게시판"으로 동작하여 기존 호출자에 영향 없음. 변경되는 것은 빈 리스트 케이스(이전: 전체 조회 → 이후: 빈 결과)뿐입니다.
- 본 PR은 신규 생성되는 크롤링 게시글이 정상화되도록 하는 것까지 책임 범위로 한정합니다.

개발기간: 2025/05/07