### PR TITLE
refactor: 자진 탈퇴 회원 INACTIVE 처리

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/entity/user/User.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/entity/user/User.java
@@ -143,6 +143,7 @@ public class User extends BaseEntity {
 
 	// 자진 탈퇴 처리
 	public void withdraw(LocalDateTime now) {
+		this.state = UserState.INACTIVE;
 		this.deletedAt = now;
 		this.academicStatus = AcademicStatus.UNDETERMINED;
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/entity/user/User.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/entity/user/User.java
@@ -180,6 +180,10 @@ public class User extends BaseEntity {
 		return this.state == UserState.INACTIVE;
 	}
 
+	public boolean isDropped() {
+		return this.state == UserState.DROP;
+	}
+
 	/**
 	 * 온보딩 플로우 분기 기준: 소셜 로그인 완료 여부
 	 */

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/entity/user/User.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/entity/user/User.java
@@ -145,7 +145,6 @@ public class User extends BaseEntity {
 	public void withdraw(LocalDateTime now) {
 		this.state = UserState.INACTIVE;
 		this.deletedAt = now;
-		this.academicStatus = AcademicStatus.UNDETERMINED;
 	}
 
 	/*

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/entity/user/User.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/entity/user/User.java
@@ -349,7 +349,10 @@ public class User extends BaseEntity {
 		this.deletedAt = now;
 	}
 
-	// 탈퇴 처리
+	/**
+	 * V1에서 이용하던 회원 탈퇴 처리입니다.
+	 * @deprecated V2 탈퇴에서는 withdraw(LocalDateTime)을 이용합니다.
+	 */
 	public void withdraw() {
 		this.state = UserState.INACTIVE;
 		this.deletedAt = LocalDateTime.now();

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAccountService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAccountService.java
@@ -215,7 +215,7 @@ public class UserAccountService {
 		User user = userReader.findUserById(userId);
 
 		// 관리자 강제 탈퇴(DROP) 먼저 체크
-		if (user.getState().equals(UserState.DROP)) {
+		if (user.isDropped()) {
 			throw UserErrorCode.USER_DROPPED.toBaseException();
 		}
 
@@ -288,7 +288,7 @@ public class UserAccountService {
 			throw UserErrorCode.USER_DELETED.toBaseException();
 		}
 
-		if (user.getState() == UserState.DROP) {
+		if (user.isDropped()) {
 			throw UserErrorCode.USER_DROPPED.toBaseException();
 		}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAccountService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAccountService.java
@@ -220,7 +220,7 @@ public class UserAccountService {
 		}
 
 		// 일반 탈퇴 유저 체크
-		if (user.isDeleted()) {
+		if (user.isInactive()) {
 			throw UserErrorCode.USER_DELETED.toBaseException();
 		}
 
@@ -284,7 +284,7 @@ public class UserAccountService {
 	public UserWithdrawResponse withdraw(String userId, String accessToken, String refreshToken, String platformHint) {
 		User user = userReader.findUserById(userId);
 
-		if (user.isDeleted()) {
+		if (user.isInactive()) {
 			throw UserErrorCode.USER_DELETED.toBaseException();
 		}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAdminService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAdminService.java
@@ -148,7 +148,7 @@ public class UserAdminService {
 	// - INACTIVE 상태 (INACTIVE가 deletedAt 설정을 보장)
 	private void validateRestorableWithdrawnUser(User targetUser) {
 		if (!targetUser.isInactive()) {
-			throw UserErrorCode.USER_NOT_RESTORABLE.toBaseException();
+			throw UserErrorCode.USER_WITHDRAWN_NOT_RESTORABLE.toBaseException();
 		}
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAdminService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAdminService.java
@@ -145,9 +145,9 @@ public class UserAdminService {
 	}
 
 	// 자진 탈퇴 사용자 복원이 가능한지 검증
-	// - INACTIVE 상태이며 실제로 탈퇴(isDeleted) 상태여야 함
+	// - INACTIVE 상태 (INACTIVE가 deletedAt 설정을 보장)
 	private void validateRestorableWithdrawnUser(User targetUser) {
-		if (!targetUser.isInactive() || !targetUser.isDeleted()) {
+		if (!targetUser.isInactive()) {
 			throw UserErrorCode.USER_NOT_RESTORABLE.toBaseException();
 		}
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAdminService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAdminService.java
@@ -145,15 +145,9 @@ public class UserAdminService {
 	}
 
 	// 자진 탈퇴 사용자 복원이 가능한지 검증
-	// - DROP 상태가 아니어야 하며, 실제로 탈퇴(isDeleted) 상태여야 함
+	// - INACTIVE 상태이며 실제로 탈퇴(isDeleted) 상태여야 함
 	private void validateRestorableWithdrawnUser(User targetUser) {
-		// 1. 추방(DROP)된 유저는 이 API를 통해 복구할 수 없음 (restoreUser API 사용 유도)
-		if (targetUser.getState() == UserState.DROP) {
-			throw UserErrorCode.USER_NOT_RESTORABLE.toBaseException();
-		}
-
-		// 2. 실제로 탈퇴(isDeleted) 상태인 유저여야 함
-		if (!targetUser.isDeleted()) {
+		if (!targetUser.isInactive() || !targetUser.isDeleted()) {
 			throw UserErrorCode.USER_NOT_RESTORABLE.toBaseException();
 		}
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/implementation/UserWriter.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/implementation/UserWriter.java
@@ -135,7 +135,7 @@ public class UserWriter {
 	}
 
 	private boolean isAlreadyAnonymized(User user) {
-		return user.isDeleted() &&
+		return user.isInactive() &&
 			user.getEmail() != null &&
 			user.getEmail().startsWith("deleted_");
 	}

--- a/app-main/src/main/java/net/causw/app/main/shared/exception/errorcode/UserErrorCode.java
+++ b/app-main/src/main/java/net/causw/app/main/shared/exception/errorcode/UserErrorCode.java
@@ -46,7 +46,8 @@ public enum UserErrorCode implements BaseResponseCode {
 	USER_NOT_DROPPABLE(HttpStatus.BAD_REQUEST, "USER_400_015", "추방할 수 없는 사용자입니다."),
 	USER_NOT_RESTORABLE(HttpStatus.BAD_REQUEST, "USER_400_016", "관리자는 추방 상태의 사용자만 복구할 수 있습니다."),
 	USER_ROLE_MISMATCH(HttpStatus.BAD_REQUEST, "USER_400_017", "요청한 현재 역할이 사용자의 역할 목록과 일치하지 않습니다."),
-	USER_NOT_ROLE_UPDATABLE(HttpStatus.BAD_REQUEST, "USER_400_018", "활성된 사용자의 역할만 변경할 수 있습니다.");
+	USER_NOT_ROLE_UPDATABLE(HttpStatus.BAD_REQUEST, "USER_400_018", "활성된 사용자의 역할만 변경할 수 있습니다."),
+	USER_WITHDRAWN_NOT_RESTORABLE(HttpStatus.BAD_REQUEST, "USER_400_019", "자진 탈퇴 상태의 사용자만 복구할 수 있습니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/app-main/src/test/java/net/causw/app/main/domain/user/account/service/UserAccountServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/user/account/service/UserAccountServiceTest.java
@@ -232,7 +232,7 @@ class UserAccountServiceTest {
 
 		when(userReader.findUserById(userId)).thenReturn(user);
 		when(user.getId()).thenReturn(userId);
-		when(user.isDeleted()).thenReturn(false);
+		when(user.isInactive()).thenReturn(false);
 		when(user.getState()).thenReturn(UserState.ACTIVE);
 
 		// 소셜 계정 목록 반환
@@ -271,7 +271,7 @@ class UserAccountServiceTest {
 		User user = mock(User.class);
 		when(userReader.findUserById(userId)).thenReturn(user);
 		when(user.getId()).thenReturn(userId);
-		when(user.isDeleted()).thenReturn(false);
+		when(user.isInactive()).thenReturn(false);
 		when(user.getState()).thenReturn(UserState.ACTIVE);
 
 		when(socialAccountReader.findAllByUserId(userId)).thenReturn(List.of());
@@ -294,7 +294,7 @@ class UserAccountServiceTest {
 		// given
 		User user = mock(User.class);
 		when(userReader.findUserById(userId)).thenReturn(user);
-		when(user.isDeleted()).thenReturn(true);
+		when(user.isInactive()).thenReturn(true);
 
 		// when & then
 		assertThrows(BaseRunTimeV2Exception.class,

--- a/app-main/src/test/java/net/causw/app/main/domain/user/account/service/UserAccountServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/user/account/service/UserAccountServiceTest.java
@@ -233,7 +233,7 @@ class UserAccountServiceTest {
 		when(userReader.findUserById(userId)).thenReturn(user);
 		when(user.getId()).thenReturn(userId);
 		when(user.isInactive()).thenReturn(false);
-		when(user.getState()).thenReturn(UserState.ACTIVE);
+		when(user.isDropped()).thenReturn(false);
 
 		// 소셜 계정 목록 반환
 		when(socialAccountReader.findAllByUserId(userId)).thenReturn(List.of(socialAccount));
@@ -272,7 +272,7 @@ class UserAccountServiceTest {
 		when(userReader.findUserById(userId)).thenReturn(user);
 		when(user.getId()).thenReturn(userId);
 		when(user.isInactive()).thenReturn(false);
-		when(user.getState()).thenReturn(UserState.ACTIVE);
+		when(user.isDropped()).thenReturn(false);
 
 		when(socialAccountReader.findAllByUserId(userId)).thenReturn(List.of());
 		when(lockerReader.findByUserId(userId)).thenReturn(Optional.empty());

--- a/app-main/src/test/java/net/causw/app/main/domain/user/account/service/UserAdminServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/user/account/service/UserAdminServiceTest.java
@@ -335,6 +335,85 @@ class UserAdminServiceTest {
 		}
 	}
 
+	@Nested
+	@DisplayName("자진 탈퇴 유저 복구")
+	class RestoreWithdrawnUser {
+
+		@Test
+		@DisplayName("INACTIVE 상태이며 deletedAt이 있으면 자진 탈퇴 유저를 복구한다")
+		void givenInactiveDeletedUser_whenRestoreWithdrawnUser_thenRestore() {
+			// given
+			User adminUser = ObjectFixtures.getCertifiedUserWithId("admin-1");
+			String userId = "user-1";
+			User user = ObjectFixtures.getCertifiedUserWithId(userId);
+			user.setState(UserState.INACTIVE);
+			user.setDeletedAt(LocalDateTime.now());
+			user.setRoles(Set.of(Role.NONE));
+
+			when(userReader.findUserById(userId)).thenReturn(user);
+			when(userAccountService.restore(userId)).thenReturn(user);
+
+			// when
+			userAdminService.restoreWithdrawnUser(adminUser, userId);
+
+			// then
+			verify(userAccountService).restore(userId);
+			verify(userAdminActionLogWriter).logRestore(
+				eq(adminUser),
+				eq(user),
+				eq(UserState.INACTIVE),
+				eq(Set.of(Role.NONE)));
+		}
+
+		@Test
+		@DisplayName("DROP 상태이며 deletedAt이 있으면 자진 탈퇴 복구 대상이 아니다")
+		void givenDroppedDeletedUser_whenRestoreWithdrawnUser_thenThrowUserNotRestorable() {
+			// given
+			User adminUser = ObjectFixtures.getCertifiedUserWithId("admin-1");
+			String userId = "user-1";
+			User user = ObjectFixtures.getCertifiedUserWithId(userId);
+			user.setState(UserState.DROP);
+			user.setDeletedAt(LocalDateTime.now());
+
+			when(userReader.findUserById(userId)).thenReturn(user);
+
+			// when
+			Throwable throwable = catchThrowable(() -> userAdminService.restoreWithdrawnUser(adminUser, userId));
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(BaseRunTimeV2Exception.class)
+				.extracting(e -> ((BaseRunTimeV2Exception)e).getErrorCode())
+				.isEqualTo(UserErrorCode.USER_NOT_RESTORABLE);
+			verify(userAccountService, never()).restore(any());
+			verify(userAdminActionLogWriter, never()).logRestore(any(), any(), any(), any());
+		}
+
+		@Test
+		@DisplayName("deletedAt이 있어도 INACTIVE 상태가 아니면 자진 탈퇴 복구 대상이 아니다")
+		void givenDeletedButNotInactiveUser_whenRestoreWithdrawnUser_thenThrowUserNotRestorable() {
+			// given
+			User adminUser = ObjectFixtures.getCertifiedUserWithId("admin-1");
+			String userId = "user-1";
+			User user = ObjectFixtures.getCertifiedUserWithId(userId);
+			user.setState(UserState.ACTIVE);
+			user.setDeletedAt(LocalDateTime.now());
+
+			when(userReader.findUserById(userId)).thenReturn(user);
+
+			// when
+			Throwable throwable = catchThrowable(() -> userAdminService.restoreWithdrawnUser(adminUser, userId));
+
+			// then
+			assertThat(throwable)
+				.isInstanceOf(BaseRunTimeV2Exception.class)
+				.extracting(e -> ((BaseRunTimeV2Exception)e).getErrorCode())
+				.isEqualTo(UserErrorCode.USER_NOT_RESTORABLE);
+			verify(userAccountService, never()).restore(any());
+			verify(userAdminActionLogWriter, never()).logRestore(any(), any(), any(), any());
+		}
+	}
+
 	@Test
 	@DisplayName("관리자 추방 시 계정은 DROP 처리되고 추방 식별자가 저장된다")
 	void dropUser_Success() {

--- a/app-main/src/test/java/net/causw/app/main/domain/user/account/service/UserAdminServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/user/account/service/UserAdminServiceTest.java
@@ -384,7 +384,7 @@ class UserAdminServiceTest {
 			assertThat(throwable)
 				.isInstanceOf(BaseRunTimeV2Exception.class)
 				.extracting(e -> ((BaseRunTimeV2Exception)e).getErrorCode())
-				.isEqualTo(UserErrorCode.USER_NOT_RESTORABLE);
+				.isEqualTo(UserErrorCode.USER_WITHDRAWN_NOT_RESTORABLE);
 			verify(userAccountService, never()).restore(any());
 			verify(userAdminActionLogWriter, never()).logRestore(any(), any(), any(), any());
 		}
@@ -408,7 +408,7 @@ class UserAdminServiceTest {
 			assertThat(throwable)
 				.isInstanceOf(BaseRunTimeV2Exception.class)
 				.extracting(e -> ((BaseRunTimeV2Exception)e).getErrorCode())
-				.isEqualTo(UserErrorCode.USER_NOT_RESTORABLE);
+				.isEqualTo(UserErrorCode.USER_WITHDRAWN_NOT_RESTORABLE);
 			verify(userAccountService, never()).restore(any());
 			verify(userAdminActionLogWriter, never()).logRestore(any(), any(), any(), any());
 		}


### PR DESCRIPTION
### 🚩 관련사항
Closes #1284

### 📢 전달사항
- 자진 탈퇴 회원을 INACTIVE 처리했습니다.
- 자진 탈퇴 회원 복구 API의 검증 로직을 강화했습니다.
  - 기존에는 DROP 상태가 아니고, deletedAt이 존재하면 자진 탈퇴 복구 대상
  - 자진 탈퇴 복구 대상을 INACTIVE 상태이면서 deletedAt이 존재하는 사용자로 한정

### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
  - [x] 자진 탈퇴 복구 검증 조건을 INACTIVE && deletedAt 존재 기준으로 변경
  - [x] 관련 주석을 현재 정책에 맞게 수정
  - [x] 자진 탈퇴 복구 성공 테스트 추가
  - [x] DROP + deletedAt 사용자는 자진 탈퇴 복구 불가 테스트 추가
  - [x] INACTIVE가 아닌데 deletedAt만 있는 사용자는 자진 탈퇴 복구 불가 테스트 추가
  - [ ] 로컬 테스트 실행 확인 필요 (탈퇴랑 한 번에 확인할게요..)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 2026.05.15.