### PR TITLE
feat: 프로필 미설정 상태를 구분하기 위한 ProfileImageType UNSET 추가

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/entity/user/User.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/entity/user/User.java
@@ -24,6 +24,7 @@ import net.causw.app.main.domain.user.account.enums.user.UserState;
 import net.causw.app.main.domain.user.account.service.dto.request.UserRegisterDto;
 import net.causw.app.main.domain.user.auth.service.dto.OAuthAttributes;
 import net.causw.app.main.shared.entity.BaseEntity;
+import net.causw.app.main.shared.exception.errorcode.UserErrorCode;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -388,7 +389,7 @@ public class User extends BaseEntity {
 	 */
 	public void updateProfileImageToDefault(ProfileImageType defaultType) {
 		if (defaultType == ProfileImageType.CUSTOM || defaultType == ProfileImageType.UNSET) {
-			throw new IllegalArgumentException("기본 이미지 타입만 허용됩니다.");
+			throw UserErrorCode.INVALID_PROFILE_IMAGE_TYPE.toBaseException();
 		}
 		this.profileImageType = defaultType;
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/entity/user/User.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/entity/user/User.java
@@ -104,7 +104,7 @@ public class User extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	@Column(name = "profile_image_type", nullable = false)
 	@Builder.Default
-	private ProfileImageType profileImageType = ProfileImageType.MALE_1;
+	private ProfileImageType profileImageType = ProfileImageType.UNSET;
 
 	@Column(name = "state", nullable = false)
 	@Enumerated(EnumType.STRING)
@@ -387,7 +387,7 @@ public class User extends BaseEntity {
 	 * 기존 커스텀 이미지(UserProfileImage)는 null로 초기화됩니다.
 	 */
 	public void updateProfileImageToDefault(ProfileImageType defaultType) {
-		if (defaultType == ProfileImageType.CUSTOM) {
+		if (defaultType == ProfileImageType.CUSTOM || defaultType == ProfileImageType.UNSET) {
 			throw new IllegalArgumentException("기본 이미지 타입만 허용됩니다.");
 		}
 		this.profileImageType = defaultType;

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/enums/user/ProfileImageType.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/enums/user/ProfileImageType.java
@@ -1,5 +1,5 @@
 package net.causw.app.main.domain.user.account.enums.user;
 
 public enum ProfileImageType {
-	MALE_1, MALE_2, FEMALE_1, FEMALE_2, CUSTOM, GHOST
+	UNSET, MALE_1, MALE_2, FEMALE_1, FEMALE_2, CUSTOM, GHOST
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserProfileImageService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserProfileImageService.java
@@ -43,12 +43,14 @@ public class UserProfileImageService {
 	 * </p>
 	 *
 	 * @param userId          변경할 유저 ID
-	 * @param profileImageType 기본 이미지 타입 (MALE_1, MALE_2, FEMALE_1, FEMALE_2)
+	 * @param profileImageType 기본 이미지 타입 (MALE_1, MALE_2, FEMALE_1, FEMALE_2). UNSET, CUSTOM, GHOST는 허용되지 않습니다.
 	 * @return 변경된 프로필 이미지 정보
 	 */
 	@Transactional
 	public ProfileImageResponse updateToDefaultProfileImage(String userId, ProfileImageType profileImageType) {
-		if (profileImageType == ProfileImageType.CUSTOM || profileImageType == ProfileImageType.GHOST) {
+		if (profileImageType == ProfileImageType.CUSTOM
+			|| profileImageType == ProfileImageType.GHOST
+			|| profileImageType == ProfileImageType.UNSET) {
 			throw UserErrorCode.INVALID_PROFILE_IMAGE_TYPE.toBaseException();
 		}
 

--- a/app-main/src/main/java/net/causw/app/main/shared/dto/ProfileImageDto.java
+++ b/app-main/src/main/java/net/causw/app/main/shared/dto/ProfileImageDto.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * <h3>비즈니스 규칙</h3>
  * <ul>
  *   <li>CUSTOM 타입인 경우에만 URL이 포함되며, 나머지 타입은 URL이 null</li>
+ *   <li>UNSET 타입은 신규 가입 후 프로필 이미지를 아직 설정하지 않은 상태를 의미하며, URL은 null</li>
  *   <li>추방(DROP) / 탈퇴(DELETED, INACTIVE) 유저는 GHOST 타입, URL null</li>
  *   <li>차단된 유저는 GHOST 타입, URL null (비식별)</li>
  * </ul>

--- a/app-main/src/main/resources/db/migration/V20260514210000__AddUnsetToProfileImageTypeEnum.sql
+++ b/app-main/src/main/resources/db/migration/V20260514210000__AddUnsetToProfileImageTypeEnum.sql
@@ -4,3 +4,9 @@ ALTER TABLE tb_user
     MODIFY COLUMN profile_image_type
     ENUM('UNSET', 'MALE_1', 'MALE_2', 'FEMALE_1', 'FEMALE_2', 'CUSTOM', 'GHOST')
     NOT NULL DEFAULT 'UNSET';
+
+-- 기존 MALE_1(미설정 기본값) → UNSET
+-- v2 프로필 설정 API 미사용 전제: MALE_1은 모두 기본값 상태
+UPDATE tb_user
+SET profile_image_type = 'UNSET'
+WHERE profile_image_type = 'MALE_1';

--- a/app-main/src/main/resources/db/migration/V20260514210000__AddUnsetToProfileImageTypeEnum.sql
+++ b/app-main/src/main/resources/db/migration/V20260514210000__AddUnsetToProfileImageTypeEnum.sql
@@ -1,0 +1,6 @@
+-- Migration: AddUnsetToProfileImageTypeEnum
+-- profile_image_type ENUM에 UNSET 추가, 신규 유저 기본값을 UNSET으로 변경
+ALTER TABLE tb_user
+    MODIFY COLUMN profile_image_type
+    ENUM('UNSET', 'MALE_1', 'MALE_2', 'FEMALE_1', 'FEMALE_2', 'CUSTOM', 'GHOST')
+    NOT NULL DEFAULT 'UNSET';


### PR DESCRIPTION
### 🚩 관련사항
close #1330 


### 📢 전달사항
#### 배경
v2 API에서 신규 가입 유저의 `profileImageType`이 `MALE_1`로 고정되어, 프론트엔드에서 프로필을 아직 설정하지 않은 유저와 MALE_1을 선택한 유저를 구분할 수 없었습니다.  
프로필 설정 온보딩 플로우를 지원하기 위해 `UNSET` 타입을 도입했습니다.
#### 변경 사항
- `ProfileImageType` enum에 `UNSET` 추가
- `User` 엔티티 기본값 `MALE_1` → `UNSET` 변경
- Flyway 마이그레이션
  - DB `profile_image_type` ENUM에 `UNSET` 추가, 컬럼 기본값 `UNSET`으로 변경
  - 기존 `MALE_1` 유저 → `UNSET` 백필 (v2 프로필 설정 API 미사용 전제)
- `UserProfileImageService.updateToDefaultProfileImage`에서 `UNSET` 직접 지정 차단
- `User.updateProfileImageToDefault` 방어 로직에 `UNSET` 차단 추가
- `ProfileImageDto` Javadoc에 `UNSET` 비즈니스 규칙 문서화


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [x] `ProfileImageType.UNSET` enum 추가
- [x] `User` 엔티티 기본값 `UNSET` 적용
- [x] Flyway: ENUM 확장 + `MALE_1` → `UNSET` 백필
- [x] 프로필 이미지 변경 API에서 `UNSET` 직접 지정 차단
- [x] `ProfileImageDto` Javadoc 보완

### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 