### PR TITLE
fix: 일일 가입자 수 조회 기준을 관리자 승인으로 변경

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/controller/UserQueryAdminController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/controller/UserQueryAdminController.java
@@ -46,12 +46,12 @@ public class UserQueryAdminController {
 		return ApiResponse.success(response);
 	}
 
-	@Operation(summary = "일일 신규 가입자 수 조회")
+	@Operation(summary = "일일 신규 가입자 수 조회", description = "해당 날짜의 신규 승인된 사용자 수를 조회합니다. 날짜 미입력 시 오늘(Asia/Seoul) 기준으로 조회합니다.")
 	@GetMapping("/daily-count")
-	public ApiResponse<UserDailyCountResponse> getDailySignupCount(
+	public ApiResponse<UserDailyCountResponse> getDailyApprovedCount(
 		@RequestParam(value = "targetDate", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate) {
 		LocalDate date = (targetDate != null) ? targetDate : LocalDate.now(ZoneId.of("Asia/Seoul"));
-		Long count = userQueryService.getDailySignupStats(date);
+		Long count = userQueryService.getDailyApprovedStats(date);
 		return ApiResponse.success(new UserDailyCountResponse(date, count));
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/user/UserAdmissionLogRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/user/UserAdmissionLogRepository.java
@@ -1,9 +1,15 @@
 package net.causw.app.main.domain.user.account.repository.user;
 
+import java.time.LocalDateTime;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import net.causw.app.main.domain.user.account.entity.user.UserAdmissionLog;
+import net.causw.app.main.domain.user.account.enums.user.UserAdmissionLogAction;
 
 @Repository
-public interface UserAdmissionLogRepository extends JpaRepository<UserAdmissionLog, String> {}
+public interface UserAdmissionLogRepository extends JpaRepository<UserAdmissionLog, String> {
+
+	Long countByActionAndCreatedAtBetween(UserAdmissionLogAction action, LocalDateTime start, LocalDateTime end);
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserQueryService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserQueryService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import net.causw.app.main.domain.user.account.service.dto.request.UserQueryCondition;
 import net.causw.app.main.domain.user.account.service.dto.result.UserSearchListResult;
+import net.causw.app.main.domain.user.account.service.implementation.AdmissionLogReader;
 import net.causw.app.main.domain.user.account.service.implementation.UserReader;
 
 import lombok.RequiredArgsConstructor;
@@ -20,16 +21,17 @@ import lombok.RequiredArgsConstructor;
 public class UserQueryService {
 
 	private final UserReader userReader;
+	private final AdmissionLogReader admissionLogReader;
 
 	public UserSearchListResult searchUsers(UserQueryCondition condition) {
 		return UserSearchListResult.from(userReader.searchByCondition(condition));
 	}
 
-	public Long getDailySignupStats(LocalDate targetDate) {
+	public Long getDailyApprovedStats(LocalDate targetDate) {
 		LocalDateTime startOfDay = targetDate.atStartOfDay();
 		LocalDateTime endOfDay = targetDate.atTime(MAX);
 
-		return userReader.countByCreatedAtBetween(startOfDay, endOfDay);
+		return admissionLogReader.countAcceptedBetween(startOfDay, endOfDay);
 	}
 
 	public Long getTotalUserCount() {

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/implementation/AdmissionLogReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/implementation/AdmissionLogReader.java
@@ -1,0 +1,22 @@
+package net.causw.app.main.domain.user.account.service.implementation;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Component;
+
+import net.causw.app.main.domain.user.account.enums.user.UserAdmissionLogAction;
+import net.causw.app.main.domain.user.account.repository.user.UserAdmissionLogRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AdmissionLogReader {
+
+	private final UserAdmissionLogRepository userAdmissionLogRepository;
+
+	public Long countAcceptedBetween(LocalDateTime start, LocalDateTime end) {
+		return userAdmissionLogRepository.countByActionAndCreatedAtBetween(
+			UserAdmissionLogAction.ACCEPT, start, end);
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/implementation/AdmissionLogReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/implementation/AdmissionLogReader.java
@@ -3,6 +3,7 @@ package net.causw.app.main.domain.user.account.service.implementation;
 import java.time.LocalDateTime;
 
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import net.causw.app.main.domain.user.account.enums.user.UserAdmissionLogAction;
 import net.causw.app.main.domain.user.account.repository.user.UserAdmissionLogRepository;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AdmissionLogReader {
 
 	private final UserAdmissionLogRepository userAdmissionLogRepository;


### PR DESCRIPTION
### 🚩 관련사항
close #1372

### 📢 전달사항
기존 일일 신규 가입자 수 조회 API(`GET /api/v2/admin/users/daily-count`)는 `tb_user.created_at`을 기준으로 당일 생성된 유저 수를 반환하고 있었습니다.

그러나 본 서비스에서 가입이 완료되는 시점은 관리자가 가입 신청을 승인하여 사용자가 ACTIVE 상태가 되는 때이므로, 조회 기준을 `tb_user_admission_log`에서 `action = 'ACCEPT'`인 레코드의 `created_at`으로 변경했습니다.

별도 컬럼(ex. `approvedAt`)을 추가하는 방법도 고려해봤으나 승인일이 여러 곳에서 사용되지 않을 것이라 판단해 기존 로그 테이블을 활용하기로 선택했습니다.

### 📸 스크린샷
N/A

### 📃 진행사항
- [x] 일일 가입자 수 조회 기준을 `tb_user_admission_log` ACCEPT 기준으로 변경
- [x] `AdmissionLogReader` 컴포넌트 신규 생성
- [x] signup → approved 메서드명 rename
- [x] Swagger `@Operation` description 추가

### ⚙️ 기타사항

개발기간: 2026-06-22 ~ 2026-06-22