### PR TITLE
Fix: FCM 토큰 DB 이전에 따른 탈퇴/추방 cleanup 토큰 삭제 로직 변경

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/implementation/UserPushTokenWriter.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/implementation/UserPushTokenWriter.java
@@ -34,7 +34,7 @@ public class UserPushTokenWriter {
 	private final FcmTokenRepository fcmTokenRepository;
 
 	/**
-	 * 새로운 FCM 토큰을 등록하고 Redis에 메타데이터를 저장합니다.
+	 * 새로운 FCM 토큰을 DB에 저장합니다.
 	 * <p>
 	 * 동일 토큰이 다른 사용자에게 등록되어 있으면 먼저 제거한 뒤 현재 사용자에게 등록합니다.
 	 * 이미 현재 사용자에게 등록된 토큰이라면 중복 저장하지 않습니다.
@@ -57,7 +57,7 @@ public class UserPushTokenWriter {
 	/**
 	 * 특정 기기의 FCM 토큰을 삭제합니다.
 	 * <p>
-	 * 로그아웃 시 호출되며, DB와 Redis 양쪽에서 해당 토큰 데이터를 제거합니다.
+	 * 로그아웃 시 호출되며, DB에서 해당 토큰 데이터를 제거합니다.
 	 *
 	 * @param user     사용자 엔티티
 	 * @param fcmToken 삭제할 FCM 토큰
@@ -67,6 +67,7 @@ public class UserPushTokenWriter {
 			//			throw AuthErrorCode.NO_PERMISSION_FOR_RESOURCE.toBaseException();
 			log.info("[FCM 토큰 삭제 실패] 이미 삭제된 FCM 토큰입니다.");
 		}
+		fcmTokenRepository.deleteByUser_IdAndTokenValue(user.getId(), fcmToken);
 	}
 
 	/**
@@ -77,6 +78,7 @@ public class UserPushTokenWriter {
 	 * @param user 사용자 엔티티
 	 */
 	public void clearFcmTokens(User user) {
-		fcmTokenRepository.deleteAllByUser(user);
+		user.getFcmTokens().forEach(user::removeFcmToken);
+		fcmTokenRepository.deleteAllByUser_Id(user.getId());
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/implementation/UserPushTokenWriter.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/implementation/UserPushTokenWriter.java
@@ -67,7 +67,6 @@ public class UserPushTokenWriter {
 			//			throw AuthErrorCode.NO_PERMISSION_FOR_RESOURCE.toBaseException();
 			log.info("[FCM 토큰 삭제 실패] 이미 삭제된 FCM 토큰입니다.");
 		}
-		fcmTokenRepository.deleteByUser_IdAndTokenValue(user.getId(), fcmToken);
 	}
 
 	/**
@@ -78,7 +77,6 @@ public class UserPushTokenWriter {
 	 * @param user 사용자 엔티티
 	 */
 	public void clearFcmTokens(User user) {
-		user.getFcmTokens().forEach(user::removeFcmToken);
-		fcmTokenRepository.deleteAllByUser_Id(user.getId());
+		user.clearFcmTokens();
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/entity/user/User.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/entity/user/User.java
@@ -389,6 +389,11 @@ public class User extends BaseEntity {
 		return fcmTokenEntities.removeIf(t -> t.getTokenValue().equals(targetToken));
 	}
 
+	// FCM 토큰 전체 삭제
+	public void clearFcmTokens() {
+		this.fcmTokenEntities.clear();
+	}
+
 	public boolean isOnlySocialUser() {
 		return this.password == null;
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/user/FcmTokenRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/user/FcmTokenRepository.java
@@ -21,4 +21,17 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, String> {
 	 * @param user 대상 유저
 	 */
 	void deleteAllByUser(User user);
+
+	/**
+	 * 특정 user의 fcm 토큰 삭제
+	 * @param userId 대상 유저 ID
+	 * @param tokenValue 삭제할 fcm 토큰 value
+	 */
+	void deleteByUser_IdAndTokenValue(String userId, String tokenValue);
+
+	/**
+	 * 특정 user의 전체 fcm 토큰 삭제
+	 * @param userId 대상 유저 ID
+	 */
+	void deleteAllByUser_Id(String userId);
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/user/FcmTokenRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/user/FcmTokenRepository.java
@@ -21,17 +21,4 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, String> {
 	 * @param user 대상 유저
 	 */
 	void deleteAllByUser(User user);
-
-	/**
-	 * 특정 user의 fcm 토큰 삭제
-	 * @param userId 대상 유저 ID
-	 * @param tokenValue 삭제할 fcm 토큰 value
-	 */
-	void deleteByUser_IdAndTokenValue(String userId, String tokenValue);
-
-	/**
-	 * 특정 user의 전체 fcm 토큰 삭제
-	 * @param userId 대상 유저 ID
-	 */
-	void deleteAllByUser_Id(String userId);
 }

--- a/app-main/src/test/java/net/causw/app/main/domain/user/account/service/implementation/UserAccountCleanupWriterTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/user/account/service/implementation/UserAccountCleanupWriterTest.java
@@ -1,0 +1,87 @@
+package net.causw.app.main.domain.user.account.service.implementation;
+
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import net.causw.app.main.domain.notification.notification.service.implementation.UserPushTokenWriter;
+import net.causw.app.main.domain.user.account.entity.user.User;
+import net.causw.app.main.domain.user.auth.service.implementation.AuthTokenManager;
+
+@ExtendWith(MockitoExtension.class)
+class UserAccountCleanupWriterTest {
+
+	@InjectMocks
+	private UserAccountCleanupWriter userAccountCleanupWriter;
+
+	@Mock
+	private SocialAccountReader socialAccountReader;
+
+	@Mock
+	private SocialAccountUnlinkManager socialAccountUnlinkManager;
+
+	@Mock
+	private AuthTokenManager authTokenManager;
+
+	@Mock
+	private UserPushTokenWriter userPushTokenWriter;
+
+	@Nested
+	@DisplayName("회원 탈퇴 정리")
+	class CleanupForWithdrawal {
+
+		@Test
+		@DisplayName("성공: 토큰 무효화와 FCM 토큰 전체 삭제를 수행한다")
+		void success() {
+			// given
+			User user = mock(User.class);
+			String userId = "user-id";
+			String accessToken = "access-token";
+			String refreshToken = "refresh-token";
+			String platformHint = "ios";
+
+			when(user.getId()).thenReturn(userId);
+			when(socialAccountReader.findAllByUserId(userId)).thenReturn(List.of());
+
+			// when
+			userAccountCleanupWriter.cleanupForWithdrawal(user, accessToken, refreshToken, platformHint);
+
+			// then
+			verify(socialAccountReader).findAllByUserId(userId);
+			verify(authTokenManager).invalidateTokens(accessToken, refreshToken);
+			verify(userPushTokenWriter).clearFcmTokens(user);
+		}
+	}
+
+	@Nested
+	@DisplayName("관리자 추방 정리")
+	class CleanupForDrop {
+
+		@Test
+		@DisplayName("성공: FCM 토큰 전체 삭제를 수행한다")
+		void success() {
+			// given
+			User user = mock(User.class);
+			String userId = "user-id";
+
+			when(user.getId()).thenReturn(userId);
+			when(socialAccountReader.findAllByUserId(userId)).thenReturn(List.of());
+
+			// when
+			userAccountCleanupWriter.cleanupForDrop(user);
+
+			// then
+			verify(socialAccountReader).findAllByUserId(userId);
+			verify(userPushTokenWriter).clearFcmTokens(user);
+			verify(authTokenManager, never()).invalidateTokens(any(), any());
+		}
+	}
+}

--- a/app-main/src/test/java/net/causw/app/main/domain/user/account/service/implementation/UserAccountCleanupWriterTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/user/account/service/implementation/UserAccountCleanupWriterTest.java
@@ -40,7 +40,7 @@ class UserAccountCleanupWriterTest {
 
 		@Test
 		@DisplayName("성공: 토큰 무효화와 FCM 토큰 전체 삭제를 수행한다")
-		void success() {
+		void givenUser_whenCleanupForWithdrawal_thenTokensInvalidatedAndCleared() {
 			// given
 			User user = mock(User.class);
 			String userId = "user-id";
@@ -67,7 +67,7 @@ class UserAccountCleanupWriterTest {
 
 		@Test
 		@DisplayName("성공: FCM 토큰 전체 삭제를 수행한다")
-		void success() {
+		void givenUser_whenCleanupForDrop_thenTokensCleared() {
 			// given
 			User user = mock(User.class);
 			String userId = "user-id";


### PR DESCRIPTION
### 🚩 관련사항
- V2 추방 관련 이슈: #1289
- Closes #1351


### 📢 전달사항
FCM 토큰 저장 방식이 Redis/기존 컬렉션 중심에서 DB 테이블(`tb_fcm_token`) 기준으로 변경되었지만, 계정 정리 시 FCM 토큰 삭제 로직이 DB 저장소 기준으로 완전히 정리되지 않은 문제가 있었습니다.

이번 PR에서는 회원 탈퇴 및 관리자 추방 시 호출되는 `UserAccountCleanupWriter` 흐름에서 FCM 토큰이 확실히 삭제되도록 수정했습니다.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
  - [x] FCM 토큰 단건 삭제 시 DB row 삭제 추가
  - [x] 회원 탈퇴/추방 시 FCM 토큰 전체 삭제 로직 보완
  - [x] userId 기준 FCM 토큰 삭제 Repository 메서드 추가
  - [x] 회원 탈퇴 cleanup 테스트 추가
  - [x] 관리자 추방 cleanup 테스트 추가
  - [x] `./gradlew compileTestJava` 성공 확인


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 2026.05.20.