### PR TITLE
fix: 게시글 조회 시 차단 유저 게시글 필터링

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/repository/query/PostQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/repository/query/PostQueryRepository.java
@@ -87,12 +87,14 @@ public class PostQueryRepository {
 	 * @param boardIds 게시판 ID 목록 (null이면 전체 게시판, 빈 리스트면 조회 안함)
 	 * @param cursorCreatedAt 커서 (마지막 게시글의 createdAt)
 	 * @param cursorId 커서 (마지막 게시글의 ID, createdAt이 같을 때 사용)
+	 * @param blockedUserIds 차단한 사용자 ID 목록 (해당 사용자 게시글 제외)
 	 * @param size 조회할 개수
 	 * @param keyword 검색 키워드 (content 기준)
 	 * @return 게시글 목록 Slice
 	 */
 	public Slice<PostCursorResult> findPostsWithCursor(
 		List<String> boardIds,
+		Set<String> blockedUserIds,
 		String cursorCreatedAt,
 		String cursorId,
 		int size,
@@ -119,6 +121,7 @@ public class PostQueryRepository {
 		BooleanExpression[] conditions = new BooleanExpression[] {
 			boardCondition,
 			post.isDeleted.eq(false),
+			notInBlockedUsers(writer, blockedUserIds),
 			containsKeywordInContent(post, keyword),
 			cursorCondition
 		};

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/PostService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/PostService.java
@@ -40,6 +40,7 @@ import net.causw.app.main.domain.community.reaction.service.implementation.LikeP
 import net.causw.app.main.domain.notification.notification.event.OfficialPostEvent;
 import net.causw.app.main.domain.user.account.entity.user.User;
 import net.causw.app.main.domain.user.relation.service.v2.implementation.BlockReader;
+import net.causw.app.main.shared.exception.errorcode.PostErrorCode;
 import net.causw.global.constant.StaticValue;
 
 import lombok.RequiredArgsConstructor;
@@ -253,6 +254,12 @@ public class PostService {
 
 		// ReadScope 검증
 		PostValidator.validateRead(viewer, boardConfig, boardAdminIds);
+
+		// 차단한 사용자가 작성한 게시글은 조회 불가
+		User writer = post.getWriter();
+		if (writer != null && userBlockReader.existsByBlockerAndBlocked(viewer, writer)) {
+			throw PostErrorCode.BLOCKED_USER_CONTENT.toBaseException();
+		}
 
 		// 게시글 이미지 조회
 		List<String> imageUrls = postReader.findPostImages(postId);

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/PostService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/PostService.java
@@ -188,9 +188,13 @@ public class PostService {
 			return PostListResult.of(List.of(), null);
 		}
 
+		// 뷰어가 차단한 사용자 조회 
+		Set<String> blockedUserIds = userBlockReader.findBlockeeUserIdsByBlocker(viewer);
+
 		// 게시글 조회 (Slice 사용)
 		Slice<PostCursorResult> slice = postReader.findPostsWithCursor(
 			boardIds,
+			blockedUserIds,
 			parsedCursor.createdAt(),
 			parsedCursor.postId(),
 			size,

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/PostService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/PostService.java
@@ -257,7 +257,8 @@ public class PostService {
 
 		// 차단한 사용자가 작성한 게시글은 조회 불가
 		User writer = post.getWriter();
-		if (writer != null && userBlockReader.existsByBlockerAndBlocked(viewer, writer)) {
+		if (writer != null && !writer.getId().equals(viewer.getId()) && !boardAdminIds.contains(viewer.getId())
+			&& userBlockReader.existsByBlockerAndBlocked(viewer, writer)) {
 			throw PostErrorCode.BLOCKED_USER_CONTENT.toBaseException();
 		}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/implementation/PostReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/implementation/PostReader.java
@@ -56,6 +56,7 @@ public class PostReader {
 	 * 커서 기반 페이징으로 게시글 목록을 조회합니다. (V2용)
 	 *
 	 * @param boardIds 게시판 ID 목록 (null이면 전체 게시판)
+	 * @param blockedUserIds 차단된 유저 ID 목록 (null이면 차단된 유저 없음)
 	 * @param cursorCreatedAt 커서 (마지막 게시글의 createdAt)
 	 * @param cursorId 커서 (마지막 게시글의 ID)
 	 * @param size 조회할 개수
@@ -64,11 +65,13 @@ public class PostReader {
 	 */
 	public Slice<PostCursorResult> findPostsWithCursor(
 		List<String> boardIds,
+		Set<String> blockedUserIds,
 		String cursorCreatedAt,
 		String cursorId,
 		int size,
 		String keyword) {
-		return postQueryRepository.findPostsWithCursor(boardIds, cursorCreatedAt, cursorId, size, keyword);
+		return postQueryRepository.findPostsWithCursor(
+			boardIds, blockedUserIds, cursorCreatedAt, cursorId, size, keyword);
 	}
 
 	/**

--- a/app-main/src/main/java/net/causw/app/main/shared/exception/errorcode/PostErrorCode.java
+++ b/app-main/src/main/java/net/causw/app/main/shared/exception/errorcode/PostErrorCode.java
@@ -12,6 +12,7 @@ public enum PostErrorCode implements BaseResponseCode {
 	POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_404_001", "게시글을 찾을 수 없습니다"),
 	DELETED_WRITER(HttpStatus.NOT_FOUND, "POST_404_002", "작성자가 삭제된 사용자입니다"),
 	POST_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_403_001", "게시글에 대한 권한이 없습니다"),
+	BLOCKED_USER_CONTENT(HttpStatus.FORBIDDEN, "POST_403_002", "차단한 유저의 컨텐츠입니다."),
 	POST_ANONYMOUS_BOARD_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "POST_400_001", "익명 게시판에는 비익명 게시글을 작성할 수 없습니다"),
 	INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST, "POST_400_002", "올바르지 않은 커서 형식입니다."),
 	IMAGE_REPRESENTATIVE_MUST_BE_ONE(HttpStatus.BAD_REQUEST, "POST_400_003", "대표 이미지는 정확히 1개여야 합니다."),

--- a/app-main/src/test/java/net/causw/app/main/domain/community/post/service/v2/PostServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/community/post/service/v2/PostServiceTest.java
@@ -67,6 +67,7 @@ import net.causw.app.main.domain.user.account.enums.user.UserState;
 import net.causw.app.main.domain.user.account.service.implementation.UserReader;
 import net.causw.app.main.domain.user.relation.service.v2.implementation.BlockReader;
 import net.causw.app.main.shared.exception.BaseRunTimeV2Exception;
+import net.causw.app.main.shared.exception.errorcode.PostErrorCode;
 import net.causw.app.main.util.ObjectFixtures;
 
 @ExtendWith(MockitoExtension.class)
@@ -1152,6 +1153,28 @@ public class PostServiceTest {
 				false,
 				BoardVisibility.VISIBLE,
 				10);
+			Mockito.lenient().when(blockReader.existsByBlockerAndBlocked(any(), any())).thenReturn(false);
+		}
+
+		@DisplayName("차단한 사용자의 게시글은 상세 조회 불가")
+		@Test
+		void getPostDetail_shouldFail_whenWriterIsBlocked() {
+			// given
+			PostDetailQuery query = new PostDetailQuery(postId, viewer);
+			List<String> boardAdminIds = List.of("admin-id");
+
+			given(postReader.findById(postId)).willReturn(post);
+			given(boardConfigReader.getByBoardId(boardId)).willReturn(boardConfig);
+			given(boardConfigReader.getAdminIdsByBoardId(boardId)).willReturn(boardAdminIds);
+			given(blockReader.existsByBlockerAndBlocked(viewer, writer)).willReturn(true);
+
+			// when & then
+			assertThatThrownBy(() -> postService.getPostDetail(query))
+				.isInstanceOf(BaseRunTimeV2Exception.class)
+				.satisfies(ex -> assertThat(((BaseRunTimeV2Exception) ex).getErrorCode())
+					.isEqualTo(PostErrorCode.BLOCKED_USER_CONTENT));
+
+			verify(likePostReader, never()).countByPostId(anyString());
 		}
 
 		@DisplayName("게시글 상세 조회 성공")

--- a/app-main/src/test/java/net/causw/app/main/domain/community/post/service/v2/PostServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/community/post/service/v2/PostServiceTest.java
@@ -842,7 +842,8 @@ public class PostServiceTest {
 				() -> assertThat(result.posts()).hasSize(1),
 				() -> assertThat(result.posts().get(0).content()).contains("검색어"));
 
-			verify(postReader, times(1)).findPostsWithCursor(anyList(), anySet(), eq(null), eq(null), eq(20), eq(keyword));
+			verify(postReader, times(1)).findPostsWithCursor(anyList(), anySet(), eq(null), eq(null), eq(20),
+				eq(keyword));
 		}
 
 		@DisplayName("게시판 ID 없이 전체 게시글 목록 조회 성공")
@@ -884,7 +885,8 @@ public class PostServiceTest {
 			given(boardConfigReader.getAccessibleBoardIdsByAcademicStatus(AcademicStatus.ENROLLED))
 				.willReturn(accessibleBoardIds);
 			given(boardConfigReader.getAdminIdSetMapByBoardIds(anySet())).willReturn(Map.of());
-			given(postReader.findPostsWithCursor(eq(accessibleBoardIds), anySet(), eq(null), eq(null), eq(20), eq(null)))
+			given(
+				postReader.findPostsWithCursor(eq(accessibleBoardIds), anySet(), eq(null), eq(null), eq(20), eq(null)))
 				.willReturn(slice);
 			given(postReader.findPostImagesByPostIds(anyList())).willReturn(Map.of());
 			given(likePostReader.getLikedPostIds(anyString(), anyList())).willReturn(Set.of());
@@ -1171,7 +1173,7 @@ public class PostServiceTest {
 			// when & then
 			assertThatThrownBy(() -> postService.getPostDetail(query))
 				.isInstanceOf(BaseRunTimeV2Exception.class)
-				.satisfies(ex -> assertThat(((BaseRunTimeV2Exception) ex).getErrorCode())
+				.satisfies(ex -> assertThat(((BaseRunTimeV2Exception)ex).getErrorCode())
 					.isEqualTo(PostErrorCode.BLOCKED_USER_CONTENT));
 
 			verify(likePostReader, never()).countByPostId(anyString());

--- a/app-main/src/test/java/net/causw/app/main/domain/community/post/service/v2/PostServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/community/post/service/v2/PostServiceTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
@@ -533,6 +534,30 @@ public class PostServiceTest {
 				false,
 				BoardVisibility.VISIBLE,
 				10);
+			Mockito.lenient().when(blockReader.findBlockeeUserIdsByBlocker(viewer)).thenReturn(Set.of());
+		}
+
+		@DisplayName("차단한 사용자의 게시글은 목록 조회 시 제외")
+		@Test
+		void getPosts_shouldExcludeBlockedUsersPosts() {
+			// given
+			Set<String> blockedUserIds = Set.of("blocked-writer-id");
+			PostListQuery query = PostListQuery.of(viewer, List.of(boardId), null, 20, null);
+			List<String> boardAdminIds = List.of("admin-id");
+
+			given(blockReader.findBlockeeUserIdsByBlocker(viewer)).willReturn(blockedUserIds);
+			given(boardConfigReader.getByBoardId(boardId)).willReturn(boardConfig);
+			given(boardConfigReader.getAdminIdsByBoardId(boardId)).willReturn(boardAdminIds);
+			given(postReader.findPostsWithCursor(anyList(), eq(blockedUserIds), eq(null), eq(null), eq(20), eq(null)))
+				.willReturn(new SliceImpl<>(List.of(), PageRequest.of(0, 20), false));
+
+			// when
+			postService.getPosts(query);
+
+			// then
+			verify(blockReader, times(1)).findBlockeeUserIdsByBlocker(viewer);
+			verify(postReader, times(1)).findPostsWithCursor(
+				anyList(), eq(blockedUserIds), eq(null), eq(null), eq(20), eq(null));
 		}
 
 		@DisplayName("특정 게시판의 게시글 목록 조회 성공")
@@ -574,7 +599,7 @@ public class PostServiceTest {
 			given(boardConfigReader.getByBoardId(boardId)).willReturn(boardConfig);
 			given(boardConfigReader.getAdminIdsByBoardId(boardId)).willReturn(boardAdminIds);
 			given(boardConfigReader.getAdminIdSetMapByBoardIds(anySet())).willReturn(Map.of());
-			given(postReader.findPostsWithCursor(anyList(), eq(null), eq(null), eq(20), eq(null)))
+			given(postReader.findPostsWithCursor(anyList(), anySet(), eq(null), eq(null), eq(20), eq(null)))
 				.willReturn(slice);
 			given(postReader.findPostImagesByPostIds(anyList())).willReturn(Map.of());
 			given(likePostReader.getLikedPostIds(anyString(), anyList())).willReturn(Set.of());
@@ -591,7 +616,7 @@ public class PostServiceTest {
 				() -> assertThat(result.posts().get(0).boardName()).isEqualTo("테스트 게시판"),
 				() -> assertThat(result.nextCursor()).isNull());
 
-			verify(postReader, times(1)).findPostsWithCursor(anyList(), eq(null), eq(null), eq(20), eq(null));
+			verify(postReader, times(1)).findPostsWithCursor(anyList(), anySet(), eq(null), eq(null), eq(20), eq(null));
 		}
 
 		@DisplayName("여러 게시판의 게시글 목록 조회 성공")
@@ -667,7 +692,7 @@ public class PostServiceTest {
 			given(boardConfigReader.getAdminIdsByBoardId(boardId)).willReturn(boardAdminIds);
 			given(boardConfigReader.getAdminIdsByBoardId(boardId2)).willReturn(boardAdminIds);
 			given(boardConfigReader.getAdminIdSetMapByBoardIds(anySet())).willReturn(Map.of());
-			given(postReader.findPostsWithCursor(anyList(), eq(null), eq(null), eq(20), eq(null)))
+			given(postReader.findPostsWithCursor(anyList(), anySet(), eq(null), eq(null), eq(20), eq(null)))
 				.willReturn(slice);
 			given(postReader.findPostImagesByPostIds(anyList())).willReturn(Map.of());
 			given(likePostReader.getLikedPostIds(anyString(), anyList())).willReturn(Set.of());
@@ -689,7 +714,7 @@ public class PostServiceTest {
 
 			verify(boardConfigReader, times(1)).getByBoardId(boardId);
 			verify(boardConfigReader, times(1)).getByBoardId(boardId2);
-			verify(postReader, times(1)).findPostsWithCursor(anyList(), eq(null), eq(null), eq(20), eq(null));
+			verify(postReader, times(1)).findPostsWithCursor(anyList(), anySet(), eq(null), eq(null), eq(20), eq(null));
 		}
 
 		@DisplayName("커서 기반 페이징으로 게시글 목록 조회 성공")
@@ -734,6 +759,7 @@ public class PostServiceTest {
 			given(boardConfigReader.getAdminIdSetMapByBoardIds(anySet())).willReturn(Map.of());
 			given(postReader.findPostsWithCursor(
 				anyList(),
+				anySet(),
 				eq("2024-01-01T12:00:00"),
 				eq("post-id-1"),
 				eq(20),
@@ -754,6 +780,7 @@ public class PostServiceTest {
 
 			verify(postReader, times(1)).findPostsWithCursor(
 				anyList(),
+				anySet(),
 				eq("2024-01-01T12:00:00"),
 				eq("post-id-1"),
 				eq(20),
@@ -800,7 +827,7 @@ public class PostServiceTest {
 			given(boardConfigReader.getByBoardId(boardId)).willReturn(boardConfig);
 			given(boardConfigReader.getAdminIdsByBoardId(boardId)).willReturn(boardAdminIds);
 			given(boardConfigReader.getAdminIdSetMapByBoardIds(anySet())).willReturn(Map.of());
-			given(postReader.findPostsWithCursor(anyList(), eq(null), eq(null), eq(20), eq(keyword)))
+			given(postReader.findPostsWithCursor(anyList(), anySet(), eq(null), eq(null), eq(20), eq(keyword)))
 				.willReturn(slice);
 			given(postReader.findPostImagesByPostIds(anyList())).willReturn(Map.of());
 			given(likePostReader.getLikedPostIds(anyString(), anyList())).willReturn(Set.of());
@@ -814,7 +841,7 @@ public class PostServiceTest {
 				() -> assertThat(result.posts()).hasSize(1),
 				() -> assertThat(result.posts().get(0).content()).contains("검색어"));
 
-			verify(postReader, times(1)).findPostsWithCursor(anyList(), eq(null), eq(null), eq(20), eq(keyword));
+			verify(postReader, times(1)).findPostsWithCursor(anyList(), anySet(), eq(null), eq(null), eq(20), eq(keyword));
 		}
 
 		@DisplayName("게시판 ID 없이 전체 게시글 목록 조회 성공")
@@ -856,7 +883,7 @@ public class PostServiceTest {
 			given(boardConfigReader.getAccessibleBoardIdsByAcademicStatus(AcademicStatus.ENROLLED))
 				.willReturn(accessibleBoardIds);
 			given(boardConfigReader.getAdminIdSetMapByBoardIds(anySet())).willReturn(Map.of());
-			given(postReader.findPostsWithCursor(eq(accessibleBoardIds), eq(null), eq(null), eq(20), eq(null)))
+			given(postReader.findPostsWithCursor(eq(accessibleBoardIds), anySet(), eq(null), eq(null), eq(20), eq(null)))
 				.willReturn(slice);
 			given(postReader.findPostImagesByPostIds(anyList())).willReturn(Map.of());
 			given(likePostReader.getLikedPostIds(anyString(), anyList())).willReturn(Set.of());
@@ -891,7 +918,7 @@ public class PostServiceTest {
 				() -> assertThat(result.nextCursor()).isNull());
 
 			verify(boardConfigReader, times(1)).getAccessibleBoardIdsByAcademicStatus(AcademicStatus.ENROLLED);
-			verify(postReader, never()).findPostsWithCursor(anyList(), any(), any(), anyInt(), any());
+			verify(postReader, never()).findPostsWithCursor(anyList(), any(), any(), any(), anyInt(), any());
 		}
 
 		@DisplayName("숨겨진 게시판은 관리자만 조회 가능")
@@ -933,7 +960,7 @@ public class PostServiceTest {
 
 			given(boardConfigReader.getByBoardId(boardId)).willReturn(boardConfig);
 			given(boardConfigReader.getAdminIdsByBoardId(boardId)).willReturn(boardAdminIds);
-			given(postReader.findPostsWithCursor(anyList(), eq(null), eq(null), eq(20), eq(null)))
+			given(postReader.findPostsWithCursor(anyList(), anySet(), eq(null), eq(null), eq(20), eq(null)))
 				.willReturn(emptySlice);
 
 			// when
@@ -984,7 +1011,7 @@ public class PostServiceTest {
 			given(boardConfigReader.getByBoardId(boardId)).willReturn(boardConfig);
 			given(boardConfigReader.getAdminIdsByBoardId(boardId)).willReturn(boardAdminIds);
 			given(boardConfigReader.getAdminIdSetMapByBoardIds(anySet())).willReturn(Map.of());
-			given(postReader.findPostsWithCursor(anyList(), eq(null), eq(null), eq(20), eq(null)))
+			given(postReader.findPostsWithCursor(anyList(), anySet(), eq(null), eq(null), eq(20), eq(null)))
 				.willReturn(slice);
 			given(postReader.findPostImagesByPostIds(anyList())).willReturn(Map.of());
 			given(likePostReader.getLikedPostIds(anyString(), anyList())).willReturn(Set.of());
@@ -1002,7 +1029,7 @@ public class PostServiceTest {
 					.isEqualTo(ProfileImageType.GHOST),
 				() -> assertThat(result.posts().get(0).writerProfileImage().profileImageUrl()).isNull());
 
-			verify(postReader, times(1)).findPostsWithCursor(anyList(), eq(null), eq(null), eq(20), eq(null));
+			verify(postReader, times(1)).findPostsWithCursor(anyList(), anySet(), eq(null), eq(null), eq(20), eq(null));
 		}
 
 		@DisplayName("익명 게시판에서 일반 게시글과 익명 게시글 혼합 조회")
@@ -1066,7 +1093,7 @@ public class PostServiceTest {
 			given(boardConfigReader.getByBoardId(boardId)).willReturn(boardConfig);
 			given(boardConfigReader.getAdminIdsByBoardId(boardId)).willReturn(boardAdminIds);
 			given(boardConfigReader.getAdminIdSetMapByBoardIds(anySet())).willReturn(Map.of());
-			given(postReader.findPostsWithCursor(anyList(), eq(null), eq(null), eq(20), eq(null)))
+			given(postReader.findPostsWithCursor(anyList(), anySet(), eq(null), eq(null), eq(20), eq(null)))
 				.willReturn(slice);
 			given(postReader.findPostImagesByPostIds(anyList())).willReturn(Map.of());
 			given(likePostReader.getLikedPostIds(anyString(), anyList())).willReturn(Set.of());
@@ -1089,7 +1116,7 @@ public class PostServiceTest {
 				() -> assertThat(result.posts().get(1).writerProfileImage().profileImageType())
 					.isEqualTo(ProfileImageType.GHOST),
 				() -> assertThat(result.posts().get(1).writerProfileImage().profileImageUrl()).isNull());
-			verify(postReader, times(1)).findPostsWithCursor(anyList(), eq(null), eq(null), eq(20), eq(null));
+			verify(postReader, times(1)).findPostsWithCursor(anyList(), anySet(), eq(null), eq(null), eq(20), eq(null));
 		}
 	}
 

--- a/app-main/src/test/java/net/causw/app/main/domain/community/post/service/v2/PostServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/community/post/service/v2/PostServiceTest.java
@@ -1179,6 +1179,60 @@ public class PostServiceTest {
 			verify(likePostReader, never()).countByPostId(anyString());
 		}
 
+		@DisplayName("작성자는 차단 관계여도 본인 게시글 상세 조회 가능")
+		@Test
+		void getPostDetail_shouldSucceed_asOwner_evenWhenBlocked() {
+			// given
+			PostDetailQuery query = new PostDetailQuery(postId, writer);
+			List<String> boardAdminIds = List.of("admin-id");
+
+			given(postReader.findById(postId)).willReturn(post);
+			given(boardConfigReader.getByBoardId(boardId)).willReturn(boardConfig);
+			given(boardConfigReader.getAdminIdsByBoardId(boardId)).willReturn(boardAdminIds);
+			given(likePostReader.countByPostId(postId)).willReturn(10L);
+			given(favoritePostReader.countByPostId(postId)).willReturn(3L);
+			given(likePostReader.existsByPostIdAndUserId(postId, "writer-id")).willReturn(false);
+			given(favoritePostReader.existsByPostIdAndUserId(postId, "writer-id")).willReturn(false);
+
+			// when
+			PostDetailResult result = postService.getPostDetail(query);
+
+			// then
+			assertAll(
+				() -> assertThat(result).isNotNull(),
+				() -> assertThat(result.id()).isEqualTo(postId),
+				() -> assertThat(result.isOwner()).isTrue());
+			verify(blockReader, never()).existsByBlockerAndBlocked(any(), any());
+		}
+
+		@DisplayName("게시판 관리자는 차단한 사용자의 게시글도 상세 조회 가능")
+		@Test
+		void getPostDetail_shouldSucceed_asBoardAdmin_evenWhenWriterIsBlocked() {
+			// given
+			User admin = ObjectFixtures.getCertifiedUserWithId("admin-id");
+			PostDetailQuery query = new PostDetailQuery(postId, admin);
+			List<String> boardAdminIds = List.of("admin-id");
+
+			given(postReader.findById(postId)).willReturn(post);
+			given(boardConfigReader.getByBoardId(boardId)).willReturn(boardConfig);
+			given(boardConfigReader.getAdminIdsByBoardId(boardId)).willReturn(boardAdminIds);
+			given(likePostReader.countByPostId(postId)).willReturn(10L);
+			given(favoritePostReader.countByPostId(postId)).willReturn(3L);
+			given(likePostReader.existsByPostIdAndUserId(postId, "admin-id")).willReturn(false);
+			given(favoritePostReader.existsByPostIdAndUserId(postId, "admin-id")).willReturn(false);
+
+			// when
+			PostDetailResult result = postService.getPostDetail(query);
+
+			// then
+			assertAll(
+				() -> assertThat(result).isNotNull(),
+				() -> assertThat(result.id()).isEqualTo(postId),
+				() -> assertThat(result.updatable()).isTrue(),
+				() -> assertThat(result.deletable()).isTrue());
+			verify(blockReader, never()).existsByBlockerAndBlocked(any(), any());
+		}
+
 		@DisplayName("게시글 상세 조회 성공")
 		@Test
 		void getPostDetail_shouldSucceed() {


### PR DESCRIPTION
### 🚩 관련사항
close #1335 

### 📢 전달사항
v2에서 유저 차단 후에도 GET /api/v2/posts 응답에 차단한 유저의 게시글이 계속 노출되는 이슈가 있었음.
게시글 조회 시 작성자가 차단한 사용자인지 필터링하는 로직을 추가함.

**[변경내용]**
1. 목록 조회: BlockReader로 차단 ID 조회 후 findPostsWithCursor에 notInBlockedUsers 적용.
2. 단건 조회: 차단한 작성자 글은 PostErrorCode.BLOCKED_USER_CONTENT(403, POST_403_002) 반환.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 