### PR TITLE
feat: 비밀번호 재설정 api public 허용되게 수정

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/core/security/WebSecurityConfig.java
+++ b/app-main/src/main/java/net/causw/app/main/core/security/WebSecurityConfig.java
@@ -81,7 +81,8 @@ public class WebSecurityConfig {
 				.requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
 				.requestMatchers("/api/v2/auth/logout", "/api/v2/auth/onboarding/**").authenticated()
 				.requestMatchers("/api/v2/auth/**", "/oauth2/**", "/login/oauth2/**",
-					"/api/v2/users/check-nickname", "/api/v2/users/check-phone")
+					"/api/v2/users/check-nickname", "/api/v2/users/check-phone",
+					"/api/v2/users/password-change")
 				.permitAll()
 				.requestMatchers(HttpMethod.GET, "/api/v2/terms")
 				.permitAll()

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/controller/UserController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/controller/UserController.java
@@ -192,14 +192,12 @@ public class UserController {
 		return ApiResponse.success();
 	}
 
-	@PostMapping("/me/password-change")
-	@Operation(summary = "비밀번호 재설정 API", description = "현재 비밀번호를 확인하고 새 비밀번호로 변경합니다.")
+	@PostMapping("/password-change")
+	@Operation(summary = "비밀번호 재설정 API", description = "이메일과 현재 비밀번호를 확인하고 새 비밀번호로 변경합니다. "
+		+ "비밀번호 찾기 후 임시 비밀번호로 로그인하기 전에도 호출할 수 있습니다.")
 	public ApiResponse<Void> updatePassword(
-		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@Valid @RequestBody UserPasswordUpdateRequest body) {
-		userAccountService.updatePassword(
-			userDetails.getUserId(),
-			UserPasswordUpdateCommand.from(body));
+		userAccountService.updatePassword(UserPasswordUpdateCommand.from(body));
 		return ApiResponse.success();
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/dto/request/UserPasswordUpdateRequest.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/dto/request/UserPasswordUpdateRequest.java
@@ -3,11 +3,14 @@ package net.causw.app.main.domain.user.account.api.v2.dto.request;
 import net.causw.app.main.domain.user.account.policy.PasswordPolicy;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record UserPasswordUpdateRequest(
-	@NotBlank(message = "현재 비밀번호를 입력해 주세요.") @Schema(description = "현재 비밀번호", example = "Current1!") String currentPassword,
+	@Email(message = "이메일 형식에 맞지 않습니다.") @NotBlank(message = "이메일을 입력해 주세요.") @Schema(description = "비밀번호를 변경할 계정 이메일", example = "user@cau.ac.kr") String email,
+
+	@NotBlank(message = "현재 비밀번호를 입력해 주세요.") @Schema(description = "현재 비밀번호 (비밀번호 찾기 후에는 임시 비밀번호)", example = "Current1!") String currentPassword,
 
 	@NotBlank(message = "새 비밀번호를 입력해 주세요.") @Pattern(regexp = PasswordPolicy.REGEX, message = PasswordPolicy.VALIDATION_MESSAGE) @Schema(description = "새 비밀번호 (영문, 숫자, 특수문자 포함 8자 이상 20자 이하)", example = "NewPass1!") String newPassword,
 	@NotBlank(message = "새 비밀번호 확인을 입력해 주세요.") @Schema(description = "새 비밀번호 확인", example = "NewPass1!") String newPasswordConfirm) {

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAccountService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAccountService.java
@@ -202,7 +202,6 @@ public class UserAccountService {
 	 * 현재 비밀번호 일치 여부, 새 비밀번호 형식, 새 비밀번호 확인 일치 여부를 검사합니다.
 	 * </p>
 	 *
-	 * @param userId             비밀번호를 변경할 유저의 고유 식별자 (PK)
 	 * @param command			비밀번호 재설정 command
 	 * @throws net.causw.app.main.shared.exception.BaseRunTimeV2Exception
 	 * [SOCIAL_USER_CANNOT_CHANGE_PASSWORD] 소셜 로그인 전용 계정인 경우,
@@ -211,8 +210,8 @@ public class UserAccountService {
 	 * [PASSWORD_CONFIRM_MISMATCH] 새 비밀번호와 확인 값이 일치하지 않는 경우
 	 */
 	@Transactional
-	public void updatePassword(String userId, UserPasswordUpdateCommand command) {
-		User user = userReader.findUserById(userId);
+	public void updatePassword(UserPasswordUpdateCommand command) {
+		User user = userReader.findByEmailOrElseThrow(command.email());
 
 		// 관리자 강제 탈퇴(DROP) 먼저 체크
 		if (user.getState().equals(UserState.DROP)) {

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/dto/request/UserPasswordUpdateCommand.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/dto/request/UserPasswordUpdateCommand.java
@@ -3,12 +3,14 @@ package net.causw.app.main.domain.user.account.service.dto.request;
 import net.causw.app.main.domain.user.account.api.v2.dto.request.UserPasswordUpdateRequest;
 
 public record UserPasswordUpdateCommand(
+	String email,
 	String currentPassword,
 	String newPassword,
 	String newPasswordConfirm) {
 
 	public static UserPasswordUpdateCommand from(UserPasswordUpdateRequest request) {
 		return new UserPasswordUpdateCommand(
+			request.email(),
 			request.currentPassword(),
 			request.newPassword(),
 			request.newPasswordConfirm());

--- a/app-main/src/test/java/net/causw/app/main/infrastructure/security/WebSecurityConfigTest.java
+++ b/app-main/src/test/java/net/causw/app/main/infrastructure/security/WebSecurityConfigTest.java
@@ -248,5 +248,13 @@ public class WebSecurityConfigTest {
 			mockMvc.perform(MockMvcRequestBuilders.get("/api/v2/terms"))
 				.andExpect(status().isNotFound());
 		}
+
+		@Test
+		@WithAnonymousUser
+		@DisplayName("/api/v2/users/password-change 경로는 인증 없이 접근 허용")
+		void shouldAllowV2PasswordChangeAccess_WhenAnonymous() throws Exception {
+			mockMvc.perform(MockMvcRequestBuilders.post("/api/v2/users/password-change"))
+				.andExpect(status().isNotFound());
+		}
 	}
 }


### PR DESCRIPTION
### 🚩 관련사항
close #1348 


### 📢 전달사항
v2 비밀번호 찾기 UX에서 password-reset/verify로 임시 비밀번호를 받은 뒤, 로그인하기 전에 새 비밀번호로 바꿀 수 있도록 비밀번호 변경 API를 public 엔드포인트로 변경했습니다.

- 엔드포인트: POST /api/v2/users/me/password-change → POST /api/v2/users/password-change
- 인증: JWT 기반 사용자 식별 제거 → permitAll
- 식별: 요청 body의 email로 사용자 조회 후, currentPassword 검증 및 새 비밀번호 저장
- 마이페이지·비밀번호 찾기 플로우가 동일 API를 사용하도록 통일


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [ ] done1
- [ ] done2 (진행되었어야 하는데 미처 하지 못한 부분 혹은 관련하여 앞으로 진행되어야 하는 부분도 전부 적어서 체크 표시로 관리해주세요.)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 