### PR TITLE
feat: 경조사 신청 시 관리자에게 알림 전송

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/service/CeremonyService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/service/CeremonyService.java
@@ -5,9 +5,9 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;

--- a/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/service/CeremonyService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/service/CeremonyService.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
@@ -26,6 +27,7 @@ import net.causw.app.main.domain.community.ceremony.service.implementation.Cerem
 import net.causw.app.main.domain.community.ceremony.service.mapper.CeremonyCreateMapper;
 import net.causw.app.main.domain.community.ceremony.service.mapper.CeremonyMapper;
 import net.causw.app.main.domain.community.ceremony.util.CeremonyValidator;
+import net.causw.app.main.domain.notification.notification.event.CeremonyAdminNotificationEvent;
 import net.causw.app.main.domain.user.account.entity.user.User;
 import net.causw.app.main.shared.exception.errorcode.CeremonyErrorCode;
 import net.causw.app.main.shared.pageable.PageableFactory;
@@ -45,6 +47,7 @@ public class CeremonyService {
 	private final CeremonyMapper ceremonyMapper;
 	private final CeremonyValidator ceremonyValidator;
 	private final PageableFactory pageableFactory;
+	private final ApplicationEventPublisher applicationEventPublisher;
 
 	@Transactional
 	public CeremonyDetailResult createCeremony(
@@ -64,6 +67,10 @@ public class CeremonyService {
 		Ceremony ceremony = ceremonyCreateMapper.toCeremony(user, command, targetAdmissionYears,
 			uuidFileList);
 		ceremonyCreator.save(ceremony);
+
+		// 신청 후 관리자에게 알림 전송
+		applicationEventPublisher.publishEvent(new CeremonyAdminNotificationEvent(ceremony.getId()));
+
 		return ceremonyMapper.toDetailResult(ceremony);
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/event/CeremonyAdminNotificationEvent.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/event/CeremonyAdminNotificationEvent.java
@@ -1,0 +1,4 @@
+package net.causw.app.main.domain.notification.notification.event;
+
+public record CeremonyAdminNotificationEvent(String ceremonyId) {
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/CeremonyAdminNotificationHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/CeremonyAdminNotificationHandler.java
@@ -40,10 +40,10 @@ public class CeremonyAdminNotificationHandler {
 	/**
 	 * 경조사 신청 관리자 알림 이벤트 핸들러.
 	 * <p>
-	 * 일반 유저가 경조사를 신청하면, 졸업 상태(GRADUATED)의 관리자에게
+	 * 일반 유저가 경조사를 신청하면, 신청자와 동일한 {@link AcademicStatus}의 관리자에게
 	 * 푸시 알림과 서비스 알림을 발송합니다.
 	 * <ul>
-	 *   <li>대상: {@link AcademicStatus#GRADUATED} 상태의 관리자</li>
+	 *   <li>대상: 신청자 학적 상태와 일치하는 관리자</li>
 	 *   <li>필터: 서비스 알림 설정 ON ({@link UserNotificationSettingKey#SERVICE_NOTICE_ENABLED})</li>
 	 *   <li>처리: 푸시 전송 + 서비스 알림 로그 저장 ({@link NoticeType#SYSTEM})</li>
 	 * </ul>
@@ -57,8 +57,9 @@ public class CeremonyAdminNotificationHandler {
 		Ceremony ceremony = ceremonyReader.findById(event.ceremonyId())
 			.orElseThrow(CeremonyErrorCode.CEREMONY_NOT_FOUND::toBaseException);
 
-		// 졸업 상태(GRADUATED) 관리자를 알림 대상으로 선정
-		List<User> adminTargets = userReader.findAdminsByAcademicStatus(AcademicStatus.GRADUATED);
+		// 신청자와 동일 학적 상태인 관리자를 알림 대상으로 선정
+		List<User> adminTargets = userReader.findAdminsByAcademicStatus(
+			ceremony.getUser().getAcademicStatus());
 		if (adminTargets.isEmpty()) {
 			return;
 		}

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/CeremonyAdminNotificationHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/CeremonyAdminNotificationHandler.java
@@ -57,17 +57,23 @@ public class CeremonyAdminNotificationHandler {
 		Ceremony ceremony = ceremonyReader.findById(event.ceremonyId())
 			.orElseThrow(CeremonyErrorCode.CEREMONY_NOT_FOUND::toBaseException);
 
-		// 신청자와 동일 학적 상태인 관리자를 알림 대상으로 선정
-		List<User> adminTargets = userReader.findAdminsByAcademicStatus(
+		// 신청자와 동일 학적 상태의 관리자 조회
+		List<User> admins = userReader.findAdminsByAcademicStatus(
 			ceremony.getUser().getAcademicStatus());
-		if (adminTargets.isEmpty()) {
+		if (admins.isEmpty()) {
 			return;
 		}
 
-		// 관리자별 알림 설정 일괄 조회
-		List<String> adminIds = adminTargets.stream().map(User::getId).toList();
+		// 관리자별 알림 설정을 읽고, 알림 설정이 활성화된 대상만 필터링
+		List<String> adminIds = admins.stream().map(User::getId).toList();
 		Map<String, UserNotificationSettingMap> settingMaps = notificationSettingReader
 			.findSettingMapByUserIds(adminIds);
+		List<User> adminTargets = admins.stream()
+			.filter(admin -> settingMaps.get(admin.getId()).get(UserNotificationSettingKey.SERVICE_NOTICE_ENABLED))
+			.toList();
+		if (adminTargets.isEmpty()) {
+			return;
+		}
 
 		String title = "경조사 신청";
 		String body = String.format("%s님이 경조사를 신청했습니다.", ceremony.getUser().getName());
@@ -77,12 +83,8 @@ public class CeremonyAdminNotificationHandler {
 		Notification notification = notificationWriter.save(
 			Notification.of(ceremony.getUser(), body, body, NoticeType.SYSTEM, ceremony.getId(), null));
 
-		// 서비스 알림 설정이 활성화된 관리자에게만 발송
-		adminTargets.stream()
-			.filter(admin -> settingMaps.get(admin.getId()).get(UserNotificationSettingKey.SERVICE_NOTICE_ENABLED))
-			.forEach(admin -> {
-				notificationPushSender.sendToUser(admin, title, body);
-				notificationWriter.saveLog(admin, notification);
-			});
+		// 필터링된 관리자 대상에게 발송
+		notificationPushSender.sendToUsers(adminTargets, title, body);
+		notificationWriter.saveLogs(adminTargets, notification);
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/CeremonyAdminNotificationHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/CeremonyAdminNotificationHandler.java
@@ -66,7 +66,8 @@ public class CeremonyAdminNotificationHandler {
 
 		// 관리자별 알림 설정 일괄 조회
 		List<String> adminIds = adminTargets.stream().map(User::getId).toList();
-		Map<String, UserNotificationSettingMap> settingMaps = notificationSettingReader.findSettingMapByUserIds(adminIds);
+		Map<String, UserNotificationSettingMap> settingMaps = notificationSettingReader
+			.findSettingMapByUserIds(adminIds);
 
 		String title = "경조사 신청";
 		String body = String.format("%s님이 경조사를 신청했습니다.", ceremony.getUser().getName());

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/CeremonyAdminNotificationHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/CeremonyAdminNotificationHandler.java
@@ -1,0 +1,85 @@
+package net.causw.app.main.domain.notification.notification.service.handler;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import net.causw.app.main.domain.community.ceremony.entity.Ceremony;
+import net.causw.app.main.domain.community.ceremony.service.implementation.CeremonyReader;
+import net.causw.app.main.domain.notification.notification.entity.Notification;
+import net.causw.app.main.domain.notification.notification.enums.NoticeType;
+import net.causw.app.main.domain.notification.notification.enums.UserNotificationSettingKey;
+import net.causw.app.main.domain.notification.notification.event.CeremonyAdminNotificationEvent;
+import net.causw.app.main.domain.notification.notification.service.dto.UserNotificationSettingMap;
+import net.causw.app.main.domain.notification.notification.service.implementation.NotificationPushSender;
+import net.causw.app.main.domain.notification.notification.service.implementation.NotificationSettingReader;
+import net.causw.app.main.domain.notification.notification.service.implementation.NotificationWriter;
+import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.AcademicStatus;
+import net.causw.app.main.domain.user.account.entity.user.User;
+import net.causw.app.main.domain.user.account.service.implementation.UserReader;
+import net.causw.app.main.shared.exception.errorcode.CeremonyErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CeremonyAdminNotificationHandler {
+
+	private final CeremonyReader ceremonyReader;
+	private final UserReader userReader;
+	private final NotificationWriter notificationWriter;
+	private final NotificationPushSender notificationPushSender;
+	private final NotificationSettingReader notificationSettingReader;
+
+	/**
+	 * 경조사 신청 관리자 알림 이벤트 핸들러.
+	 * <p>
+	 * 일반 유저가 경조사를 신청하면, 졸업 상태(GRADUATED)의 관리자(동문회장)에게
+	 * 푸시 알림과 서비스 알림을 발송합니다.
+	 * <ul>
+	 *   <li>대상: {@link AcademicStatus#GRADUATED} 상태의 관리자</li>
+	 *   <li>처리: 푸시 전송 + 서비스 알림 로그 저장</li>
+	 * </ul>
+	 *
+	 * @param event 경조사 관리자 알림 이벤트
+	 */
+	@Async("asyncExecutor")
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void handle(CeremonyAdminNotificationEvent event) {
+		Ceremony ceremony = ceremonyReader.findById(event.ceremonyId())
+			.orElseThrow(CeremonyErrorCode.CEREMONY_NOT_FOUND::toBaseException);
+
+		// 졸업 상태의 관리자(동문회장)를 알림 대상으로 선정
+		List<User> adminTargets = userReader.findAdminsByAcademicStatus(AcademicStatus.GRADUATED);
+		if (adminTargets.isEmpty()) {
+			return;
+		}
+
+		// 관리자별 알림 설정 일괄 조회
+		List<String> adminIds = adminTargets.stream().map(User::getId).toList();
+		Map<String, UserNotificationSettingMap> settingMaps = notificationSettingReader.findSettingMapByUserIds(adminIds);
+
+		String title = "경조사 신청";
+		String body = String.format("%s님이 경조사를 신청했습니다.", ceremony.getUser().getName());
+
+		// 서비스 알림함 저장용 Notification 엔티티 생성
+		// UI에서 정보를 표시할 때 body 대신 title을 사용하므로, 바디와 같은 내용을 title에 저장
+		Notification notification = notificationWriter.save(
+			Notification.of(ceremony.getUser(), body, body, NoticeType.CEREMONY_V2, ceremony.getId(), null));
+
+		// 서비스 알림 설정이 활성화된 관리자에게만 발송
+		adminTargets.stream()
+			.filter(admin -> settingMaps.get(admin.getId()).get(UserNotificationSettingKey.SERVICE_NOTICE_ENABLED))
+			.forEach(admin -> {
+				notificationPushSender.sendToUser(admin, title, body);
+				notificationWriter.saveLog(admin, notification);
+			});
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/CeremonyAdminNotificationHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/CeremonyAdminNotificationHandler.java
@@ -40,11 +40,12 @@ public class CeremonyAdminNotificationHandler {
 	/**
 	 * 경조사 신청 관리자 알림 이벤트 핸들러.
 	 * <p>
-	 * 일반 유저가 경조사를 신청하면, 졸업 상태(GRADUATED)의 관리자(동문회장)에게
+	 * 일반 유저가 경조사를 신청하면, 졸업 상태(GRADUATED)의 관리자에게
 	 * 푸시 알림과 서비스 알림을 발송합니다.
 	 * <ul>
 	 *   <li>대상: {@link AcademicStatus#GRADUATED} 상태의 관리자</li>
-	 *   <li>처리: 푸시 전송 + 서비스 알림 로그 저장</li>
+	 *   <li>필터: 서비스 알림 설정 ON ({@link UserNotificationSettingKey#SERVICE_NOTICE_ENABLED})</li>
+	 *   <li>처리: 푸시 전송 + 서비스 알림 로그 저장 ({@link NoticeType#SYSTEM})</li>
 	 * </ul>
 	 *
 	 * @param event 경조사 관리자 알림 이벤트
@@ -56,7 +57,7 @@ public class CeremonyAdminNotificationHandler {
 		Ceremony ceremony = ceremonyReader.findById(event.ceremonyId())
 			.orElseThrow(CeremonyErrorCode.CEREMONY_NOT_FOUND::toBaseException);
 
-		// 졸업 상태의 관리자(동문회장)를 알림 대상으로 선정
+		// 졸업 상태(GRADUATED) 관리자를 알림 대상으로 선정
 		List<User> adminTargets = userReader.findAdminsByAcademicStatus(AcademicStatus.GRADUATED);
 		if (adminTargets.isEmpty()) {
 			return;
@@ -72,7 +73,7 @@ public class CeremonyAdminNotificationHandler {
 		// 서비스 알림함 저장용 Notification 엔티티 생성
 		// UI에서 정보를 표시할 때 body 대신 title을 사용하므로, 바디와 같은 내용을 title에 저장
 		Notification notification = notificationWriter.save(
-			Notification.of(ceremony.getUser(), body, body, NoticeType.CEREMONY_V2, ceremony.getId(), null));
+			Notification.of(ceremony.getUser(), body, body, NoticeType.SYSTEM, ceremony.getId(), null));
 
 		// 서비스 알림 설정이 활성화된 관리자에게만 발송
 		adminTargets.stream()

--- a/app-main/src/test/java/net/causw/app/main/domain/notification/notification/service/handler/CeremonyAdminNotificationHandlerTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/notification/notification/service/handler/CeremonyAdminNotificationHandlerTest.java
@@ -1,0 +1,194 @@
+package net.causw.app.main.domain.notification.notification.service.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import net.causw.app.main.domain.community.ceremony.entity.Ceremony;
+import net.causw.app.main.domain.community.ceremony.service.implementation.CeremonyReader;
+import net.causw.app.main.domain.notification.notification.entity.Notification;
+import net.causw.app.main.domain.notification.notification.enums.NoticeType;
+import net.causw.app.main.domain.notification.notification.enums.UserNotificationSettingKey;
+import net.causw.app.main.domain.notification.notification.event.CeremonyAdminNotificationEvent;
+import net.causw.app.main.domain.notification.notification.service.dto.UserNotificationSettingMap;
+import net.causw.app.main.domain.notification.notification.service.implementation.NotificationPushSender;
+import net.causw.app.main.domain.notification.notification.service.implementation.NotificationSettingReader;
+import net.causw.app.main.domain.notification.notification.service.implementation.NotificationWriter;
+import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.AcademicStatus;
+import net.causw.app.main.domain.user.account.entity.user.User;
+import net.causw.app.main.domain.user.account.service.implementation.UserReader;
+import net.causw.app.main.shared.exception.BaseRunTimeV2Exception;
+
+@ExtendWith(MockitoExtension.class)
+class CeremonyAdminNotificationHandlerTest {
+
+	@InjectMocks
+	private CeremonyAdminNotificationHandler handler;
+
+	@Mock
+	private CeremonyReader ceremonyReader;
+	@Mock
+	private UserReader userReader;
+	@Mock
+	private NotificationWriter notificationWriter;
+	@Mock
+	private NotificationPushSender notificationPushSender;
+	@Mock
+	private NotificationSettingReader notificationSettingReader;
+
+	@Nested
+	@DisplayName("경조사 신청 관리자 알림 (handle)")
+	class HandleTest {
+
+		@Test
+		@DisplayName("성공: 신청자 학적과 동일한 관리자 중 서비스 알림 ON인 대상에게 발송")
+		void givenAdminsWithNotificationOn_whenHandle_thenSendToAdmins() {
+			// given
+			User applicant = mock(User.class);
+			given(applicant.getName()).willReturn("김신청");
+			given(applicant.getAcademicStatus()).willReturn(AcademicStatus.ENROLLED);
+
+			Ceremony ceremony = mock(Ceremony.class);
+			given(ceremony.getId()).willReturn("ceremonyId");
+			given(ceremony.getUser()).willReturn(applicant);
+
+			User admin1 = userWithId("adminId1");
+			User admin2 = userWithId("adminId2");
+			List<User> admins = List.of(admin1, admin2);
+
+			Notification savedNotification = mock(Notification.class);
+
+			given(ceremonyReader.findById("ceremonyId")).willReturn(Optional.of(ceremony));
+			given(userReader.findAdminsByAcademicStatus(AcademicStatus.ENROLLED)).willReturn(admins);
+			given(notificationSettingReader.findSettingMapByUserIds(List.of("adminId1", "adminId2")))
+				.willReturn(Map.of(
+					"adminId1", settingMapAllOn(),
+					"adminId2", settingMapAllOn()));
+			given(notificationWriter.save(any())).willReturn(savedNotification);
+
+			// when
+			handler.handle(new CeremonyAdminNotificationEvent("ceremonyId"));
+
+			// then
+			verify(userReader).findAdminsByAcademicStatus(AcademicStatus.ENROLLED);
+
+			ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
+			verify(notificationWriter).save(notificationCaptor.capture());
+			Notification captured = notificationCaptor.getValue();
+			assertThat(captured.getNoticeType()).isEqualTo(NoticeType.SYSTEM);
+			assertThat(captured.getTargetId()).isEqualTo("ceremonyId");
+
+			verify(notificationPushSender).sendToUser(eq(admin1), eq("경조사 신청"), eq("김신청님이 경조사를 신청했습니다."));
+			verify(notificationPushSender).sendToUser(eq(admin2), eq("경조사 신청"), eq("김신청님이 경조사를 신청했습니다."));
+			verify(notificationWriter).saveLog(admin1, savedNotification);
+			verify(notificationWriter).saveLog(admin2, savedNotification);
+		}
+
+		@Test
+		@DisplayName("스킵: 신청자 학적에 맞는 관리자가 없으면 저장·발송하지 않음")
+		void givenNoAdmins_whenHandle_thenSkip() {
+			// given
+			User applicant = mock(User.class);
+			given(applicant.getAcademicStatus()).willReturn(AcademicStatus.GRADUATED);
+
+			Ceremony ceremony = mock(Ceremony.class);
+			given(ceremony.getUser()).willReturn(applicant);
+
+			given(ceremonyReader.findById("ceremonyId")).willReturn(Optional.of(ceremony));
+			given(userReader.findAdminsByAcademicStatus(AcademicStatus.GRADUATED)).willReturn(List.of());
+
+			// when
+			handler.handle(new CeremonyAdminNotificationEvent("ceremonyId"));
+
+			// then
+			verify(notificationWriter, never()).save(any());
+			verify(notificationPushSender, never()).sendToUser(any(), any(), any());
+		}
+
+		@Test
+		@DisplayName("스킵: 서비스 알림 설정 OFF인 관리자는 푸시·로그 제외")
+		void givenAdminWithNotificationOff_whenHandle_thenExcludeAdmin() {
+			// given
+			User applicant = mock(User.class);
+			given(applicant.getName()).willReturn("이신청");
+			given(applicant.getAcademicStatus()).willReturn(AcademicStatus.GRADUATED);
+
+			Ceremony ceremony = mock(Ceremony.class);
+			given(ceremony.getId()).willReturn("ceremonyId");
+			given(ceremony.getUser()).willReturn(applicant);
+
+			User adminOn = userWithId("adminOnId");
+			User adminOff = userWithId("adminOffId");
+			List<User> admins = List.of(adminOn, adminOff);
+
+			Notification savedNotification = mock(Notification.class);
+
+			given(ceremonyReader.findById("ceremonyId")).willReturn(Optional.of(ceremony));
+			given(userReader.findAdminsByAcademicStatus(AcademicStatus.GRADUATED)).willReturn(admins);
+			given(notificationSettingReader.findSettingMapByUserIds(List.of("adminOnId", "adminOffId")))
+				.willReturn(Map.of(
+					"adminOnId", settingMapAllOn(),
+					"adminOffId", settingMapWith(UserNotificationSettingKey.SERVICE_NOTICE_ENABLED, false)));
+			given(notificationWriter.save(any())).willReturn(savedNotification);
+
+			// when
+			handler.handle(new CeremonyAdminNotificationEvent("ceremonyId"));
+
+			// then
+			verify(notificationPushSender).sendToUser(eq(adminOn), any(), any());
+			verify(notificationPushSender, never()).sendToUser(eq(adminOff), any(), any());
+			verify(notificationWriter).saveLog(adminOn, savedNotification);
+			verify(notificationWriter, never()).saveLog(eq(adminOff), any());
+		}
+
+		@Test
+		@DisplayName("실패: 경조사가 없으면 NOT_FOUND 예외")
+		void givenNotFoundCeremony_whenHandle_thenThrowException() {
+			// given
+			given(ceremonyReader.findById("missingId")).willReturn(Optional.empty());
+
+			// when
+			assertThatThrownBy(() -> handler.handle(new CeremonyAdminNotificationEvent("missingId")))
+				.isInstanceOf(BaseRunTimeV2Exception.class);
+
+			// then
+			verify(userReader, never()).findAdminsByAcademicStatus(any());
+		}
+	}
+
+	// ─────────────────────────────────────────────────
+	// 헬퍼
+	// ─────────────────────────────────────────────────
+
+	private User userWithId(String id) {
+		User user = mock(User.class);
+		given(user.getId()).willReturn(id);
+		return user;
+	}
+
+	private UserNotificationSettingMap settingMapAllOn() {
+		return UserNotificationSettingMap.ofFull(Map.of());
+	}
+
+	private UserNotificationSettingMap settingMapWith(UserNotificationSettingKey key, boolean value) {
+		return UserNotificationSettingMap.ofFull(Map.of(key, value));
+	}
+}

--- a/app-main/src/test/java/net/causw/app/main/domain/notification/notification/service/handler/CeremonyAdminNotificationHandlerTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/notification/notification/service/handler/CeremonyAdminNotificationHandlerTest.java
@@ -96,10 +96,11 @@ class CeremonyAdminNotificationHandlerTest {
 			assertThat(captured.getNoticeType()).isEqualTo(NoticeType.SYSTEM);
 			assertThat(captured.getTargetId()).isEqualTo("ceremonyId");
 
-			verify(notificationPushSender).sendToUser(eq(admin1), eq("경조사 신청"), eq("김신청님이 경조사를 신청했습니다."));
-			verify(notificationPushSender).sendToUser(eq(admin2), eq("경조사 신청"), eq("김신청님이 경조사를 신청했습니다."));
-			verify(notificationWriter).saveLog(admin1, savedNotification);
-			verify(notificationWriter).saveLog(admin2, savedNotification);
+			verify(notificationPushSender).sendToUsers(
+				eq(List.of(admin1, admin2)),
+				eq("경조사 신청"),
+				eq("김신청님이 경조사를 신청했습니다."));
+			verify(notificationWriter).saveLogs(eq(List.of(admin1, admin2)), eq(savedNotification));
 		}
 
 		@Test
@@ -120,7 +121,7 @@ class CeremonyAdminNotificationHandlerTest {
 
 			// then
 			verify(notificationWriter, never()).save(any());
-			verify(notificationPushSender, never()).sendToUser(any(), any(), any());
+			verify(notificationPushSender, never()).sendToUsers(any(), any(), any());
 		}
 
 		@Test
@@ -153,10 +154,8 @@ class CeremonyAdminNotificationHandlerTest {
 			handler.handle(new CeremonyAdminNotificationEvent("ceremonyId"));
 
 			// then
-			verify(notificationPushSender).sendToUser(eq(adminOn), any(), any());
-			verify(notificationPushSender, never()).sendToUser(eq(adminOff), any(), any());
-			verify(notificationWriter).saveLog(adminOn, savedNotification);
-			verify(notificationWriter, never()).saveLog(eq(adminOff), any());
+			verify(notificationPushSender).sendToUsers(eq(List.of(adminOn)), any(), any());
+			verify(notificationWriter).saveLogs(eq(List.of(adminOn)), eq(savedNotification));
 		}
 
 		@Test


### PR DESCRIPTION
### 🚩 관련사항
close #1269 


### 📢 전달사항
일반 사용자가 경조사를 신청하면, 관리자 역할의 유저에게 푸시 알림 및 서비스 알림을 전송하는 기능을 구현했습니다.

수신 대상: 신청자 학적과 같은 관리자
메시지
- 제목: "경조사 신청"
- 본문: "{신청자 이름}님이 경조사를 신청했습니다."


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [x] CeremonyAdminNotificationEvent record 클래스 생성 (ceremonyId 포함)
- [x] CeremonyAdminNotificationHandler 핸들러 구현
- [x] 단위 테스트 작성 (CeremonyAdminNotificationHandlerTest)

### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 