### PR TITLE
fix: 알림 설정

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/repository/UserBoardSubscribeRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/repository/UserBoardSubscribeRepository.java
@@ -35,6 +35,7 @@ public interface UserBoardSubscribeRepository extends JpaRepository<UserBoardSub
 	@EntityGraph(attributePaths = {"board"})
 	List<UserBoardSubscribe> findByUserAndIsSubscribedTrue(User user);
 
+	@EntityGraph(attributePaths = {"board"})
 	List<UserBoardSubscribe> findByUserAndBoardIn(User user, List<Board> boards);
 
 	void deleteAllByUserAndBoard_IsAlumniFalse(User user);

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/implementation/UserBoardSubscribeReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/implementation/UserBoardSubscribeReader.java
@@ -1,9 +1,13 @@
 package net.causw.app.main.domain.notification.notification.service.implementation;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import net.causw.app.main.shared.entity.BaseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,11 +28,37 @@ public class UserBoardSubscribeReader {
 	private final UserBoardSubscribeRepository userBoardSubscribeRepository;
 	private final UserBoardSubscribeQueryRepository userBoardSubscribeQueryRepository;
 
+	/**
+	 * <p>
+	 *     특정 게시판들에 대한 유저의 알림 설정 여부
+	 * </p>
+	 * <p>
+	 *     알림 설정 row 가 없는 경우, 기본 설정값은 알림 ON
+	 * </p>
+	 *
+	 * @param user 확인 대상 유저
+	 * @param boards 확인 대상 게시판
+	 * @return 알림 ON 인 board 리스트
+	 */
 	public Set<String> findSubscribedBoardIds(User user, List<Board> boards) {
-		return userBoardSubscribeRepository.findByUserAndBoardIn(user, boards).stream()
-			.filter(s -> Boolean.TRUE.equals(s.getIsSubscribed()))
-			.map(s -> s.getBoard().getId())
-			.collect(Collectors.toSet());
+		List<UserBoardSubscribe> userBoardSubscribes = userBoardSubscribeRepository.findByUserAndBoardIn(user, boards);
+		// boardId -> 알림 설정 기록
+		Map<String, UserBoardSubscribe> boardIdSubscribeMap = userBoardSubscribes.stream().collect(Collectors.toMap(
+				userBoardSubscribe -> {
+					var board = userBoardSubscribe.getBoard();
+					return board.getId();
+				},
+				Function.identity()
+		));
+
+		return boards.stream()
+				.map(Board::getId)
+				.filter(id -> {
+					UserBoardSubscribe boardSubscribe = boardIdSubscribeMap.get(id);
+
+					// boardSubscribe가 존재하지 않거나, 알림을 명시적으로 켜둔 경우 모두 return
+					return boardSubscribe == null || Boolean.TRUE.equals(boardSubscribe.getIsSubscribed());
+				}).collect(Collectors.toSet());
 	}
 
 	public List<UserBoardSubscribe> findForNotification(Board board, Set<String> blockerUserIds) {

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/implementation/UserBoardSubscribeReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/implementation/UserBoardSubscribeReader.java
@@ -1,9 +1,7 @@
 package net.causw.app.main.domain.notification.notification.service.implementation;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
@@ -41,21 +39,16 @@ public class UserBoardSubscribeReader {
 	public Set<String> findSubscribedBoardIds(User user, List<Board> boards) {
 		List<UserBoardSubscribe> userBoardSubscribes = userBoardSubscribeRepository.findByUserAndBoardIn(user, boards);
 		// boardId -> 알림 설정 기록
-		Map<String, UserBoardSubscribe> boardIdSubscribeMap = userBoardSubscribes.stream().collect(Collectors.toMap(
-			userBoardSubscribe -> {
-				var board = userBoardSubscribe.getBoard();
-				return board.getId();
-			},
-			Function.identity()));
+		Set<String> unSubscribedBoardIds = userBoardSubscribes.stream()
+			.filter(subscribe -> Boolean.FALSE.equals(subscribe.getIsSubscribed()))
+			.map(subscribe -> subscribe.getBoard().getId())
+			.collect(Collectors.toSet());
 
+		// 알림 설정이 false인 것만 제외
 		return boards.stream()
 			.map(Board::getId)
-			.filter(id -> {
-				UserBoardSubscribe boardSubscribe = boardIdSubscribeMap.get(id);
-
-				// boardSubscribe가 존재하지 않거나, 알림을 명시적으로 켜둔 경우 모두 return
-				return boardSubscribe == null || Boolean.TRUE.equals(boardSubscribe.getIsSubscribed());
-			}).collect(Collectors.toSet());
+			.filter(id -> !unSubscribedBoardIds.contains(id))
+			.collect(Collectors.toSet());
 	}
 
 	public List<UserBoardSubscribe> findForNotification(Board board, Set<String> blockerUserIds) {

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/implementation/UserBoardSubscribeReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/implementation/UserBoardSubscribeReader.java
@@ -1,13 +1,11 @@
 package net.causw.app.main.domain.notification.notification.service.implementation;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import net.causw.app.main.shared.entity.BaseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,21 +42,20 @@ public class UserBoardSubscribeReader {
 		List<UserBoardSubscribe> userBoardSubscribes = userBoardSubscribeRepository.findByUserAndBoardIn(user, boards);
 		// boardId -> 알림 설정 기록
 		Map<String, UserBoardSubscribe> boardIdSubscribeMap = userBoardSubscribes.stream().collect(Collectors.toMap(
-				userBoardSubscribe -> {
-					var board = userBoardSubscribe.getBoard();
-					return board.getId();
-				},
-				Function.identity()
-		));
+			userBoardSubscribe -> {
+				var board = userBoardSubscribe.getBoard();
+				return board.getId();
+			},
+			Function.identity()));
 
 		return boards.stream()
-				.map(Board::getId)
-				.filter(id -> {
-					UserBoardSubscribe boardSubscribe = boardIdSubscribeMap.get(id);
+			.map(Board::getId)
+			.filter(id -> {
+				UserBoardSubscribe boardSubscribe = boardIdSubscribeMap.get(id);
 
-					// boardSubscribe가 존재하지 않거나, 알림을 명시적으로 켜둔 경우 모두 return
-					return boardSubscribe == null || Boolean.TRUE.equals(boardSubscribe.getIsSubscribed());
-				}).collect(Collectors.toSet());
+				// boardSubscribe가 존재하지 않거나, 알림을 명시적으로 켜둔 경우 모두 return
+				return boardSubscribe == null || Boolean.TRUE.equals(boardSubscribe.getIsSubscribed());
+			}).collect(Collectors.toSet());
 	}
 
 	public List<UserBoardSubscribe> findForNotification(Board board, Set<String> blockerUserIds) {


### PR DESCRIPTION
### 🚩 관련사항
Close #1359

### 📢 전달사항
유저 게시판 알림 설정 조회 시 기본값이 의도와 다르게 동작하던 이슈를 수정했습니다.

**문제 상황**
- `UserBoardSubscribeReader.findSubscribedBoardIds()`는 알림이 ON 상태인 게시판 ID 집합을 반환합니다.
- 기존 구현은 `UserBoardSubscribe` row가 존재하면서 `isSubscribed = true`인 경우에만 ON으로 간주했습니다.
- 그러나 `UserBoardSubscribe` row가 아예 없는 경우(= 한 번도 알림 설정을 변경한 적 없는 게시판)는 정책상 **기본값이 알림 ON** 이어야 함에도, 기존 로직에서는 결과 집합에 포함되지 않아 알림이 발송되지 않는 문제가 있었습니다.

**수정 내용**
- 조회된 `UserBoardSubscribe` 목록을 `boardId -> UserBoardSubscribe` Map으로 변환합니다.
- 입력으로 들어온 `boards` 전체를 순회하면서, 다음 두 조건 중 하나를 만족하면 알림 ON으로 판정하도록 변경했습니다.
  1. 해당 board에 대한 `UserBoardSubscribe` row가 존재하지 않음 (기본값 ON 적용)
  2. row가 존재하고 `isSubscribed = true`로 명시적으로 설정됨
- 의도 명확화를 위해 메서드에 Javadoc을 추가했습니다.

### 📸 스크린샷
N/A

### 📃 진행사항
- [x] 유저 알림 조회 시 기본값이 ON 아니었던 이슈 수정 (`UserBoardSubscribeReader.findSubscribedBoardIds`)
- [x] 메서드 Javadoc 추가 및 스타일 정리

### ⚙️ 기타사항

개발기간: 2026-05-24 ~ 2026-05-24
