### PR TITLE
refactor: AcademicStatus 미사용 값 deprecated 처리

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/campus/circle/service/v1/CircleService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/campus/circle/service/v1/CircleService.java
@@ -1097,8 +1097,6 @@ public class CircleService {
 
 		if (form.getIsAllowedEnrolled())
 			allowedAcademicStatus.add(AcademicStatus.ENROLLED);
-		if (form.getIsAllowedLeaveOfAbsence())
-			allowedAcademicStatus.add(AcademicStatus.LEAVE_OF_ABSENCE);
 		if (form.getIsAllowedGraduation())
 			allowedAcademicStatus.add(AcademicStatus.GRADUATED);
 
@@ -1132,20 +1130,6 @@ public class CircleService {
 							ErrorCode.NOT_ALLOWED_TO_REPLY_FORM,
 							MessageUtil.NOT_ALLOWED_TO_REPLY_FORM);
 					}
-				}
-			}
-
-			if (allowedAcademicStatus.contains(AcademicStatus.LEAVE_OF_ABSENCE)
-				&& writer.getAcademicStatus().equals(AcademicStatus.LEAVE_OF_ABSENCE)) {
-				EnumSet<RegisteredSemester> allowedRegisteredSemester = form.getLeaveOfAbsenceRegisteredSemester();
-				if (!allowedRegisteredSemester
-					.stream()
-					.map(RegisteredSemester::getSemester)
-					.collect(Collectors.toSet())
-					.contains(writer.getCurrentCompletedSemester())) {
-					throw new BadRequestException(
-						ErrorCode.NOT_ALLOWED_TO_REPLY_FORM,
-						MessageUtil.NOT_ALLOWED_TO_REPLY_FORM);
 				}
 			}
 		}

--- a/app-main/src/main/java/net/causw/app/main/domain/campus/semester/service/v1/SemesterService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/campus/semester/service/v1/SemesterService.java
@@ -90,11 +90,9 @@ public class SemesterService {
 		semesterRepository.save(priorSemester);
 		semesterRepository.save(newSemester);
 
-		// 신학기 시작으로 학적상태가 재학 또는 휴학인 학생들을 미결정으로 변경
+		// 신학기 시작으로 학적상태가 재학인 학생들을 미결정으로 변경
 		List<User> userList = userRepository.findByAcademicStatusInOrAcademicStatusIsNull(
-			List.of(
-				AcademicStatus.ENROLLED,
-				AcademicStatus.LEAVE_OF_ABSENCE))
+			List.of(AcademicStatus.ENROLLED))
 			.stream()
 			.peek(
 				(u) -> u.setAcademicStatus(AcademicStatus.UNDETERMINED))

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/entity/BoardReadScope.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/entity/BoardReadScope.java
@@ -30,11 +30,7 @@ public enum BoardReadScope {
 	 */
 	public List<AcademicStatus> getTargetAcademicStatuses() {
 		return switch (this) {
-			case ENROLLED -> List.of(
-				AcademicStatus.ENROLLED,
-				AcademicStatus.LEAVE_OF_ABSENCE,
-				AcademicStatus.SUSPEND,
-				AcademicStatus.PROFESSOR);
+			case ENROLLED -> List.of(AcademicStatus.ENROLLED);
 			case GRADUATED -> List.of(AcademicStatus.GRADUATED);
 			case BOTH -> List.of(); // 빈 리스트 = 모든 학적 허용
 		};
@@ -51,7 +47,7 @@ public enum BoardReadScope {
 			return List.of(BOTH);
 		}
 		return switch (academicStatus) {
-			case ENROLLED, LEAVE_OF_ABSENCE, SUSPEND, PROFESSOR -> List.of(BOTH, ENROLLED);
+			case ENROLLED -> List.of(BOTH, ENROLLED);
 			case GRADUATED -> List.of(BOTH, GRADUATED);
 			default -> List.of(BOTH);
 		};

--- a/app-main/src/main/java/net/causw/app/main/domain/community/form/service/v1/FormService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/form/service/v1/FormService.java
@@ -358,8 +358,6 @@ public class FormService {
 
 		if (form.getIsAllowedEnrolled())
 			allowedAcademicStatus.add(AcademicStatus.ENROLLED);
-		if (form.getIsAllowedLeaveOfAbsence())
-			allowedAcademicStatus.add(AcademicStatus.LEAVE_OF_ABSENCE);
 		if (form.getIsAllowedGraduation())
 			allowedAcademicStatus.add(AcademicStatus.GRADUATED);
 
@@ -393,20 +391,6 @@ public class FormService {
 							ErrorCode.NOT_ALLOWED_TO_REPLY_FORM,
 							MessageUtil.NOT_ALLOWED_TO_REPLY_FORM);
 					}
-				}
-			}
-
-			if (allowedAcademicStatus.contains(AcademicStatus.LEAVE_OF_ABSENCE)
-				&& writer.getAcademicStatus().equals(AcademicStatus.LEAVE_OF_ABSENCE)) {
-				EnumSet<RegisteredSemester> allowedRegisteredSemester = form.getLeaveOfAbsenceRegisteredSemester();
-				if (!allowedRegisteredSemester
-					.stream()
-					.map(RegisteredSemester::getSemester)
-					.collect(Collectors.toSet())
-					.contains(writer.getCurrentCompletedSemester())) {
-					throw new BadRequestException(
-						ErrorCode.NOT_ALLOWED_TO_REPLY_FORM,
-						MessageUtil.NOT_ALLOWED_TO_REPLY_FORM);
 				}
 			}
 		}

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/util/PostValidator.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/util/PostValidator.java
@@ -129,10 +129,7 @@ public class PostValidator {
 
 		// ENROLLED인 경우 재학생만 가능
 		if (readScope == BoardReadScope.ENROLLED) {
-			if (academicStatus == AcademicStatus.ENROLLED
-				|| academicStatus == AcademicStatus.LEAVE_OF_ABSENCE
-				|| academicStatus == AcademicStatus.SUSPEND
-				|| academicStatus == AcademicStatus.PROFESSOR) {
+			if (academicStatus == AcademicStatus.ENROLLED) {
 				return;
 			}
 			throw BoardErrorCode.BOARD_FORBIDDEN.toBaseException();

--- a/app-main/src/main/java/net/causw/app/main/domain/user/academic/enums/userAcademicRecord/AcademicStatus.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/academic/enums/userAcademicRecord/AcademicStatus.java
@@ -32,8 +32,7 @@ public enum AcademicStatus {
 	private final String value;
 	@Deprecated
 	private static final EnumSet<AcademicStatus> DEPRECATED_SET = EnumSet.of(
-		LEAVE_OF_ABSENCE, DROPPED_OUT, SUSPEND, EXPEL, PROFESSOR
-	);
+		LEAVE_OF_ABSENCE, DROPPED_OUT, SUSPEND, EXPEL, PROFESSOR);
 
 	public static AcademicStatus fromString(String academicStatus) {
 		if (academicStatus == null || academicStatus.isEmpty()) {

--- a/app-main/src/main/java/net/causw/app/main/domain/user/academic/enums/userAcademicRecord/AcademicStatus.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/academic/enums/userAcademicRecord/AcademicStatus.java
@@ -40,7 +40,8 @@ public enum AcademicStatus {
 		for (AcademicStatus status : AcademicStatus.values()) {
 			if (status.name().equalsIgnoreCase(academicStatus)) {
 				if (DEPRECATED_SET.contains(status)) {
-					throw UserErrorCode.INVALID_ACADEMIC_STATUS.toBaseException();
+					log.warn("Deprecated academic status '{}' received", academicStatus);
+					return ENROLLED;
 				}
 				return status;
 			}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/academic/enums/userAcademicRecord/AcademicStatus.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/academic/enums/userAcademicRecord/AcademicStatus.java
@@ -30,7 +30,6 @@ public enum AcademicStatus {
 	PROFESSOR("교수"); // 교수
 
 	private final String value;
-	@Deprecated
 	private static final EnumSet<AcademicStatus> DEPRECATED_SET = EnumSet.of(
 		LEAVE_OF_ABSENCE, DROPPED_OUT, SUSPEND, EXPEL, PROFESSOR);
 

--- a/app-main/src/main/java/net/causw/app/main/domain/user/academic/enums/userAcademicRecord/AcademicStatus.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/academic/enums/userAcademicRecord/AcademicStatus.java
@@ -1,10 +1,14 @@
 package net.causw.app.main.domain.user.academic.enums.userAcademicRecord;
 
+import java.util.EnumSet;
+
 import net.causw.app.main.shared.exception.errorcode.UserErrorCode;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Getter
 @AllArgsConstructor
 public enum AcademicStatus {
@@ -12,7 +16,7 @@ public enum AcademicStatus {
 	GRADUATED("졸업"), // 졸업
 	UNDETERMINED("미정"), // 미정 (학적상태가 인증 필요)
 	/**
-	 * @deprecated V1에서 사용하던 status "휴학", "중퇴", "정학", "퇴학", "교수"는 V2에서 사용되지 않음
+	 * @deprecated V1에서 사용하던 status "휴학", "중퇴", "정학", "퇴학", "교수"는 V2에서 사용되지 않음("재학"으로 통합)
 	 */
 	@Deprecated
 	LEAVE_OF_ABSENCE("휴학"), // 휴학
@@ -26,6 +30,10 @@ public enum AcademicStatus {
 	PROFESSOR("교수"); // 교수
 
 	private final String value;
+	@Deprecated
+	private static final EnumSet<AcademicStatus> DEPRECATED_SET = EnumSet.of(
+		LEAVE_OF_ABSENCE, DROPPED_OUT, SUSPEND, EXPEL, PROFESSOR
+	);
 
 	public static AcademicStatus fromString(String academicStatus) {
 		if (academicStatus == null || academicStatus.isEmpty()) {
@@ -33,9 +41,13 @@ public enum AcademicStatus {
 		}
 		for (AcademicStatus status : AcademicStatus.values()) {
 			if (status.name().equalsIgnoreCase(academicStatus)) {
+				if (DEPRECATED_SET.contains(status)) {
+					throw UserErrorCode.INVALID_ACADEMIC_STATUS.toBaseException();
+				}
 				return status;
 			}
 		}
 		throw UserErrorCode.INVALID_ACADEMIC_STATUS.toBaseException();
 	}
+
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/academic/service/v1/UserAcademicRecordApplicationService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/academic/service/v1/UserAcademicRecordApplicationService.java
@@ -269,22 +269,6 @@ public class UserAcademicRecordApplicationService {
 				createUserAcademicRecordApplicationRequestDto.getGraduationType(),
 				StaticValue.USER_APPLIED);
 
-		} else if (targetAcademicStatus == AcademicStatus.LEAVE_OF_ABSENCE) {
-			// 휴학생의 학적 최초 인증 이벤트 발행
-			if (user.getAcademicStatus() == AcademicStatus.UNDETERMINED) {
-				eventPublisher.publishEvent(new CertifiedUserCreatedEvent(user.getId()));
-			}
-
-			// 학적 상태 변경
-			user.setAcademicStatus(createUserAcademicRecordApplicationRequestDto.getTargetAcademicStatus());
-			userRepository.save(user);
-
-			userAcademicRecordLog = UserAcademicRecordLog.create(
-				user,
-				user,
-				createUserAcademicRecordApplicationRequestDto.getTargetAcademicStatus(),
-				StaticValue.USER_APPLIED);
-
 		} else {
 			throw new BadRequestException(
 				ErrorCode.INVALID_PARAMETER,

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/userInfo/UserInfoQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/userInfo/UserInfoQueryRepository.java
@@ -69,7 +69,8 @@ public class UserInfoQueryRepository {
 
 		// 학적 상태 필터
 		if (academicStatusList == null || academicStatusList.isEmpty()) {
-			condition = condition.and(userInfo.user.academicStatus.in(AcademicStatus.GRADUATED, AcademicStatus.ENROLLED));
+			condition = condition
+				.and(userInfo.user.academicStatus.in(AcademicStatus.GRADUATED, AcademicStatus.ENROLLED));
 		} else {
 			List<AcademicStatus> academicStatuses = academicStatusList.stream()
 				.map(AcademicStatus::fromString)

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/userInfo/UserInfoQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/userInfo/UserInfoQueryRepository.java
@@ -69,8 +69,7 @@ public class UserInfoQueryRepository {
 
 		// 학적 상태 필터
 		if (academicStatusList == null || academicStatusList.isEmpty()) {
-			condition = condition.and(userInfo.user.academicStatus.in(AcademicStatus.GRADUATED, AcademicStatus.ENROLLED,
-				AcademicStatus.LEAVE_OF_ABSENCE));
+			condition = condition.and(userInfo.user.academicStatus.in(AcademicStatus.GRADUATED, AcademicStatus.ENROLLED));
 		} else {
 			List<AcademicStatus> academicStatuses = academicStatusList.stream()
 				.map(AcademicStatus::fromString)

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/mapper/UserInfoMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/mapper/UserInfoMapper.java
@@ -78,9 +78,8 @@ public interface UserInfoMapper extends UuidFileToUrlDtoMapper {
 	static String mapAcademicStatus(UserInfo userInfo) {
 		return switch (userInfo.getUser().getAcademicStatus()) {
 			case ENROLLED -> "재학생";
-			case LEAVE_OF_ABSENCE -> "휴학생";
 			case GRADUATED -> "졸업생";
-			default -> "기타"; // 교수, 중퇴, 정학, 미정
+			default -> "기타"; // 미정
 		};
 	}
 

--- a/app-main/src/main/resources/db/migration/V20260520151556__update_academic_status_to_enrolled.sql
+++ b/app-main/src/main/resources/db/migration/V20260520151556__update_academic_status_to_enrolled.sql
@@ -1,6 +1,0 @@
--- Migration: update_academic_status_to_enrolled
-
--- user 테이블에서 'ENROLLED'로 통합
-UPDATE tb_user
-SET academic_status = 'ENROLLED'
-WHERE academic_status IN ('LEAVE_OF_ABSENCE', 'DROPPED_OUT', 'SUSPEND', 'EXPEL', 'PROFESSOR');

--- a/app-main/src/main/resources/db/migration/V20260520151556__update_academic_status_to_enrolled.sql
+++ b/app-main/src/main/resources/db/migration/V20260520151556__update_academic_status_to_enrolled.sql
@@ -1,0 +1,6 @@
+-- Migration: update_academic_status_to_enrolled
+
+-- user 테이블에서 'ENROLLED'로 통합
+UPDATE tb_user
+SET academic_status = 'ENROLLED'
+WHERE academic_status IN ('LEAVE_OF_ABSENCE', 'DROPPED_OUT', 'SUSPEND', 'EXPEL', 'PROFESSOR');

--- a/app-main/src/main/resources/db/migration/V20260520163901__MigrateDeprecatedAcademicStatus.sql
+++ b/app-main/src/main/resources/db/migration/V20260520163901__MigrateDeprecatedAcademicStatus.sql
@@ -5,5 +5,7 @@ SET academic_status = 'ENROLLED'
 WHERE academic_status IN ('LEAVE_OF_ABSENCE', 'DROPPED_OUT', 'SUSPEND', 'EXPEL', 'PROFESSOR');
 
 -- user_academic_record_log 테이블에서 행 삭제
+-- 이력 기록 테이블 특성상 과거의 기록을 수정하는 것이 적절치 않고,
+-- DB에 'LEAVE_OF_ABSENCE'로 바꾸는 기록만 있어서 기록을 삭제하는 것이 적절하다고 판단함
 DELETE FROM tb_user_academic_record_log
 WHERE prior_academic_record_application_status IN ('LEAVE_OF_ABSENCE', 'DROPPED_OUT', 'SUSPEND', 'EXPEL', 'PROFESSOR');

--- a/app-main/src/main/resources/db/migration/V20260520163901__MigrateDeprecatedAcademicStatus.sql
+++ b/app-main/src/main/resources/db/migration/V20260520163901__MigrateDeprecatedAcademicStatus.sql
@@ -1,0 +1,9 @@
+-- Migration: MigrateDeprecatedAcademicStatus
+-- user 테이블에서 'ENROLLED'로 통합
+UPDATE tb_user
+SET academic_status = 'ENROLLED'
+WHERE academic_status IN ('LEAVE_OF_ABSENCE', 'DROPPED_OUT', 'SUSPEND', 'EXPEL', 'PROFESSOR');
+
+-- user_academic_record_log 테이블에서 행 삭제
+DELETE FROM tb_user_academic_record_log
+WHERE prior_academic_record_application_status IN ('LEAVE_OF_ABSENCE', 'DROPPED_OUT', 'SUSPEND', 'EXPEL', 'PROFESSOR');


### PR DESCRIPTION
### 🚩 관련사항
#1273

### 📢 전달사항
- Form에서 is_allowed_leave_of_absence, leave_of_absence_registered_semester 필드를 어떻게 해야할지 정해야할 것 같습니다.

### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [x] `AcademicStatus.java` — deprecated 값 5개에 `@Deprecated` 어노테이션 추가, Javadoc 마이그레이션 안내 명시
- [x] `AcademicStatus.fromString()` — deprecated 값 입력 시 예외 처리 또는 경고 로그 추가
- [x] `PostValidator.java` — `LEAVE_OF_ABSENCE`, `SUSPEND`, `PROFESSOR` 분기 제거
- [x] `BoardReadScope.java` — `LEAVE_OF_ABSENCE`, `SUSPEND`, `PROFESSOR` 제거
- [x] `CircleService.java` — `LEAVE_OF_ABSENCE` 허용 조건 제거
- [x] `FormService.java` — `LEAVE_OF_ABSENCE` 허용 조건 제거
- [x] `SemesterService.java` — `LEAVE_OF_ABSENCE` 분기 제거
- [x] `UserAcademicRecordApplicationService.java` — `LEAVE_OF_ABSENCE` 분기 제거
- [x] `UserInfoQueryRepository.java` — `LEAVE_OF_ABSENCE` 필터 조건 제거
- [x] `UserInfoMapper.java` — `LEAVE_OF_ABSENCE` 표시 텍스트(`"휴학생"`) 제거


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 