### PR TITLE
feat: 재학인증 신청 시 알림에 학번 null로 뜨는 이슈

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/event/AdmissionRequestedEvent.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/event/AdmissionRequestedEvent.java
@@ -2,5 +2,5 @@ package net.causw.app.main.domain.notification.notification.event;
 
 import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.AcademicStatus;
 
-public record AdmissionRequestedEvent(String requesterId, AcademicStatus targetStatus) {
+public record AdmissionRequestedEvent(String requesterId, AcademicStatus targetStatus, String requestStudentId) {
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/AdmissionNotificationHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/AdmissionNotificationHandler.java
@@ -2,12 +2,7 @@ package net.causw.app.main.domain.notification.notification.service.handler;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
-import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.AcademicStatus;
-import net.causw.app.main.domain.user.account.entity.user.UserAdmission;
-import net.causw.app.main.domain.user.account.service.implementation.AdmissionReader;
-import net.causw.app.main.shared.exception.errorcode.UserErrorCode;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -25,7 +20,9 @@ import net.causw.app.main.domain.notification.notification.service.dto.UserNotif
 import net.causw.app.main.domain.notification.notification.service.implementation.NotificationPushSender;
 import net.causw.app.main.domain.notification.notification.service.implementation.NotificationSettingReader;
 import net.causw.app.main.domain.notification.notification.service.implementation.NotificationWriter;
+import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.AcademicStatus;
 import net.causw.app.main.domain.user.account.entity.user.User;
+import net.causw.app.main.domain.user.account.service.implementation.AdmissionReader;
 import net.causw.app.main.domain.user.account.service.implementation.UserReader;
 
 import lombok.RequiredArgsConstructor;
@@ -75,7 +72,7 @@ public class AdmissionNotificationHandler {
 		String message;
 		if (AcademicStatus.GRADUATED.equals(event.targetStatus())) {
 			message = String.format("%s(졸업생)님이 재학정보 인증을 요청했습니다.", requester.getName());
-		}else{
+		} else {
 			String studentId = event.requestStudentId();
 			message = String.format("%s(%s)님이 재학정보 인증을 요청했습니다.", requester.getName(), studentId);
 		}

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/AdmissionNotificationHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/AdmissionNotificationHandler.java
@@ -2,7 +2,12 @@ package net.causw.app.main.domain.notification.notification.service.handler;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
+import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.AcademicStatus;
+import net.causw.app.main.domain.user.account.entity.user.UserAdmission;
+import net.causw.app.main.domain.user.account.service.implementation.AdmissionReader;
+import net.causw.app.main.shared.exception.errorcode.UserErrorCode;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -33,6 +38,7 @@ public class AdmissionNotificationHandler {
 	private final NotificationWriter notificationWriter;
 	private final NotificationPushSender notificationPushSender;
 	private final NotificationSettingReader notificationSettingReader;
+	private final AdmissionReader admissionReader;
 
 	/**
 	 * 재학정보 인증 요청 알림 이벤트 핸들러.
@@ -51,7 +57,8 @@ public class AdmissionNotificationHandler {
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void handleRequest(AdmissionRequestedEvent event) {
 		// ID로 요청자 조회
-		User requester = userReader.findUserById(event.requesterId());
+		String userId = event.requesterId();
+		User requester = userReader.findUserById(userId);
 
 		// 해당 학적 상태를 담당하는 관리자 목록 조회
 		List<User> admins = userReader.findAdminsByAcademicStatus(event.targetStatus());
@@ -65,8 +72,16 @@ public class AdmissionNotificationHandler {
 			.findSettingMapByUserIds(adminIds);
 
 		String pushTitle = "재학정보 인증 요청";
-		String pushBody = String.format("%s(%s)님이 재학정보 인증을 요청했습니다.", requester.getName(), requester.getStudentId());
-		String serviceTitle = String.format("%s(%s)님이 재학정보 인증을 요청했습니다.", requester.getName(), requester.getStudentId());
+		String message;
+		if (AcademicStatus.GRADUATED.equals(event.targetStatus())) {
+			message = String.format("%s(졸업생)님이 재학정보 인증을 요청했습니다.", requester.getName());
+		}else{
+			String studentId = event.requestStudentId();
+			message = String.format("%s(%s)님이 재학정보 인증을 요청했습니다.", requester.getName(), studentId);
+		}
+
+		String pushBody = message;
+		String serviceTitle = message;
 
 		// 알림 엔티티 저장 (발송자: 요청자)
 		Notification notification = notificationWriter.save(

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/AdmissionNotificationHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/AdmissionNotificationHandler.java
@@ -66,13 +66,8 @@ public class AdmissionNotificationHandler {
 			.findSettingMapByUserIds(adminIds);
 
 		String pushTitle = "재학정보 인증 요청";
-		String message;
-		if (AcademicStatus.GRADUATED.equals(event.targetStatus())) {
-			message = String.format("%s(졸업생)님이 재학정보 인증을 요청했습니다.", requester.getName());
-		} else {
-			String studentId = event.requestStudentId();
-			message = String.format("%s(%s)님이 재학정보 인증을 요청했습니다.", requester.getName(), studentId);
-		}
+		String studentId = AcademicStatus.GRADUATED.equals(event.targetStatus()) ? "졸업생" : event.requestStudentId();
+		String message = String.format("%s(%s)님이 재학정보 인증을 요청했습니다.", requester.getName(), studentId);
 
 		String pushBody = message;
 		String serviceTitle = message;

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/AdmissionNotificationHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/AdmissionNotificationHandler.java
@@ -22,7 +22,6 @@ import net.causw.app.main.domain.notification.notification.service.implementatio
 import net.causw.app.main.domain.notification.notification.service.implementation.NotificationWriter;
 import net.causw.app.main.domain.user.academic.enums.userAcademicRecord.AcademicStatus;
 import net.causw.app.main.domain.user.account.entity.user.User;
-import net.causw.app.main.domain.user.account.service.implementation.AdmissionReader;
 import net.causw.app.main.domain.user.account.service.implementation.UserReader;
 
 import lombok.RequiredArgsConstructor;
@@ -35,7 +34,6 @@ public class AdmissionNotificationHandler {
 	private final NotificationWriter notificationWriter;
 	private final NotificationPushSender notificationPushSender;
 	private final NotificationSettingReader notificationSettingReader;
-	private final AdmissionReader admissionReader;
 
 	/**
 	 * 재학정보 인증 요청 알림 이벤트 핸들러.
@@ -54,8 +52,7 @@ public class AdmissionNotificationHandler {
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void handleRequest(AdmissionRequestedEvent event) {
 		// ID로 요청자 조회
-		String userId = event.requesterId();
-		User requester = userReader.findUserById(userId);
+		User requester = userReader.findUserById(event.requesterId());
 
 		// 해당 학적 상태를 담당하는 관리자 목록 조회
 		List<User> admins = userReader.findAdminsByAcademicStatus(event.targetStatus());

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/AdmissionService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/AdmissionService.java
@@ -70,7 +70,7 @@ public class AdmissionService {
 			dto.requestedDepartment(),
 			dto.graduationYear());
 
-		eventPublisher.publishEvent(new AdmissionRequestedEvent(user.getId(), admission.getRequestedAcademicStatus()));
+		eventPublisher.publishEvent(new AdmissionRequestedEvent(user.getId(), admission.getRequestedAcademicStatus(), dto.requestedStudentId()));
 
 		return AdmissionResult.from(admission);
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/AdmissionService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/AdmissionService.java
@@ -70,7 +70,8 @@ public class AdmissionService {
 			dto.requestedDepartment(),
 			dto.graduationYear());
 
-		eventPublisher.publishEvent(new AdmissionRequestedEvent(user.getId(), admission.getRequestedAcademicStatus(), dto.requestedStudentId()));
+		eventPublisher.publishEvent(new AdmissionRequestedEvent(user.getId(), admission.getRequestedAcademicStatus(),
+			dto.requestedStudentId()));
 
 		return AdmissionResult.from(admission);
 	}

--- a/app-main/src/test/java/net/causw/app/main/domain/notification/notification/service/handler/AdmissionNotificationHandlerTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/notification/notification/service/handler/AdmissionNotificationHandlerTest.java
@@ -59,9 +59,7 @@ class AdmissionNotificationHandlerTest {
 		void givenAdminsWithNotificationOn_whenHandleRequest_thenSendToAdmins() {
 			// given
 			User requester = mock(User.class);
-			// 성공 경로에서 pushBody 포맷에 사용되는 stub
 			given(requester.getName()).willReturn("홍길동");
-			given(requester.getStudentId()).willReturn("20191234");
 
 			User admin1 = userWithId("adminId1");
 			User admin2 = userWithId("adminId2");
@@ -76,7 +74,7 @@ class AdmissionNotificationHandlerTest {
 			given(notificationWriter.save(any())).willReturn(mock(Notification.class));
 
 			// when
-			handler.handleRequest(new AdmissionRequestedEvent("requesterId", AcademicStatus.ENROLLED));
+			handler.handleRequest(new AdmissionRequestedEvent("requesterId", AcademicStatus.ENROLLED, "20191234"));
 
 			// then
 			verify(notificationWriter).save(any());
@@ -93,7 +91,7 @@ class AdmissionNotificationHandlerTest {
 			given(userReader.findAdminsByAcademicStatus(AcademicStatus.ENROLLED)).willReturn(List.of());
 
 			// when
-			handler.handleRequest(new AdmissionRequestedEvent("requesterId", AcademicStatus.ENROLLED));
+			handler.handleRequest(new AdmissionRequestedEvent("requesterId", AcademicStatus.ENROLLED, "20191234"));
 
 			// then
 			verify(notificationWriter, never()).save(any());
@@ -105,7 +103,6 @@ class AdmissionNotificationHandlerTest {
 			// given
 			User requester = mock(User.class);
 			given(requester.getName()).willReturn("홍길동");
-			given(requester.getStudentId()).willReturn("20191234");
 
 			User adminOn = userWithId("adminOnId");
 			User adminOff = userWithId("adminOffId");
@@ -120,7 +117,7 @@ class AdmissionNotificationHandlerTest {
 			given(notificationWriter.save(any())).willReturn(mock(Notification.class));
 
 			// when
-			handler.handleRequest(new AdmissionRequestedEvent("requesterId", AcademicStatus.ENROLLED));
+			handler.handleRequest(new AdmissionRequestedEvent("requesterId", AcademicStatus.ENROLLED, "20191234"));
 
 			// then
 			verify(notificationPushSender).sendToUser(eq(adminOn), any(), any());


### PR DESCRIPTION
### 🚩 관련사항
#1338

### 📢 전달사항
재학인증 요청 알림 메시지에 신청자의 학번이 `null`로 표시되는 버그를 수정합니다.

**원인**
`AdmissionNotificationHandler.handleRequest()`에서 알림 메시지 생성 시 `requester.getStudentId()`를 사용했습니다.
그러나 `User.studentId`는 재학인증 **승인 시점**에 설정되기 때문에, 신청 시점에는 항상 `null`이었습니다.
신청자가 입력한 학번은 `UserAdmission.requestedStudentId`에 저장되므로, 이를 이벤트를 통해 전달해야 합니다.

**수정 내용**
- `AdmissionRequestedEvent`에 이미 추가되어 있던 `requestStudentId` 필드를 핸들러에서 올바르게 사용하도록 수정
- 졸업생(`GRADUATED`) 상태의 경우 학번 대신 `(졸업생)`으로 표시
- 불필요하게 import되었던 `AdmissionReader`, `UserAdmission`, `UserErrorCode`, `Optional` 제거

**집중해서 볼 부분**
- `AdmissionNotificationHandler.handleRequest()` — 메시지 생성 분기 로직 (`GRADUATED` 여부에 따른 처리)
- `AdmissionService.createAdmission()` — 이벤트 발행 시 `dto.requestedStudentId()` 전달 확인

### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.
<img width="882" height="323" alt="image" src="https://github.com/user-attachments/assets/479e7de6-cd04-4a64-a683-f2c1d92f1fae" />

<img width="847" height="290" alt="image" src="https://github.com/user-attachments/assets/dbe3bf14-b5c5-47db-be6f-a21cd6e988eb" />

### 📃 진행사항
- [x] 재학인증 요청 알림 메시지에 신청 학번(`requestStudentId`) 정상 표시
- [x] 졸업생 신청 시 학번 대신 `(졸업생)` 표시
- [x] 불필요한 import 정리 (spotless)

### ⚙️ 기타사항

개발기간: 2026-05-17 ~ 2026-05-17