### PR TITLE
fix: 공휴일 기간이 실제기간보다 +1일 되는 오류 수정

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/campus/schedule/service/HolidayScheduleSyncService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/campus/schedule/service/HolidayScheduleSyncService.java
@@ -68,7 +68,7 @@ public class HolidayScheduleSyncService {
 			}
 
 			LocalDateTime start = holiday.date().atStartOfDay();
-			LocalDateTime end = holiday.date().atTime(LocalTime.MAX);
+			LocalDateTime end = holiday.date().atTime(23, 59, 59);
 			boolean exists = scheduleReader.existsByTypeAndTitleAndStartAndEnd(
 				ScheduleType.HOLIDAY,
 				holiday.name(),

--- a/app-main/src/main/java/net/causw/app/main/domain/campus/schedule/service/HolidayScheduleSyncService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/campus/schedule/service/HolidayScheduleSyncService.java
@@ -1,7 +1,6 @@
 package net.causw.app.main.domain.campus.schedule.service;
 
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.Year;
 import java.time.ZoneId;
 import java.util.HashSet;

--- a/app-main/src/test/java/net/causw/app/main/domain/campus/schedule/service/HolidayScheduleSyncServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/campus/schedule/service/HolidayScheduleSyncServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.times;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -58,19 +57,19 @@ class HolidayScheduleSyncServiceTest {
 			ScheduleType.HOLIDAY,
 			newYear.name(),
 			newYear.date().atStartOfDay(),
-			newYear.date().atTime(LocalTime.MAX))).willReturn(false);
+			newYear.date().atTime(23, 59, 59))).willReturn(false);
 
 		given(scheduleReader.existsByTypeAndTitleAndStartAndEnd(
 			ScheduleType.HOLIDAY,
 			alreadySaved.name(),
 			alreadySaved.date().atStartOfDay(),
-			alreadySaved.date().atTime(LocalTime.MAX))).willReturn(true);
+			alreadySaved.date().atTime(23, 59, 59))).willReturn(true);
 
 		given(scheduleReader.existsByTypeAndTitleAndStartAndEnd(
 			ScheduleType.HOLIDAY,
 			nextYearHoliday.name(),
 			nextYearHoliday.date().atStartOfDay(),
-			nextYearHoliday.date().atTime(LocalTime.MAX))).willReturn(false);
+			nextYearHoliday.date().atTime(23, 59, 59))).willReturn(false);
 
 		given(scheduleWriter.save(any(Schedule.class))).willAnswer(invocation -> invocation.getArgument(0));
 


### PR DESCRIPTION
### 🚩 관련사항

Close #1369

### 📢 전달사항

공휴일 동기화(`HolidayScheduleSyncService#syncHolidays`)에서 저장되는 일정의 종료 시각을 `LocalTime.MAX`(`23:59:59.999999999`)로 지정하던 부분을 `23:59:59`로 변경했습니다.

`LocalTime.MAX`는 나노초까지 포함된 값이라, DB의 초 단위 정밀도(`datetime(0)`)에 저장될 때 반올림이 일어나면서 종료일이 다음 날 `00:00:00`으로 저장되는 문제가 있었습니다. 그 결과 공휴일이 실제 날짜보다 +1일 길게 저장되었고, `existsByTypeAndTitleAndStartAndEnd` 중복 체크도 저장된 값과 비교 대상 값이 어긋나 정상적으로 동작하지 않았습니다.

집중해서 봐야 할 부분:
- `HolidayScheduleSyncService.java:71` — `atTime(23, 59, 59)`로 변경
- 변경 후 공휴일 일정의 `end` 값이 의도한 날짜의 `23:59:59`로 저장되는지 확인
- 동일 공휴일 재동기화 시 중복 저장되지 않는지 확인

### 📸 스크린샷

N/A

### 📃 진행사항

- [x] `HolidayScheduleSyncService`의 종료 시각 산출 로직을 `LocalTime.MAX` → `LocalTime.of(23, 59, 59)`로 수정
- [ ] 현재 스케쥴에 기록된 holiday 수정

### ⚙️ 기타사항

개발기간: 2026-05-25 ~ 2026-05-25
