### PR TITLE
fix: 회원가입 시 atk, rtk 도 같이 return 하도록 수정

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/user/auth/service/AuthService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/auth/service/AuthService.java
@@ -170,9 +170,11 @@ public class AuthService {
 			.toList();
 		userTermsAgreementWriter.saveAll(newAgreements);
 
+		AuthTokenPair tokens = authTokenManager.issueTokens(savedUser, null);
+
 		// 신규 가입 유저는 커스텀 프로필 이미지가 없으므로 null 전달
-		return AuthResult.of(null, savedUser.getName(), savedUser.getEmail(),
-			ProfileImageDto.from(savedUser, null), null,
+		return AuthResult.of(tokens.accessToken(), savedUser.getName(), savedUser.getEmail(),
+			ProfileImageDto.from(savedUser, null), tokens.refreshToken(),
 			savedUser.isGuest(), true, savedUser.isAcademicCertified(),
 			savedUser.getAcademicStatus());
 	}

--- a/app-main/src/test/java/net/causw/app/main/domain/user/auth/service/v2/AuthServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/user/auth/service/v2/AuthServiceTest.java
@@ -168,6 +168,7 @@ public class AuthServiceTest {
 			given(termsReader.findAllById(anyList())).willReturn(List.of(serviceTerms, privacyTerms));
 			given(emailVerificationReader.findLatestByEmailAndStatus(EMAIL, VerificationStatus.VERIFIED))
 				.willReturn(verifiedEmail);
+			given(authTokenManager.issueTokens(any(User.class), eq(null))).willReturn(authTokenPair);
 
 			// when
 			AuthResult result = authService.registerEmailUser(registerDto);
@@ -175,8 +176,8 @@ public class AuthServiceTest {
 			// then
 			assertThat(result).isNotNull();
 			assertThat(result.email()).isEqualTo(EMAIL);
-			assertThat(result.accessToken()).isNull();
-			assertThat(result.refreshToken()).isNull();
+			assertThat(result.accessToken()).isEqualTo(ACCESS_TOKEN);
+			assertThat(result.refreshToken()).isEqualTo(REFRESH_TOKEN);
 
 			// verify
 			verify(droppedUserIdentifierValidator).validateEmail(EMAIL);


### PR DESCRIPTION
### 🚩 관련사항
Close #1325

### 📢 전달사항
회원가입(`POST /api/v2/auth/signup`) 성공 후 응답에 `accessToken`과 `refreshToken`이 `null`로 내려오는 버그를 수정했습니다.

`AuthService.registerEmailUser()`에서 사용자 저장 및 약관 동의 처리 후 `authTokenManager.issueTokens()`를 호출하지 않고 `AuthResult.of()`에 바로 `null`을 전달하고 있었습니다. 이로 인해 회원가입 직후 클라이언트가 유효한 토큰 없이 인증 API를 호출하게 되는 문제가 발생했습니다.



### 📸 스크린샷
N/A

### 📃 진행사항
- [x] 회원가입 완료 시 `authTokenManager.issueTokens()` 호출 추가
- [x] `AuthResult.of()` 반환값에 `accessToken`, `refreshToken` 포함

### ⚙️ 기타사항

개발기간: 2026-05-13 ~ 2026-05-13