### PR TITLE
feat: 마이페이지 게시글 접근 권한 필터링

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/repository/query/PostQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/repository/query/PostQueryRepository.java
@@ -101,7 +101,7 @@ public class PostQueryRepository {
 		String keyword) {
 		// 빈 리스트가 전달된 경우 "조회 가능한 게시판이 한 개도 없음"을 의미하므로 즉시 빈 결과 반환.
 		// (null은 docstring 계약상 "전체 게시판"이므로 별도 처리하지 않음)
-		if (hasNoAccessibleBoards(boardIds)) {
+		if (hasEmptyBoardFilter(boardIds)) {
 			return emptySlice(size);
 		}
 
@@ -271,6 +271,10 @@ public class PostQueryRepository {
 	}
 
 	private static boolean hasNoAccessibleBoards(List<String> boardIds) {
+		return boardIds == null || boardIds.isEmpty();
+	}
+
+	private static boolean hasEmptyBoardFilter(List<String> boardIds) {
 		return boardIds != null && boardIds.isEmpty();
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/repository/query/PostQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/repository/query/PostQueryRepository.java
@@ -101,8 +101,8 @@ public class PostQueryRepository {
 		String keyword) {
 		// 빈 리스트가 전달된 경우 "조회 가능한 게시판이 한 개도 없음"을 의미하므로 즉시 빈 결과 반환.
 		// (null은 docstring 계약상 "전체 게시판"이므로 별도 처리하지 않음)
-		if (boardIds != null && boardIds.isEmpty()) {
-			return new SliceImpl<>(List.of(), Pageable.ofSize(size), false);
+		if (hasNoAccessibleBoards(boardIds)) {
+			return emptySlice(size);
 		}
 
 		QPost post = QPost.post;
@@ -112,10 +112,7 @@ public class PostQueryRepository {
 		BooleanExpression cursorCondition = createCursorCondition(cursorCreatedAt, cursorId, post);
 
 		// 게시판 조건
-		BooleanExpression boardCondition = NO_CONDITION;
-		if (boardIds != null && !boardIds.isEmpty()) {
-			boardCondition = post.board.id.in(boardIds);
-		}
+		BooleanExpression boardCondition = inBoards(post, boardIds);
 
 		// 게시글 조회 조건
 		BooleanExpression[] conditions = new BooleanExpression[] {
@@ -144,9 +141,14 @@ public class PostQueryRepository {
 	public Slice<PostCursorResult> findPostsCommentedByUserWithCursor(
 		String userId,
 		Set<String> blockedUserIds,
+		List<String> accessibleBoardIds,
 		String cursorCreatedAt,
 		String cursorId,
 		int size) {
+		if (hasNoAccessibleBoards(accessibleBoardIds)) {
+			return emptySlice(size);
+		}
+
 		QPost post = QPost.post;
 		QUser writer = new QUser("writer");
 		QComment comment = QComment.comment;
@@ -165,6 +167,7 @@ public class PostQueryRepository {
 			.exists();
 
 		BooleanExpression[] conditions = new BooleanExpression[] {
+			inBoards(post, accessibleBoardIds),
 			userCommentedPost, // 댓글 단 글만 조회
 			writer.id.ne(userId), // 자신이 쓴 글은 제외
 			post.isDeleted.eq(false), // 삭제된 글 제외
@@ -185,15 +188,21 @@ public class PostQueryRepository {
 	 */
 	public Slice<PostCursorResult> findPostsWrittenByUserWithCursor(
 		String userId,
+		List<String> accessibleBoardIds,
 		String cursorCreatedAt,
 		String cursorId,
 		int size) {
+		if (hasNoAccessibleBoards(accessibleBoardIds)) {
+			return emptySlice(size);
+		}
+
 		QPost post = QPost.post;
 		QUser writer = new QUser("writer");
 
 		BooleanExpression cursorCondition = createCursorCondition(cursorCreatedAt, cursorId, post);
 
 		BooleanExpression[] conditions = new BooleanExpression[] {
+			inBoards(post, accessibleBoardIds),
 			post.writer.id.eq(userId), // 자신이 쓴 글만 조회
 			post.isDeleted.eq(false), // 삭제된 글 제외
 			cursorCondition // 커서 조건
@@ -214,9 +223,14 @@ public class PostQueryRepository {
 	public Slice<PostCursorResult> findPostsLikedByUserWithCursor(
 		String userId,
 		Set<String> blockedUserIds,
+		List<String> accessibleBoardIds,
 		String cursorCreatedAt,
 		String cursorId,
 		int size) {
+		if (hasNoAccessibleBoards(accessibleBoardIds)) {
+			return emptySlice(size);
+		}
+
 		QPost post = QPost.post;
 		QUser writer = new QUser("writer");
 		QLikePost likePost = QLikePost.likePost;
@@ -230,6 +244,7 @@ public class PostQueryRepository {
 			.exists();
 
 		BooleanExpression[] conditions = new BooleanExpression[] {
+			inBoards(post, accessibleBoardIds),
 			userLikedPost, // 좋아요 누른 글만 조회
 			post.isDeleted.eq(false), // 삭제된 글 제외
 			notInBlockedUsers(writer, blockedUserIds), // 차단한 사용자 글 제외
@@ -253,6 +268,18 @@ public class PostQueryRepository {
 				.or(post.createdAt.eq(LocalDateTime.parse(cursorCreatedAt)).and(post.id.lt(cursorId)));
 		}
 		return cursorCondition;
+	}
+
+	private static boolean hasNoAccessibleBoards(List<String> boardIds) {
+		return boardIds != null && boardIds.isEmpty();
+	}
+
+	private static Slice<PostCursorResult> emptySlice(int size) {
+		return new SliceImpl<>(List.of(), Pageable.ofSize(size), false);
+	}
+
+	private static BooleanExpression inBoards(QPost post, List<String> boardIds) {
+		return boardIds == null ? NO_CONDITION : post.board.id.in(boardIds);
 	}
 
 	/**

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/PostService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/PostService.java
@@ -335,9 +335,13 @@ public class PostService {
 	 * @return 게시글 목록 결과
 	 */
 	public PostListResult getPostsCommentedByUser(User user, String cursor, Integer size) {
-		Set<String> blockedUserIds = userBlockReader.findBlockeeUserIdsByBlocker(user);
 		List<String> accessibleBoardIds = boardConfigReader.getAccessibleBoardIdsByAcademicStatus(
 			user.getAcademicStatus());
+		if (hasNoAccessibleBoards(accessibleBoardIds)) {
+			return PostListResult.of(List.of(), null);
+		}
+
+		Set<String> blockedUserIds = userBlockReader.findBlockeeUserIdsByBlocker(user);
 		int pageSize = size != null ? size : StaticValue.DEFAULT_POST_PAGE_SIZE;
 		PostCursorManager.ParsedCursor parsedCursor = PostCursorManager.parseCursor(cursor);
 
@@ -363,6 +367,10 @@ public class PostService {
 	public PostListResult getPostsWrittenByUser(User user, String cursor, Integer size) {
 		List<String> accessibleBoardIds = boardConfigReader.getAccessibleBoardIdsByAcademicStatus(
 			user.getAcademicStatus());
+		if (hasNoAccessibleBoards(accessibleBoardIds)) {
+			return PostListResult.of(List.of(), null);
+		}
+
 		int pageSize = size != null ? size : StaticValue.DEFAULT_POST_PAGE_SIZE;
 		PostCursorManager.ParsedCursor parsedCursor = PostCursorManager.parseCursor(cursor);
 
@@ -384,9 +392,13 @@ public class PostService {
 	 * @return 게시글 목록 결과
 	 */
 	public PostListResult getPostsLikedByUser(User user, String cursor, Integer size) {
-		Set<String> blockedUserIds = userBlockReader.findBlockeeUserIdsByBlocker(user);
 		List<String> accessibleBoardIds = boardConfigReader.getAccessibleBoardIdsByAcademicStatus(
 			user.getAcademicStatus());
+		if (hasNoAccessibleBoards(accessibleBoardIds)) {
+			return PostListResult.of(List.of(), null);
+		}
+
+		Set<String> blockedUserIds = userBlockReader.findBlockeeUserIdsByBlocker(user);
 		int pageSize = size != null ? size : StaticValue.DEFAULT_POST_PAGE_SIZE;
 		PostCursorManager.ParsedCursor parsedCursor = PostCursorManager.parseCursor(cursor);
 
@@ -435,6 +447,10 @@ public class PostService {
 		}
 
 		return PostListResult.of(postItems, nextCursor);
+	}
+
+	private static boolean hasNoAccessibleBoards(List<String> accessibleBoardIds) {
+		return accessibleBoardIds == null || accessibleBoardIds.isEmpty();
 	}
 
 	/**

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/PostService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/PostService.java
@@ -336,12 +336,15 @@ public class PostService {
 	 */
 	public PostListResult getPostsCommentedByUser(User user, String cursor, Integer size) {
 		Set<String> blockedUserIds = userBlockReader.findBlockeeUserIdsByBlocker(user);
+		List<String> accessibleBoardIds = boardConfigReader.getAccessibleBoardIdsByAcademicStatus(
+			user.getAcademicStatus());
 		int pageSize = size != null ? size : StaticValue.DEFAULT_POST_PAGE_SIZE;
 		PostCursorManager.ParsedCursor parsedCursor = PostCursorManager.parseCursor(cursor);
 
 		Slice<PostCursorResult> slice = postReader.findPostsCommentedByUserWithCursor(
 			user.getId(),
 			blockedUserIds,
+			accessibleBoardIds,
 			parsedCursor.createdAt(),
 			parsedCursor.postId(),
 			pageSize);
@@ -358,11 +361,14 @@ public class PostService {
 	 * @return 게시글 목록 결과
 	 */
 	public PostListResult getPostsWrittenByUser(User user, String cursor, Integer size) {
+		List<String> accessibleBoardIds = boardConfigReader.getAccessibleBoardIdsByAcademicStatus(
+			user.getAcademicStatus());
 		int pageSize = size != null ? size : StaticValue.DEFAULT_POST_PAGE_SIZE;
 		PostCursorManager.ParsedCursor parsedCursor = PostCursorManager.parseCursor(cursor);
 
 		Slice<PostCursorResult> slice = postReader.findPostsWrittenByUserWithCursor(
 			user.getId(),
+			accessibleBoardIds,
 			parsedCursor.createdAt(),
 			parsedCursor.postId(),
 			pageSize);
@@ -379,12 +385,15 @@ public class PostService {
 	 */
 	public PostListResult getPostsLikedByUser(User user, String cursor, Integer size) {
 		Set<String> blockedUserIds = userBlockReader.findBlockeeUserIdsByBlocker(user);
+		List<String> accessibleBoardIds = boardConfigReader.getAccessibleBoardIdsByAcademicStatus(
+			user.getAcademicStatus());
 		int pageSize = size != null ? size : StaticValue.DEFAULT_POST_PAGE_SIZE;
 		PostCursorManager.ParsedCursor parsedCursor = PostCursorManager.parseCursor(cursor);
 
 		Slice<PostCursorResult> slice = postReader.findPostsLikedByUserWithCursor(
 			user.getId(),
 			blockedUserIds,
+			accessibleBoardIds,
 			parsedCursor.createdAt(),
 			parsedCursor.postId(),
 			pageSize);

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/implementation/PostReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/implementation/PostReader.java
@@ -105,11 +105,12 @@ public class PostReader {
 	public Slice<PostCursorResult> findPostsCommentedByUserWithCursor(
 		String userId,
 		Set<String> blockedUserIds,
+		List<String> accessibleBoardIds,
 		String cursorCreatedAt,
 		String cursorId,
 		int size) {
 		return postQueryRepository.findPostsCommentedByUserWithCursor(
-			userId, blockedUserIds, cursorCreatedAt, cursorId, size);
+			userId, blockedUserIds, accessibleBoardIds, cursorCreatedAt, cursorId, size);
 	}
 
 	/**
@@ -117,10 +118,12 @@ public class PostReader {
 	 */
 	public Slice<PostCursorResult> findPostsWrittenByUserWithCursor(
 		String userId,
+		List<String> accessibleBoardIds,
 		String cursorCreatedAt,
 		String cursorId,
 		int size) {
-		return postQueryRepository.findPostsWrittenByUserWithCursor(userId, cursorCreatedAt, cursorId, size);
+		return postQueryRepository.findPostsWrittenByUserWithCursor(
+			userId, accessibleBoardIds, cursorCreatedAt, cursorId, size);
 	}
 
 	/**
@@ -129,11 +132,12 @@ public class PostReader {
 	public Slice<PostCursorResult> findPostsLikedByUserWithCursor(
 		String userId,
 		Set<String> blockedUserIds,
+		List<String> accessibleBoardIds,
 		String cursorCreatedAt,
 		String cursorId,
 		int size) {
 		return postQueryRepository.findPostsLikedByUserWithCursor(
-			userId, blockedUserIds, cursorCreatedAt, cursorId, size);
+			userId, blockedUserIds, accessibleBoardIds, cursorCreatedAt, cursorId, size);
 	}
 
 	/**

--- a/app-main/src/test/java/net/causw/app/main/domain/community/post/repository/query/PostQueryRepositoryTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/community/post/repository/query/PostQueryRepositoryTest.java
@@ -51,6 +51,23 @@ class PostQueryRepositoryTest {
 			verifyNoInteractions(jpaQueryFactory);
 		}
 
+		@DisplayName("접근 가능한 게시판 목록이 null이면 내가 댓글 단 글 조회는 DB 조회 없이 빈 Slice를 반환한다")
+		@Test
+		void findPostsCommentedByUserWithCursor_shouldReturnEmptySlice_whenAccessibleBoardsAreNull() {
+			// when
+			Slice<PostCursorResult> result = postQueryRepository.findPostsCommentedByUserWithCursor(
+				"user-id",
+				Set.of(),
+				null,
+				null,
+				null,
+				20);
+
+			// then
+			assertEmptySlice(result, 20);
+			verifyNoInteractions(jpaQueryFactory);
+		}
+
 		@DisplayName("접근 가능한 게시판이 없으면 내가 작성한 글 조회는 DB 조회 없이 빈 Slice를 반환한다")
 		@Test
 		void findPostsWrittenByUserWithCursor_shouldReturnEmptySlice_whenNoAccessibleBoards() {
@@ -58,6 +75,22 @@ class PostQueryRepositoryTest {
 			Slice<PostCursorResult> result = postQueryRepository.findPostsWrittenByUserWithCursor(
 				"user-id",
 				List.of(),
+				null,
+				null,
+				20);
+
+			// then
+			assertEmptySlice(result, 20);
+			verifyNoInteractions(jpaQueryFactory);
+		}
+
+		@DisplayName("접근 가능한 게시판 목록이 null이면 내가 작성한 글 조회는 DB 조회 없이 빈 Slice를 반환한다")
+		@Test
+		void findPostsWrittenByUserWithCursor_shouldReturnEmptySlice_whenAccessibleBoardsAreNull() {
+			// when
+			Slice<PostCursorResult> result = postQueryRepository.findPostsWrittenByUserWithCursor(
+				"user-id",
+				null,
 				null,
 				null,
 				20);
@@ -75,6 +108,23 @@ class PostQueryRepositoryTest {
 				"user-id",
 				Set.of(),
 				List.of(),
+				null,
+				null,
+				20);
+
+			// then
+			assertEmptySlice(result, 20);
+			verifyNoInteractions(jpaQueryFactory);
+		}
+
+		@DisplayName("접근 가능한 게시판 목록이 null이면 내가 좋아요한 글 조회는 DB 조회 없이 빈 Slice를 반환한다")
+		@Test
+		void findPostsLikedByUserWithCursor_shouldReturnEmptySlice_whenAccessibleBoardsAreNull() {
+			// when
+			Slice<PostCursorResult> result = postQueryRepository.findPostsLikedByUserWithCursor(
+				"user-id",
+				Set.of(),
+				null,
 				null,
 				null,
 				20);

--- a/app-main/src/test/java/net/causw/app/main/domain/community/post/repository/query/PostQueryRepositoryTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/community/post/repository/query/PostQueryRepositoryTest.java
@@ -1,0 +1,93 @@
+package net.causw.app.main.domain.community.post.repository.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Slice;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+@ExtendWith(MockitoExtension.class)
+class PostQueryRepositoryTest {
+
+	@Mock
+	private JPAQueryFactory jpaQueryFactory;
+
+	private PostQueryRepository postQueryRepository;
+
+	@BeforeEach
+	void setUp() {
+		postQueryRepository = new PostQueryRepository(jpaQueryFactory);
+	}
+
+	@Nested
+	@DisplayName("마이페이지 커서 조회 테스트")
+	class MyPageCursorQueryTest {
+
+		@DisplayName("접근 가능한 게시판이 없으면 내가 댓글 단 글 조회는 DB 조회 없이 빈 Slice를 반환한다")
+		@Test
+		void findPostsCommentedByUserWithCursor_shouldReturnEmptySlice_whenNoAccessibleBoards() {
+			// when
+			Slice<PostCursorResult> result = postQueryRepository.findPostsCommentedByUserWithCursor(
+				"user-id",
+				Set.of(),
+				List.of(),
+				null,
+				null,
+				20);
+
+			// then
+			assertEmptySlice(result, 20);
+			verifyNoInteractions(jpaQueryFactory);
+		}
+
+		@DisplayName("접근 가능한 게시판이 없으면 내가 작성한 글 조회는 DB 조회 없이 빈 Slice를 반환한다")
+		@Test
+		void findPostsWrittenByUserWithCursor_shouldReturnEmptySlice_whenNoAccessibleBoards() {
+			// when
+			Slice<PostCursorResult> result = postQueryRepository.findPostsWrittenByUserWithCursor(
+				"user-id",
+				List.of(),
+				null,
+				null,
+				20);
+
+			// then
+			assertEmptySlice(result, 20);
+			verifyNoInteractions(jpaQueryFactory);
+		}
+
+		@DisplayName("접근 가능한 게시판이 없으면 내가 좋아요한 글 조회는 DB 조회 없이 빈 Slice를 반환한다")
+		@Test
+		void findPostsLikedByUserWithCursor_shouldReturnEmptySlice_whenNoAccessibleBoards() {
+			// when
+			Slice<PostCursorResult> result = postQueryRepository.findPostsLikedByUserWithCursor(
+				"user-id",
+				Set.of(),
+				List.of(),
+				null,
+				null,
+				20);
+
+			// then
+			assertEmptySlice(result, 20);
+			verifyNoInteractions(jpaQueryFactory);
+		}
+
+		private void assertEmptySlice(Slice<PostCursorResult> result, int expectedSize) {
+			assertThat(result.getContent()).isEmpty();
+			assertThat(result.hasNext()).isFalse();
+			assertThat(result.getPageable().getPageSize()).isEqualTo(expectedSize);
+		}
+	}
+}

--- a/app-main/src/test/java/net/causw/app/main/domain/community/post/service/PostServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/community/post/service/PostServiceTest.java
@@ -1157,14 +1157,9 @@ public class PostServiceTest {
 		void getPostsCommentedByUser_shouldReturnEmpty_whenNoAccessibleBoards() {
 			// given
 			List<String> accessibleBoardIds = List.of();
-			Slice<PostCursorResult> emptySlice = new SliceImpl<>(List.of(), PageRequest.of(0, pageSize), false);
 
 			given(boardConfigReader.getAccessibleBoardIdsByAcademicStatus(AcademicStatus.ENROLLED))
 				.willReturn(accessibleBoardIds);
-			given(blockReader.findBlockeeUserIdsByBlocker(viewer)).willReturn(Set.of());
-			given(postReader.findPostsCommentedByUserWithCursor(
-				eq("viewer-id"), anySet(), eq(accessibleBoardIds), eq(null), eq(null), eq(pageSize)))
-				.willReturn(emptySlice);
 
 			// when
 			PostListResult result = postService.getPostsCommentedByUser(viewer, null, pageSize);
@@ -1173,8 +1168,9 @@ public class PostServiceTest {
 			assertAll(
 				() -> assertThat(result.posts()).isEmpty(),
 				() -> assertThat(result.nextCursor()).isNull());
-			verify(postReader, times(1)).findPostsCommentedByUserWithCursor(
-				eq("viewer-id"), anySet(), eq(accessibleBoardIds), eq(null), eq(null), eq(pageSize));
+			verify(blockReader, never()).findBlockeeUserIdsByBlocker(any(User.class));
+			verify(postReader, never()).findPostsCommentedByUserWithCursor(
+				anyString(), anySet(), anyList(), any(), any(), anyInt());
 		}
 
 		@DisplayName("접근 가능한 게시판이 없으면 내가 작성한 글 조회는 빈 결과를 반환한다")
@@ -1182,13 +1178,9 @@ public class PostServiceTest {
 		void getPostsWrittenByUser_shouldReturnEmpty_whenNoAccessibleBoards() {
 			// given
 			List<String> accessibleBoardIds = List.of();
-			Slice<PostCursorResult> emptySlice = new SliceImpl<>(List.of(), PageRequest.of(0, pageSize), false);
 
 			given(boardConfigReader.getAccessibleBoardIdsByAcademicStatus(AcademicStatus.ENROLLED))
 				.willReturn(accessibleBoardIds);
-			given(postReader.findPostsWrittenByUserWithCursor(
-				eq("viewer-id"), eq(accessibleBoardIds), eq(null), eq(null), eq(pageSize)))
-				.willReturn(emptySlice);
 
 			// when
 			PostListResult result = postService.getPostsWrittenByUser(viewer, null, pageSize);
@@ -1197,8 +1189,8 @@ public class PostServiceTest {
 			assertAll(
 				() -> assertThat(result.posts()).isEmpty(),
 				() -> assertThat(result.nextCursor()).isNull());
-			verify(postReader, times(1)).findPostsWrittenByUserWithCursor(
-				eq("viewer-id"), eq(accessibleBoardIds), eq(null), eq(null), eq(pageSize));
+			verify(postReader, never()).findPostsWrittenByUserWithCursor(anyString(), anyList(), any(), any(),
+				anyInt());
 		}
 
 		@DisplayName("접근 가능한 게시판이 없으면 내가 좋아요한 글 조회는 빈 결과를 반환한다")
@@ -1206,14 +1198,9 @@ public class PostServiceTest {
 		void getPostsLikedByUser_shouldReturnEmpty_whenNoAccessibleBoards() {
 			// given
 			List<String> accessibleBoardIds = List.of();
-			Slice<PostCursorResult> emptySlice = new SliceImpl<>(List.of(), PageRequest.of(0, pageSize), false);
 
 			given(boardConfigReader.getAccessibleBoardIdsByAcademicStatus(AcademicStatus.ENROLLED))
 				.willReturn(accessibleBoardIds);
-			given(blockReader.findBlockeeUserIdsByBlocker(viewer)).willReturn(Set.of());
-			given(postReader.findPostsLikedByUserWithCursor(
-				eq("viewer-id"), anySet(), eq(accessibleBoardIds), eq(null), eq(null), eq(pageSize)))
-				.willReturn(emptySlice);
 
 			// when
 			PostListResult result = postService.getPostsLikedByUser(viewer, null, pageSize);
@@ -1222,8 +1209,9 @@ public class PostServiceTest {
 			assertAll(
 				() -> assertThat(result.posts()).isEmpty(),
 				() -> assertThat(result.nextCursor()).isNull());
-			verify(postReader, times(1)).findPostsLikedByUserWithCursor(
-				eq("viewer-id"), anySet(), eq(accessibleBoardIds), eq(null), eq(null), eq(pageSize));
+			verify(blockReader, never()).findBlockeeUserIdsByBlocker(any(User.class));
+			verify(postReader, never()).findPostsLikedByUserWithCursor(
+				anyString(), anySet(), anyList(), any(), any(), anyInt());
 		}
 	}
 

--- a/app-main/src/test/java/net/causw/app/main/domain/community/post/service/PostServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/community/post/service/PostServiceTest.java
@@ -1140,6 +1140,94 @@ public class PostServiceTest {
 	}
 
 	@Nested
+	@DisplayName("마이페이지 게시글 목록 조회 테스트")
+	class GetMyPostsTest {
+
+		User viewer;
+		int pageSize;
+
+		@BeforeEach
+		void setUp() {
+			viewer = ObjectFixtures.getCertifiedUserWithId("viewer-id");
+			pageSize = 20;
+		}
+
+		@DisplayName("접근 가능한 게시판이 없으면 내가 댓글 단 글 조회는 빈 결과를 반환한다")
+		@Test
+		void getPostsCommentedByUser_shouldReturnEmpty_whenNoAccessibleBoards() {
+			// given
+			List<String> accessibleBoardIds = List.of();
+			Slice<PostCursorResult> emptySlice = new SliceImpl<>(List.of(), PageRequest.of(0, pageSize), false);
+
+			given(boardConfigReader.getAccessibleBoardIdsByAcademicStatus(AcademicStatus.ENROLLED))
+				.willReturn(accessibleBoardIds);
+			given(blockReader.findBlockeeUserIdsByBlocker(viewer)).willReturn(Set.of());
+			given(postReader.findPostsCommentedByUserWithCursor(
+				eq("viewer-id"), anySet(), eq(accessibleBoardIds), eq(null), eq(null), eq(pageSize)))
+				.willReturn(emptySlice);
+
+			// when
+			PostListResult result = postService.getPostsCommentedByUser(viewer, null, pageSize);
+
+			// then
+			assertAll(
+				() -> assertThat(result.posts()).isEmpty(),
+				() -> assertThat(result.nextCursor()).isNull());
+			verify(postReader, times(1)).findPostsCommentedByUserWithCursor(
+				eq("viewer-id"), anySet(), eq(accessibleBoardIds), eq(null), eq(null), eq(pageSize));
+		}
+
+		@DisplayName("접근 가능한 게시판이 없으면 내가 작성한 글 조회는 빈 결과를 반환한다")
+		@Test
+		void getPostsWrittenByUser_shouldReturnEmpty_whenNoAccessibleBoards() {
+			// given
+			List<String> accessibleBoardIds = List.of();
+			Slice<PostCursorResult> emptySlice = new SliceImpl<>(List.of(), PageRequest.of(0, pageSize), false);
+
+			given(boardConfigReader.getAccessibleBoardIdsByAcademicStatus(AcademicStatus.ENROLLED))
+				.willReturn(accessibleBoardIds);
+			given(postReader.findPostsWrittenByUserWithCursor(
+				eq("viewer-id"), eq(accessibleBoardIds), eq(null), eq(null), eq(pageSize)))
+				.willReturn(emptySlice);
+
+			// when
+			PostListResult result = postService.getPostsWrittenByUser(viewer, null, pageSize);
+
+			// then
+			assertAll(
+				() -> assertThat(result.posts()).isEmpty(),
+				() -> assertThat(result.nextCursor()).isNull());
+			verify(postReader, times(1)).findPostsWrittenByUserWithCursor(
+				eq("viewer-id"), eq(accessibleBoardIds), eq(null), eq(null), eq(pageSize));
+		}
+
+		@DisplayName("접근 가능한 게시판이 없으면 내가 좋아요한 글 조회는 빈 결과를 반환한다")
+		@Test
+		void getPostsLikedByUser_shouldReturnEmpty_whenNoAccessibleBoards() {
+			// given
+			List<String> accessibleBoardIds = List.of();
+			Slice<PostCursorResult> emptySlice = new SliceImpl<>(List.of(), PageRequest.of(0, pageSize), false);
+
+			given(boardConfigReader.getAccessibleBoardIdsByAcademicStatus(AcademicStatus.ENROLLED))
+				.willReturn(accessibleBoardIds);
+			given(blockReader.findBlockeeUserIdsByBlocker(viewer)).willReturn(Set.of());
+			given(postReader.findPostsLikedByUserWithCursor(
+				eq("viewer-id"), anySet(), eq(accessibleBoardIds), eq(null), eq(null), eq(pageSize)))
+				.willReturn(emptySlice);
+
+			// when
+			PostListResult result = postService.getPostsLikedByUser(viewer, null, pageSize);
+
+			// then
+			assertAll(
+				() -> assertThat(result.posts()).isEmpty(),
+				() -> assertThat(result.nextCursor()).isNull());
+			verify(postReader, times(1)).findPostsLikedByUserWithCursor(
+				eq("viewer-id"), anySet(), eq(accessibleBoardIds), eq(null), eq(null), eq(pageSize));
+		}
+	}
+
+	@Nested
 	@DisplayName("게시글 상세 조회 테스트")
 	class GetPostDetailTest {
 


### PR DESCRIPTION
### 🚩 관련사항
Closes #1365

### 📢 전달사항
마이페이지 게시글 목록 조회 3종에서 현재 사용자가 더 이상 접근할 수 없는 게시판의 과거 활동 내역이 노출될 수 있는 문제를 수정했습니다.

일반 게시글 목록 조회와 동일하게 사용자의 `AcademicStatus` 기준 접근 가능 게시판 ID 목록을 먼저 구하고, 이를 QueryDSL 조회 조건에 `post.board.id.in(accessibleBoardIds)`로 주입했습니다. 서비스 레이어에서 조회 결과를 후처리하지 않고 DB 조회 단계에서 필터링하므로 커서 페이징의 `size`와 `hasNext` 판정이 유지됩니다.

리뷰 시에는 다음 부분을 중점적으로 봐주세요.
- `GET /api/v2/posts/me`
- `GET /api/v2/posts/me/commented`
- `GET /api/v2/posts/me/liked`
- `accessibleBoardIds`가 빈 목록일 때 DB 조회 없이 빈 `Slice`를 반환하는 short-circuit 처리

검증:
- `./gradlew :app-main:test --tests net.causw.app.main.domain.community.post.service.PostServiceTest --tests net.causw.app.main.domain.community.post.repository.query.PostQueryRepositoryTest`
- `./gradlew :app-main:spotlessCheck test`

### 📸 스크린샷
해당 없음.

### 📃 진행사항
- [x] 마이페이지 조회 3종에서 접근 가능 게시판 ID 조회 및 전달
- [x] QueryDSL 조건에 게시판 접근 권한 필터 추가
- [x] 접근 가능 게시판이 없을 때 빈 `Slice` 즉시 반환
- [x] 서비스/쿼리 레이어 회귀 테스트 추가

### ⚙️ 기타사항
DB 스키마 변경은 없습니다. `db-change` 라벨은 필요하지 않습니다.

개발기간: 2026.06.26
