### PR TITLE
fix: 게시글 수정시 익명여부 미반영 수정

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/entity/Post.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/entity/Post.java
@@ -158,16 +158,10 @@ public class Post extends BaseEntity {
 		this.postAttachImageList.addAll(postAttachImageList);
 	}
 
-	public void updateContentAndImages(String content, List<PostAttachImage> postAttachImageList) {
-		this.content = content;
-		this.postAttachImageList.clear();
-		this.postAttachImageList.addAll(postAttachImageList);
-	}
-
-	public void updateContentImagesAndAnonymous(String content, Boolean isAnonymous,
+	public void updateContentAndImages(String content, Boolean isAnonymous,
 		List<PostAttachImage> postAttachImageList) {
 		this.content = content;
-		this.isAnonymous = isAnonymous;
+		this.isAnonymous = (isAnonymous != null) ? isAnonymous : this.isAnonymous;
 		this.postAttachImageList.clear();
 		this.postAttachImageList.addAll(postAttachImageList);
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/entity/Post.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/entity/Post.java
@@ -164,6 +164,14 @@ public class Post extends BaseEntity {
 		this.postAttachImageList.addAll(postAttachImageList);
 	}
 
+	public void updateContentImagesAndAnonymous(String content, Boolean isAnonymous,
+		List<PostAttachImage> postAttachImageList) {
+		this.content = content;
+		this.isAnonymous = isAnonymous;
+		this.postAttachImageList.clear();
+		this.postAttachImageList.addAll(postAttachImageList);
+	}
+
 	public void setIsDeleted(Boolean isDeleted) {
 		this.isDeleted = isDeleted;
 		if (form != null) {

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/PostService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/PostService.java
@@ -139,8 +139,8 @@ public class PostService {
 			post, command.newImageFiles(), command.imageMetas());
 
 		// 게시글 업데이트
-		Post updatedPost = postWriter.updateContentAndImages(
-			post, command.content(), imageResult.finalImages());
+		Post updatedPost = postWriter.updateContentImagesAndAnonymous(
+			post, command.content(), command.isAnonymous(), imageResult.finalImages());
 
 		List<String> imageUrls = imageResult.finalImages().stream()
 			.map(img -> img.getUuidFile().getFileUrl())

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/PostService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/PostService.java
@@ -94,7 +94,7 @@ public class PostService {
 			savedPost, command.imageFiles(), command.imageMetas());
 
 		if (!postAttachImages.isEmpty()) {
-			savedPost.updateContentAndImages(savedPost.getContent(), postAttachImages);
+			savedPost.updateContentAndImages(savedPost.getContent(), savedPost.getIsAnonymous(), postAttachImages);
 		}
 
 		List<String> imageUrls = postAttachImages.stream()
@@ -139,7 +139,7 @@ public class PostService {
 			post, command.newImageFiles(), command.imageMetas());
 
 		// 게시글 업데이트
-		Post updatedPost = postWriter.updateContentImagesAndAnonymous(
+		Post updatedPost = postWriter.updateContentAndImages(
 			post, command.content(), command.isAnonymous(), imageResult.finalImages());
 
 		List<String> imageUrls = imageResult.finalImages().stream()

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/implementation/PostWriter.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/implementation/PostWriter.java
@@ -63,6 +63,21 @@ public class PostWriter {
 	}
 
 	/**
+	 * Post의 내용, 익명 여부, 이미지를 업데이트합니다.
+	 *
+	 * @param post 수정할 Post
+	 * @param content 내용
+	 * @param isAnonymous 익명 여부
+	 * @param postAttachImageList 첨부 이미지 리스트
+	 * @return 수정된 Post Entity
+	 */
+	public Post updateContentImagesAndAnonymous(Post post, String content, Boolean isAnonymous,
+		List<PostAttachImage> postAttachImageList) {
+		post.updateContentImagesAndAnonymous(content, isAnonymous, postAttachImageList);
+		return postRepository.save(post);
+	}
+
+	/**
 	 * Post에 Vote를 연결합니다.
 	 *
 	 * @param post Post Entity

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/implementation/PostWriter.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/implementation/PostWriter.java
@@ -50,30 +50,18 @@ public class PostWriter {
 	}
 
 	/**
-	 * Post의 내용과 이미지만 업데이트합니다.
-	 *
-	 * @param post 수정할 Post
-	 * @param content 내용
-	 * @param postAttachImageList 첨부 이미지 리스트
-	 * @return 수정된 Post Entity
-	 */
-	public Post updateContentAndImages(Post post, String content, List<PostAttachImage> postAttachImageList) {
-		post.updateContentAndImages(content, postAttachImageList);
-		return postRepository.save(post);
-	}
-
-	/**
 	 * Post의 내용, 익명 여부, 이미지를 업데이트합니다.
+	 * isAnonymous가 null인 경우 기존 값을 유지합니다.
 	 *
 	 * @param post 수정할 Post
 	 * @param content 내용
-	 * @param isAnonymous 익명 여부
+	 * @param isAnonymous 익명 여부 (null 허용 - null이면 기존 값 유지)
 	 * @param postAttachImageList 첨부 이미지 리스트
 	 * @return 수정된 Post Entity
 	 */
-	public Post updateContentImagesAndAnonymous(Post post, String content, Boolean isAnonymous,
+	public Post updateContentAndImages(Post post, String content, Boolean isAnonymous,
 		List<PostAttachImage> postAttachImageList) {
-		post.updateContentImagesAndAnonymous(content, isAnonymous, postAttachImageList);
+		post.updateContentAndImages(content, isAnonymous, postAttachImageList);
 		return postRepository.save(post);
 	}
 

--- a/app-main/src/test/java/net/causw/app/main/domain/community/post/service/v2/PostServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/community/post/service/v2/PostServiceTest.java
@@ -422,7 +422,7 @@ public class PostServiceTest {
 			given(boardConfigReader.getAdminIdsByBoardId(boardId)).willReturn(boardAdminIds);
 			given(postImageManager.mergeAndBuildForUpdate(eq(post), isNull(), isNull()))
 				.willReturn(new PostImageManager.ImageUpdateResult(List.of(), List.of()));
-			given(postWriter.updateContentImagesAndAnonymous(eq(post), eq("수정된 내용"), eq(false), anyList()))
+			given(postWriter.updateContentAndImages(eq(post), eq("수정된 내용"), eq(false), anyList()))
 				.willReturn(post);
 
 			// when
@@ -433,7 +433,7 @@ public class PostServiceTest {
 				() -> assertThat(result).isNotNull(),
 				() -> assertThat(result.id()).isEqualTo(postId));
 
-			verify(postWriter, times(1)).updateContentImagesAndAnonymous(eq(post), eq("수정된 내용"), eq(false),
+			verify(postWriter, times(1)).updateContentAndImages(eq(post), eq("수정된 내용"), eq(false),
 				anyList());
 		}
 
@@ -486,7 +486,7 @@ public class PostServiceTest {
 			given(postImageManager.mergeAndBuildForUpdate(eq(post), eq(newImageFiles), eq(imageMetas)))
 				.willReturn(new PostImageManager.ImageUpdateResult(
 					List.of(newAttachImage), List.of("old-file-id")));
-			given(postWriter.updateContentImagesAndAnonymous(eq(post), eq("수정된 내용"), eq(false), anyList()))
+			given(postWriter.updateContentAndImages(eq(post), eq("수정된 내용"), eq(false), anyList()))
 				.willReturn(post);
 
 			// when
@@ -535,7 +535,7 @@ public class PostServiceTest {
 			assertThatThrownBy(() -> postService.update(command))
 				.hasMessageContaining("비익명 게시판에서 익명으로 작성할 수 없습니다.");
 
-			verify(postWriter, never()).updateContentImagesAndAnonymous(any(), any(), any(), anyList());
+			verify(postWriter, never()).updateContentAndImages(any(), any(), any(), anyList());
 		}
 	}
 

--- a/app-main/src/test/java/net/causw/app/main/domain/community/post/service/v2/PostServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/community/post/service/v2/PostServiceTest.java
@@ -1,9 +1,18 @@
 package net.causw.app.main.domain.community.post.service.v2;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.times;
 import static org.mockito.BDDMockito.verify;
 
@@ -413,7 +422,8 @@ public class PostServiceTest {
 			given(boardConfigReader.getAdminIdsByBoardId(boardId)).willReturn(boardAdminIds);
 			given(postImageManager.mergeAndBuildForUpdate(eq(post), isNull(), isNull()))
 				.willReturn(new PostImageManager.ImageUpdateResult(List.of(), List.of()));
-			given(postWriter.updateContentAndImages(eq(post), eq("수정된 내용"), anyList())).willReturn(post);
+			given(postWriter.updateContentImagesAndAnonymous(eq(post), eq("수정된 내용"), eq(false), anyList()))
+				.willReturn(post);
 
 			// when
 			PostUpdateResult result = postService.update(command);
@@ -423,7 +433,8 @@ public class PostServiceTest {
 				() -> assertThat(result).isNotNull(),
 				() -> assertThat(result.id()).isEqualTo(postId));
 
-			verify(postWriter, times(1)).updateContentAndImages(eq(post), eq("수정된 내용"), anyList());
+			verify(postWriter, times(1)).updateContentImagesAndAnonymous(eq(post), eq("수정된 내용"), eq(false),
+				anyList());
 		}
 
 		@DisplayName("게시글 이미지 교체 성공")
@@ -475,7 +486,8 @@ public class PostServiceTest {
 			given(postImageManager.mergeAndBuildForUpdate(eq(post), eq(newImageFiles), eq(imageMetas)))
 				.willReturn(new PostImageManager.ImageUpdateResult(
 					List.of(newAttachImage), List.of("old-file-id")));
-			given(postWriter.updateContentAndImages(eq(post), eq("수정된 내용"), anyList())).willReturn(post);
+			given(postWriter.updateContentImagesAndAnonymous(eq(post), eq("수정된 내용"), eq(false), anyList()))
+				.willReturn(post);
 
 			// when
 			PostUpdateResult result = postService.update(command);
@@ -523,7 +535,7 @@ public class PostServiceTest {
 			assertThatThrownBy(() -> postService.update(command))
 				.hasMessageContaining("비익명 게시판에서 익명으로 작성할 수 없습니다.");
 
-			verify(postWriter, never()).updateContentAndImages(any(), any(), anyList());
+			verify(postWriter, never()).updateContentImagesAndAnonymous(any(), any(), any(), anyList());
 		}
 	}
 


### PR DESCRIPTION
### 🚩 관련사항
Closes: #1367


### 📢 전달사항
게시글 update시 익명 여부가 미반영되던 버그를 수정했습니다.
익명 게시판 여부를 고려하여 반영합니다.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [x] 수정


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 