### PR TITLE
feat: 크롤링 게시글 제목 본문 추가, 상세조회 이미지 표시 및 알림 형태 개선

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/PostService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/PostService.java
@@ -86,7 +86,7 @@ public class PostService {
 
 		// 공식 공지글인 경우 알림 발송 이벤트
 		if (boardConfig.isNotice()) {
-			eventPublisher.publishEvent(new OfficialPostEvent(savedPost.getBoard().getId(), savedPost.getId()));
+			eventPublisher.publishEvent(new OfficialPostEvent(savedPost.getBoard().getId(), savedPost.getId(), null));
 		}
 
 		// 이미지 업로드 및 PostAttachImage 구성 (PostImageManager에 위임)

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/implementation/PostReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/v2/implementation/PostReader.java
@@ -165,7 +165,7 @@ public class PostReader {
 	 * @return 이미지 URL 목록
 	 */
 	public List<String> findPostImages(String postId) {
-		Map<String, List<String>> result = postQueryRepository.findPostImagesByPostIds(List.of(postId));
+		Map<String, List<String>> result = this.findPostImagesByPostIds(List.of(postId));
 		return result.getOrDefault(postId, List.of());
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/v1/CrawledToPostTransferService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/v1/CrawledToPostTransferService.java
@@ -149,13 +149,19 @@ public class CrawledToPostTransferService {
 			.toList();
 	}
 
-	//HTML 본문에서 <img> 태그를 제거하여 반환
-	private String removeImageTags(String html, String baseUri) {
+	//HTML 본문에서 <img> 태그 및 의미없는 빈 <p> 태그 제거하여 반환
+	private String cleanUpHtml(String html, String baseUri) {
 		if (html == null || html.isBlank()) {
 			return html;
 		}
 		Document doc = Jsoup.parse(html, baseUri != null ? baseUri : "");
 		doc.select("img").remove();
+
+		for (org.jsoup.nodes.Element p : doc.select("p")) {
+			if (!p.hasText()) {
+				p.remove();
+			}
+		}
 		return doc.body().html();
 	}
 
@@ -172,8 +178,7 @@ public class CrawledToPostTransferService {
 
 		// 원본 HTML 내용 (이미지 태그 제거)
 		String originalContent = (notice.getContent() == null || notice.getContent().isBlank())
-			? "<p>내용 없음</p>" : removeImageTags(notice.getContent(), notice.getLink());
-		originalContent = originalContent.replaceAll("(?i)<p[^>]*>(?:&nbsp;|\\s|<br\\s*/?>)*</p>", "");
+			? "<p>내용 없음</p>" : cleanUpHtml(notice.getContent(), notice.getLink());
 		contentBuilder.append(originalContent);
 
 		// 첨부파일이 있으면 링크 추가

--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/v1/CrawledToPostTransferService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/v1/CrawledToPostTransferService.java
@@ -173,6 +173,7 @@ public class CrawledToPostTransferService {
 		// 원본 HTML 내용 (이미지 태그 제거)
 		String originalContent = (notice.getContent() == null || notice.getContent().isBlank())
 			? "<p>내용 없음</p>" : removeImageTags(notice.getContent(), notice.getLink());
+		originalContent = originalContent.replaceAll("<p>(?:&nbsp;|\\s|<br\\s*/?>)*</p>", "");
 		contentBuilder.append(originalContent);
 
 		// 첨부파일이 있으면 링크 추가

--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/v1/CrawledToPostTransferService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/v1/CrawledToPostTransferService.java
@@ -158,7 +158,7 @@ public class CrawledToPostTransferService {
 		doc.select("img").remove();
 
 		for (org.jsoup.nodes.Element p : doc.select("p")) {
-			if (!p.hasText()) {
+			if (p.text().isBlank()) {
 				p.remove();
 			}
 		}

--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/v1/CrawledToPostTransferService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/v1/CrawledToPostTransferService.java
@@ -170,11 +170,10 @@ public class CrawledToPostTransferService {
 		StringBuilder contentBuilder = new StringBuilder();
 
 		// 제목도 본문에 포함
-		if (title != null && !"제목 없음".equals(title.trim())) {
-			contentBuilder.append("<p style='margin-bottom: 20px;'><strong>")
-				.append(title)
-				.append("</strong></p>");
-		}
+		String safeTitle = Jsoup.clean(title, org.jsoup.safety.Safelist.none());
+		contentBuilder.append("<p style='margin-bottom: 20px;'><strong>")
+			.append(safeTitle)
+			.append("</strong></p>");
 
 		// 원본 HTML 내용 (이미지 태그 제거)
 		String originalContent = (notice.getContent() == null || notice.getContent().isBlank())

--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/v1/CrawledToPostTransferService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/v1/CrawledToPostTransferService.java
@@ -119,7 +119,7 @@ public class CrawledToPostTransferService {
 
 			// 새 게시글인 경우에만 알림 전송
 			//			boardNotificationService.sendByBoardIsSubscribed(board, newPost);
-			applicationEventPublisher.publishEvent(new OfficialPostEvent(board.getId(), newPost.getId()));
+			applicationEventPublisher.publishEvent(new OfficialPostEvent(board.getId(), newPost.getId(), title));
 		}
 		return true;
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/v1/CrawledToPostTransferService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/v1/CrawledToPostTransferService.java
@@ -84,7 +84,7 @@ public class CrawledToPostTransferService {
 			? "제목 없음" : notice.getTitle();
 
 		// Post 변환 시점에서 첨부파일 링크 추가
-		String contentHtml = buildContentWithAttachmentsAndLink(notice);
+		String contentHtml = buildContentWithAttachmentsAndLink(notice, title);
 
 		// 원본 HTML에서 이미지 URL 추출 (첨부파일 영역 추가 전 원본 기준)
 		List<String> imageUrls = extractImageUrls(notice.getContent(), notice.getLink());
@@ -160,8 +160,15 @@ public class CrawledToPostTransferService {
 	}
 
 	//본문 내용에 첨부파일 링크를 추가하여 반환
-	private String buildContentWithAttachmentsAndLink(CrawledNotice notice) {
+	private String buildContentWithAttachmentsAndLink(CrawledNotice notice, String title) {
 		StringBuilder contentBuilder = new StringBuilder();
+
+		// 제목도 본문에 포함
+		if (title != null && !"제목 없음".equals(title.trim())) {
+			contentBuilder.append("<p style='margin-bottom: 20px;'><strong>")
+				.append(title)
+				.append("</strong></p>");
+		}
 
 		// 원본 HTML 내용 (이미지 태그 제거)
 		String originalContent = (notice.getContent() == null || notice.getContent().isBlank())

--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/v1/CrawledToPostTransferService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/v1/CrawledToPostTransferService.java
@@ -173,7 +173,7 @@ public class CrawledToPostTransferService {
 		// 원본 HTML 내용 (이미지 태그 제거)
 		String originalContent = (notice.getContent() == null || notice.getContent().isBlank())
 			? "<p>내용 없음</p>" : removeImageTags(notice.getContent(), notice.getLink());
-		originalContent = originalContent.replaceAll("<p>(?:&nbsp;|\\s|<br\\s*/?>)*</p>", "");
+		originalContent = originalContent.replaceAll("(?i)<p[^>]*>(?:&nbsp;|\\s|<br\\s*/?>)*</p>", "");
 		contentBuilder.append(originalContent);
 
 		// 첨부파일이 있으면 링크 추가

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/event/OfficialPostEvent.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/event/OfficialPostEvent.java
@@ -1,4 +1,4 @@
 package net.causw.app.main.domain.notification.notification.event;
 
-public record OfficialPostEvent(String boardId, String postId) {
+public record OfficialPostEvent(String boardId, String postId, String title) {
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/OfficialPostNotificationHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/OfficialPostNotificationHandler.java
@@ -69,7 +69,7 @@ public class OfficialPostNotificationHandler {
 		String serviceTitle;
 
 		// 크롤링 공지의 경우 제목이 존재하므로 제목을 사용. 일반 게시글은 본문에서 텍스트만 추출하여 사용
-		if (event.title() != null && !event.title().isBlank()) {
+		if (event.title() != null && !event.title().isBlank() && !"제목 없음".equals(event.title().trim())) {
 			rawPushBody = event.title();
 			serviceTitle = NotificationTextUtil.ellipsis(event.title(), NotificationTextUtil.SERVICE_TITLE_MAX_LENGTH);
 		} else {

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/OfficialPostNotificationHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/OfficialPostNotificationHandler.java
@@ -62,13 +62,26 @@ public class OfficialPostNotificationHandler {
 
 		// 알림 발송
 		// 푸시알림 제목: 게시판 이름
-		// 푸시알림 내용: 공지글 내용 (최대 60자, 그 이상은 ...으로 표시)
-		// 서비스 알림 제목: 공지글 내용 (최대 20자, 그 이상은 ...으로 표시)
-		String sanitizedContent = NotificationTextUtil.sanitize(post.getContent());
+		// 푸시알림 내용: 공지글 내용 (최대 60자, 그 이상은 ...으로 표시) (크롤링은 추출된 제목)
+		// 서비스 알림 제목: 공지글 내용 (최대 50자, 그 이상은 ...으로 표시) (크롤링은 추출된 제목)
 		String pushTitle = board.getName();
-		String pushBody = NotificationTextUtil.ellipsis(sanitizedContent, NotificationTextUtil.PUSH_BODY_MAX_LENGTH);
-		String serviceTitle = NotificationTextUtil.ellipsis(sanitizedContent,
-			NotificationTextUtil.SERVICE_TITLE_MAX_LENGTH);
+		String rawPushBody;
+		String serviceTitle;
+
+		// 크롤링 공지의 경우 제목이 존재하므로 제목을 사용. 일반 게시글은 본문에서 텍스트만 추출하여 사용
+		if (event.title() != null && !event.title().isBlank()) {
+			rawPushBody = event.title();
+			serviceTitle = NotificationTextUtil.ellipsis(event.title(), NotificationTextUtil.SERVICE_TITLE_MAX_LENGTH);
+		} else {
+			String rawHtml = post.getContent() == null ? "" : post.getContent();
+			String actualHtml = rawHtml.replace("&nbsp;", " ").replace("</p>", "\n</p>");
+			String sanitized = NotificationTextUtil.sanitize(actualHtml).trim();
+
+			rawPushBody = sanitized;
+			serviceTitle = NotificationTextUtil.ellipsis(sanitized, NotificationTextUtil.SERVICE_TITLE_MAX_LENGTH);
+		}
+
+		String pushBody = NotificationTextUtil.ellipsis(rawPushBody, NotificationTextUtil.PUSH_BODY_MAX_LENGTH);
 
 		// 알림 발송자를 게시글 작성자로 설정하여 알림 저장
 		Notification notification = notificationWriter.save(

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/OfficialPostNotificationHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/handler/OfficialPostNotificationHandler.java
@@ -2,6 +2,7 @@ package net.causw.app.main.domain.notification.notification.service.handler;
 
 import java.util.List;
 
+import org.jsoup.Jsoup;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -74,8 +75,8 @@ public class OfficialPostNotificationHandler {
 			serviceTitle = NotificationTextUtil.ellipsis(event.title(), NotificationTextUtil.SERVICE_TITLE_MAX_LENGTH);
 		} else {
 			String rawHtml = post.getContent() == null ? "" : post.getContent();
-			String actualHtml = rawHtml.replace("&nbsp;", " ").replace("</p>", "\n</p>");
-			String sanitized = NotificationTextUtil.sanitize(actualHtml).trim();
+			String htmlWithNewlines = rawHtml.replace("</p>", "\n</p>");
+			String sanitized = Jsoup.parse(htmlWithNewlines).text().trim();
 
 			rawPushBody = sanitized;
 			serviceTitle = NotificationTextUtil.ellipsis(sanitized, NotificationTextUtil.SERVICE_TITLE_MAX_LENGTH);

--- a/app-main/src/test/java/net/causw/app/main/domain/notification/notification/service/handler/OfficialPostNotificationHandlerTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/notification/notification/service/handler/OfficialPostNotificationHandlerTest.java
@@ -1,5 +1,6 @@
 package net.causw.app.main.domain.notification.notification.service.handler;
 
+import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -203,8 +205,14 @@ class OfficialPostNotificationHandlerTest {
 			handler.handle(new OfficialPostEvent("boardId", "postId", crawledTitle));
 
 			// then
-			verify(notificationWriter).save(any());
-			verify(notificationPushSender).sendToUsers(eq(targets), any(), any());
+			ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
+			verify(notificationWriter).save(notificationCaptor.capture());
+			Notification savedNotification = notificationCaptor.getValue();
+
+			assertThat(savedNotification.getTitle()).isEqualTo(crawledTitle);
+			assertThat(savedNotification.getBody()).isEqualTo(crawledTitle);
+
+			verify(notificationPushSender).sendToUsers(eq(targets), eq("공지 게시판"), eq(crawledTitle));
 			verify(notificationWriter).saveLogs(eq(targets), any());
 		}
 	}

--- a/app-main/src/test/java/net/causw/app/main/domain/notification/notification/service/handler/OfficialPostNotificationHandlerTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/notification/notification/service/handler/OfficialPostNotificationHandlerTest.java
@@ -199,7 +199,7 @@ class OfficialPostNotificationHandlerTest {
 			given(post.getId()).willReturn("postId");
 			given(notificationWriter.save(any())).willReturn(mock(Notification.class));
 
-			// when (🚀 세 번째 파라미터에 title 주입)
+			// when
 			handler.handle(new OfficialPostEvent("boardId", "postId", crawledTitle));
 
 			// then

--- a/app-main/src/test/java/net/causw/app/main/domain/notification/notification/service/handler/OfficialPostNotificationHandlerTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/notification/notification/service/handler/OfficialPostNotificationHandlerTest.java
@@ -75,7 +75,7 @@ class OfficialPostNotificationHandlerTest {
 			given(notificationWriter.save(any())).willReturn(mock(Notification.class));
 
 			// when
-			handler.handle(new OfficialPostEvent("boardId", "postId"));
+			handler.handle(new OfficialPostEvent("boardId", "postId", null));
 
 			// then
 			verify(notificationWriter).save(any());
@@ -97,7 +97,7 @@ class OfficialPostNotificationHandlerTest {
 			given(boardConfigReader.getByBoardId("boardId")).willReturn(boardConfig);
 
 			// when
-			handler.handle(new OfficialPostEvent("boardId", "postId"));
+			handler.handle(new OfficialPostEvent("boardId", "postId", null));
 
 			// then
 			verify(notificationWriter, never()).save(any());
@@ -119,7 +119,7 @@ class OfficialPostNotificationHandlerTest {
 			given(boardConfigReader.getByBoardId("boardId")).willReturn(boardConfig);
 
 			// when
-			handler.handle(new OfficialPostEvent("boardId", "postId"));
+			handler.handle(new OfficialPostEvent("boardId", "postId", null));
 
 			// then
 			verify(notificationWriter, never()).save(any());
@@ -145,7 +145,7 @@ class OfficialPostNotificationHandlerTest {
 			given(notificationWriter.save(any())).willReturn(mock(Notification.class));
 
 			// when
-			handler.handle(new OfficialPostEvent("boardId", "postId"));
+			handler.handle(new OfficialPostEvent("boardId", "postId", null));
 
 			// then
 			verify(notificationWriter).save(any());
@@ -173,10 +173,39 @@ class OfficialPostNotificationHandlerTest {
 			given(notificationWriter.save(any())).willReturn(mock(Notification.class));
 
 			// when
-			handler.handle(new OfficialPostEvent("boardId", "postId"));
+			handler.handle(new OfficialPostEvent("boardId", "postId", null));
 
 			// then
 			verify(userBoardSubscribeReader).findNotificationTargets("boardId", BoardReadScope.ENROLLED);
+		}
+
+		@Test
+		@DisplayName("성공: 크롤링 공지글(title 존재)인 경우 제목 기반으로 알림 발송")
+		void givenCrawledNotice_whenHandle_thenSendToSubscribersWithTitle() {
+			// given
+			Board board = mockBoard("boardId");
+			Post post = mockPost();
+			BoardConfig boardConfig = mockVisibleNoticeConfig(BoardReadScope.BOTH);
+			List<User> targets = List.of(mock(User.class), mock(User.class));
+			String crawledTitle = "크롤링 공지사항 제목입니다";
+
+			given(boardReader.getById("boardId")).willReturn(board);
+			given(postReader.findById("postId")).willReturn(post);
+			given(boardConfigReader.getByBoardId("boardId")).willReturn(boardConfig);
+			given(userBoardSubscribeReader.findNotificationTargets("boardId", BoardReadScope.BOTH)).willReturn(targets);
+
+			// 크롤링 글은 post.getContent()를 읽지 않으므로 해당 stub 불필요
+			given(board.getName()).willReturn("공지 게시판");
+			given(post.getId()).willReturn("postId");
+			given(notificationWriter.save(any())).willReturn(mock(Notification.class));
+
+			// when (🚀 세 번째 파라미터에 title 주입)
+			handler.handle(new OfficialPostEvent("boardId", "postId", crawledTitle));
+
+			// then
+			verify(notificationWriter).save(any());
+			verify(notificationPushSender).sendToUsers(eq(targets), any(), any());
+			verify(notificationWriter).saveLogs(eq(targets), any());
 		}
 	}
 


### PR DESCRIPTION
### 🚩 관련사항

#1298 

### 📢 전달사항

**1. 발생했던 문제 및 원인**

* **제목 미노출:** 프로젝트 구조 변경으로 `Post` 엔티티에서 `title` 필드가 삭제되어, 크롤링된 공지사항의 제목을 보여줄 공간이 증발함.
* **상세화면 이미지 누락:** 게시글 목록에서는 이미지가 정상 노출되나, 단건 상세 조회(`getPostDetail`) 시 S3 이미지(postQueryRepository)만 조회하고 크롤링 전용 이미지 테이블을 병합하지 않아 사진이 누락됨.
* **알림 포맷팅 깨짐:** 알림 발송 시 크롤링 본문의 HTML을 정규식으로 파싱하다 보니 `&nbsp;`, `📎 첨부파일` 등의 임의 텍스트가 알림 제목/내용에 섞여 들어가는 문제 발생.

**2. 주요 변경 사항 (해결 방법)**

* **본문 최상단 제목 병합 (`CrawledToPostTransferService`)**
  * DB 스키마(`tb_post`)를 변경하지 않고, 크롤링 전환 시점에 본문(`content`) 최상단에 `<strong>` 태그로 제목을 삽입하여 데이터 보존.
  * 불안정한 정규식 대신 **`Jsoup` 라이브러리를 활용하여 HTML DOM을 직접 조작**하는 방식으로 리팩토링. 1회의 파싱으로  태그 제거와 의미 없는 빈 단락(`<p>&nbsp;</p>` 등, `!p.hasText()`) 제거를 통합 처리하여 파싱 성능과 데이터 안정성을 크게 향상시킴.


* **단건 조회 이미지 병합 로직 통일 (`PostReader`)**
  * 단건 조회 메서드(`findPostImages`)에서 기존에 구현되어 있던 다건 조회용 병합 메서드(`findPostImagesByPostIds`)를 재사용하도록 한 줄 수정하여 S3/크롤링 이미지 누락 완벽 해결.


* **알림 이벤트 아키텍처 리팩토링 (`OfficialPostEvent`, `OfficialPostNotificationHandler`)**
  * `OfficialPostEvent` DTO에 `title` 필드를 확장하여, 데이터 파이프라인 단절 없이 원본 크롤링 제목을 이벤트 버스로 직접 전달.
  * 크롤링 공지는 전달받은 '제목'만 깔끔하게 알림으로 사용하고, 일반 공지(학생회 등)는 기존 정책(본문 앞부분 컷팅)을 따르도록 분기 처리 완벽 적용.
  * 예외 케이스로 인해 크롤링 공지 제목이 "제목 없음"으로 넘어오더라도 유저에게 그대로 발송되지 않도록, 일반 공지글과 동일하게 본문 텍스트를 추출하여 알림을 보내는 예외 방어 로직 적용.



**3. 집중적으로 봐주셨으면 하는 부분**

크롤링 게시글에 한하여 알림 전달 형태를 제목만 전달되게 수정하였습니다.
기존 본문을 글자수로 잘라서 전달하던 방식과 다르기 때문에, 이 방식이 적합한지 의견 부탁드립니다.

### 📸 스크린샷

<img width="420" height="685" alt="image" src="https://github.com/user-attachments/assets/ffb84850-872b-4156-a82e-6c9f95ce67da" />

<img width="949" height="873" alt="image" src="https://github.com/user-attachments/assets/7621ed0c-353e-4218-91aa-db4f727d6fdf" />

운영계 크롤링 글 상황 - 제목이 누락되어있고, 상세조회에서 사진이 표시되지 않음

<img width="435" height="704" alt="image" src="https://github.com/user-attachments/assets/af73de31-1005-4349-8a9c-adf9d3347bfe" />
<img width="881" height="883" alt="image" src="https://github.com/user-attachments/assets/b6e145c9-5e77-40cd-bae2-0ae0cf124f32" />

로컬 수정결과 - 제목이 본문 최상단에 포함되고, 상세조회에서도 사진이 첨부파일로 정상 표시됨

<img width="845" height="558" alt="image" src="https://github.com/user-attachments/assets/05dfd553-cc74-4a7c-b0e1-01c41daddb7b" />

운영계 알림 형태 - 형태를 인지하기 어려운 본문의 내용이 표시됨

<img width="890" height="609" alt="image" src="https://github.com/user-attachments/assets/5f241a31-7894-43eb-8a1b-0a435f18fb55" />

로컬 수정 알림 형태 - 크롤링 게시글의 제목으로 알림이 표시

### 📃 진행사항

* [x] 크롤링 게시물 본문 상단에 제목(`<strong>`) 병합 및 `Jsoup`을 활용한 UI 공백(빈 태그) 안전 제거
* [x] `PostReader` 상세 조회 시 크롤링 이미지 목록 정상 반환되도록 수정
* [x] `OfficialPostEvent` 객체에 `title` 상태 추가 및 "제목 없음" 알림 방어 로직 적용
* [x] 알림 핸들러의 크롤링/일반 공지 알림 포맷 분기 처리

### ⚙️ 기타사항

푸시알림 테스트는 하지 못하였음.
추후 개발계에서 확인 필요

* **개발기간:** 1w