### PR TITLE
feat: 사물함 연장 및 만료 반납 알림 보강

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/admin/audit/event/AdminAuditLogEventListener.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/admin/audit/event/AdminAuditLogEventListener.java
@@ -2,8 +2,6 @@ package net.causw.app.main.domain.admin.audit.event;
 
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 

--- a/app-main/src/main/java/net/causw/app/main/domain/admin/audit/event/AdminAuditLogEventListener.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/admin/audit/event/AdminAuditLogEventListener.java
@@ -19,7 +19,6 @@ public class AdminAuditLogEventListener {
 
 	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	@Transactional
 	public void handle(AdminAuditLogEvent event) {
 		adminAuditLogWriter.write(event.command());
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/admin/audit/event/AdminAuditLogEventListener.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/admin/audit/event/AdminAuditLogEventListener.java
@@ -1,11 +1,16 @@
 package net.causw.app.main.domain.admin.audit.event;
 
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 import net.causw.app.main.domain.admin.audit.service.implementation.AdminAuditLogWriter;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
@@ -13,7 +18,9 @@ public class AdminAuditLogEventListener {
 
 	private final AdminAuditLogWriter adminAuditLogWriter;
 
-	@EventListener
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void handle(AdminAuditLogEvent event) {
 		adminAuditLogWriter.write(event.command());
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/admin/audit/event/AdminAuditLogEventListener.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/admin/audit/event/AdminAuditLogEventListener.java
@@ -1,16 +1,15 @@
 package net.causw.app.main.domain.admin.audit.event;
 
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-
-import net.causw.app.main.domain.admin.audit.service.implementation.AdminAuditLogWriter;
-
-import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+
+import net.causw.app.main.domain.admin.audit.service.implementation.AdminAuditLogWriter;
+
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor

--- a/app-main/src/main/java/net/causw/app/main/domain/admin/audit/event/AdminAuditLogEventListener.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/admin/audit/event/AdminAuditLogEventListener.java
@@ -19,7 +19,7 @@ public class AdminAuditLogEventListener {
 
 	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Transactional
 	public void handle(AdminAuditLogEvent event) {
 		adminAuditLogWriter.write(event.command());
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/api/v2/controller/dto/response/MyLockerResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/api/v2/controller/dto/response/MyLockerResponse.java
@@ -13,13 +13,17 @@ public record MyLockerResponse(
 
 	@Schema(description = "사물함 위치 표시명", example = "4층 15번", nullable = true) String displayName,
 
-	@Schema(description = "만료일시", example = "2026-06-30T23:59:59", nullable = true) LocalDateTime expiredAt) {
+	@Schema(description = "만료일시", example = "2026-06-30T23:59:59", nullable = true) LocalDateTime expiredAt,
+
+	@Schema(description = "사물함 연장됨 여부", example = "false", nullable = true) Boolean isExtended
+
+) {
 
 	public static MyLockerResponse empty() {
-		return new MyLockerResponse(false, null, null, null);
+		return new MyLockerResponse(false, null, null, null, null);
 	}
 
-	public static MyLockerResponse of(String lockerId, String displayName, LocalDateTime expiredAt) {
-		return new MyLockerResponse(true, lockerId, displayName, expiredAt);
+	public static MyLockerResponse of(String lockerId, String displayName, LocalDateTime expiredAt, boolean isExtended) {
+		return new MyLockerResponse(true, lockerId, displayName, expiredAt, isExtended);
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/api/v2/controller/dto/response/MyLockerResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/api/v2/controller/dto/response/MyLockerResponse.java
@@ -23,7 +23,8 @@ public record MyLockerResponse(
 		return new MyLockerResponse(false, null, null, null, null);
 	}
 
-	public static MyLockerResponse of(String lockerId, String displayName, LocalDateTime expiredAt, boolean isExtended) {
+	public static MyLockerResponse of(String lockerId, String displayName, LocalDateTime expiredAt,
+		boolean isExtended) {
 		return new MyLockerResponse(true, lockerId, displayName, expiredAt, isExtended);
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/entity/Locker.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/entity/Locker.java
@@ -53,8 +53,7 @@ public class Locker extends BaseEntity {
 		Boolean isActive,
 		User user,
 		LockerLocation location,
-		LocalDateTime expireDate
-	) {
+		LocalDateTime expireDate) {
 		return Locker.builder()
 			.lockerNumber(lockerNumber)
 			.isActive(isActive)

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/entity/Locker.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/entity/Locker.java
@@ -45,18 +45,23 @@ public class Locker extends BaseEntity {
 	@JoinColumn(name = "location_id", nullable = false)
 	private LockerLocation location;
 
+	// 연장여부 (반납/회수 시 기본값 false)
+	private boolean isExtended;
+
 	public static Locker of(
 		Long lockerNumber,
 		Boolean isActive,
 		User user,
 		LockerLocation location,
-		LocalDateTime expireDate) {
+		LocalDateTime expireDate
+	) {
 		return Locker.builder()
 			.lockerNumber(lockerNumber)
 			.isActive(isActive)
 			.user(user)
 			.location(location)
 			.expireDate(expireDate)
+			.isExtended(false)
 			.build();
 	}
 
@@ -64,53 +69,48 @@ public class Locker extends BaseEntity {
 		return Optional.ofNullable(this.user);
 	}
 
-	public void update(boolean isActive, User user, LocalDateTime expireDate) {
-		this.isActive = isActive;
-		this.user = user;
-		this.expireDate = expireDate;
-	}
-
-	public void updateLocation(LockerLocation location) {
-		this.location = location;
-	}
-
-	public void registerV1(User user, LocalDateTime expiredAt) {
-		this.user = user;
-		this.isActive = Boolean.FALSE;
-		this.expireDate = expiredAt;
-	}
-
-	public void returnLockerV1() {
-		this.user = null;
-		this.isActive = Boolean.TRUE;
-		this.expireDate = null;
-	}
-
+	/**
+	 * 사물함 신청
+	 * @param user 신청 유저
+	 * @param expiredAt 만료일
+	 */
 	public void register(User user, LocalDateTime expiredAt) {
 		this.user = user;
 		this.expireDate = expiredAt;
+		this.isExtended = false;
 	}
 
+	/**
+	 * 사물함 반납
+	 */
 	public void returnLocker() {
 		this.user = null;
 		this.expireDate = null;
+		this.isExtended = false;
 	}
 
+	/**
+	 * 사물함 연장
+	 * @param expiredAt 연장 일시
+	 */
 	public void extendExpireDate(LocalDateTime expiredAt) {
 		this.expireDate = expiredAt;
+		this.isExtended = true;
 	}
 
+	/**
+	 * 사물함 활성화
+	 */
 	public void enable() {
 		this.isActive = true;
 	}
 
+	/**
+	 * 사물함 비활성화
+	 */
 	public void disable() {
 		this.isActive = false;
 		this.user = null;
-	}
-
-	public void move(LockerLocation lockerLocation) {
-		this.location = lockerLocation;
 	}
 
 	public LockerStatus getStatus() {

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/repository/query/LockerQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/repository/query/LockerQueryRepository.java
@@ -2,6 +2,7 @@ package net.causw.app.main.domain.asset.locker.repository.query;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -25,6 +26,18 @@ import lombok.RequiredArgsConstructor;
 public class LockerQueryRepository {
 
 	private final JPAQueryFactory jpaQueryFactory;
+
+	public Optional<Locker> findLockerById(String lockerId) {
+		QLocker qLocker = QLocker.locker;
+		QLockerLocation qlockerLocation = QLockerLocation.lockerLocation;
+
+		Locker locker = jpaQueryFactory
+				.selectFrom(qLocker)
+				.join(qLocker.location, qlockerLocation).fetchJoin()
+				.where(qLocker.id.eq(lockerId))
+				.fetchOne();
+		return Optional.ofNullable(locker);
+	}
 
 	public Page<Locker> findLockers(
 		String userKeyword,

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/repository/query/LockerQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/repository/query/LockerQueryRepository.java
@@ -32,10 +32,10 @@ public class LockerQueryRepository {
 		QLockerLocation qlockerLocation = QLockerLocation.lockerLocation;
 
 		Locker locker = jpaQueryFactory
-				.selectFrom(qLocker)
-				.join(qLocker.location, qlockerLocation).fetchJoin()
-				.where(qLocker.id.eq(lockerId))
-				.fetchOne();
+			.selectFrom(qLocker)
+			.join(qLocker.location, qlockerLocation).fetchJoin()
+			.where(qLocker.id.eq(lockerId))
+			.fetchOne();
 		return Optional.ofNullable(locker);
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/LockerAdminService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/LockerAdminService.java
@@ -2,6 +2,8 @@ package net.causw.app.main.domain.asset.locker.service;
 
 import java.time.LocalDateTime;
 
+import net.causw.app.main.domain.notification.notification.event.LockerExpiredEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -41,6 +43,7 @@ public class LockerAdminService {
 	private final LockerValidator lockerValidator;
 	private final LockerWriter lockerWriter;
 	private final AdminAuditLogEventPublisher adminAuditLogEventPublisher;
+	private final ApplicationEventPublisher applicationEventPublisher;
 	private final UserReader userReader;
 
 	/**
@@ -165,9 +168,7 @@ public class LockerAdminService {
 
 		// locker user 존재할 시에 반환
 		var currentUser = locker.getUser();
-		if (currentUser.isPresent()) {
-			lockerWriter.releaseLocker(locker, admin, currentUser.get().getEmail(), currentUser.get().getName());
-		}
+        currentUser.ifPresent(user -> lockerWriter.releaseLocker(locker, admin, user.getEmail(), user.getName()));
 
 		lockerWriter.disableLocker(locker, admin);
 		adminAuditLogEventPublisher.publishLockerDisable(locker, admin, currentUser);
@@ -180,10 +181,16 @@ public class LockerAdminService {
 		var expiredLockers = lockerReader.findExpiredLockers(LocalDateTime.now());
 		expiredLockers.forEach(locker -> {
 			var expiredUser = locker.getUser();
+
+			var userId = expiredUser.map(User::getId).orElse(null);
 			var userEmail = expiredUser.map(User::getEmail).orElse("알 수 없음");
 			var userName = expiredUser.map(User::getName).orElse("알 수 없음");
 			lockerWriter.releaseLocker(locker, admin, userEmail, userName);
+
 			adminAuditLogEventPublisher.publishLockerReleaseExpired(locker, admin, expiredUser);
+			if (userId != null) {
+				applicationEventPublisher.publishEvent(new LockerExpiredEvent(userId, locker.getId()));
+			}
 		});
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/LockerAdminService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/LockerAdminService.java
@@ -2,7 +2,6 @@ package net.causw.app.main.domain.asset.locker.service;
 
 import java.time.LocalDateTime;
 
-import net.causw.app.main.domain.notification.notification.event.LockerExpiredEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,6 +17,7 @@ import net.causw.app.main.domain.asset.locker.service.implementation.LockerLogRe
 import net.causw.app.main.domain.asset.locker.service.implementation.LockerReader;
 import net.causw.app.main.domain.asset.locker.service.implementation.LockerValidator;
 import net.causw.app.main.domain.asset.locker.service.implementation.LockerWriter;
+import net.causw.app.main.domain.notification.notification.event.LockerExpiredEvent;
 import net.causw.app.main.domain.user.account.entity.user.User;
 import net.causw.app.main.domain.user.account.service.implementation.UserReader;
 import net.causw.app.main.shared.exception.errorcode.UserErrorCode;
@@ -168,7 +168,7 @@ public class LockerAdminService {
 
 		// locker user 존재할 시에 반환
 		var currentUser = locker.getUser();
-        currentUser.ifPresent(user -> lockerWriter.releaseLocker(locker, admin, user.getEmail(), user.getName()));
+		currentUser.ifPresent(user -> lockerWriter.releaseLocker(locker, admin, user.getEmail(), user.getName()));
 
 		lockerWriter.disableLocker(locker, admin);
 		adminAuditLogEventPublisher.publishLockerDisable(locker, admin, currentUser);

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/dto/result/MyLockerResult.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/dto/result/MyLockerResult.java
@@ -17,7 +17,9 @@ public record MyLockerResult(
 	boolean hasLocker,
 	String lockerId,
 	String displayName,
-	LocalDateTime expiredAt) {
+	LocalDateTime expiredAt,
+	Boolean isExtended
+	) {
 
 	/**
 	 * 사물함을 보유하지 않은 상태를 나타내는 결과를 반환한다.
@@ -25,7 +27,7 @@ public record MyLockerResult(
 	 * @return 사물함 미보유 상태 결과
 	 */
 	public static MyLockerResult empty() {
-		return new MyLockerResult(false, null, null, null);
+		return new MyLockerResult(false, null, null, null, null);
 	}
 
 	/**
@@ -36,7 +38,7 @@ public record MyLockerResult(
 	 * @param expiredAt   사물함 만료 일시
 	 * @return 사물함 보유 상태 결과
 	 */
-	public static MyLockerResult of(String lockerId, String displayName, LocalDateTime expiredAt) {
-		return new MyLockerResult(true, lockerId, displayName, expiredAt);
+	public static MyLockerResult of(String lockerId, String displayName, LocalDateTime expiredAt, boolean isExtended) {
+		return new MyLockerResult(true, lockerId, displayName, expiredAt, isExtended);
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/dto/result/MyLockerResult.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/dto/result/MyLockerResult.java
@@ -18,8 +18,7 @@ public record MyLockerResult(
 	String lockerId,
 	String displayName,
 	LocalDateTime expiredAt,
-	Boolean isExtended
-	) {
+	Boolean isExtended) {
 
 	/**
 	 * 사물함을 보유하지 않은 상태를 나타내는 결과를 반환한다.

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/implementation/LockerLocationReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/implementation/LockerLocationReader.java
@@ -20,7 +20,7 @@ public class LockerLocationReader {
 
 	public LockerLocation findById(String locationId) {
 		return lockerLocationRepository.findById(locationId)
-			.orElseThrow(LockerErrorCode.LOCKER_NOT_FOUND::toBaseException);
+			.orElseThrow(LockerErrorCode.LOCKER_LOCATION_NOT_FOUND::toBaseException);
 	}
 
 	public List<LockerLocation> findAll() {

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/implementation/LockerLogWriter.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/implementation/LockerLogWriter.java
@@ -50,7 +50,7 @@ public class LockerLogWriter {
 
 	public void logAdminRelease(Locker locker, User admin, String userEmail, String userName) {
 		save(locker, admin.getEmail(), admin.getName(), LockerLogAction.ADMIN_RELEASE,
-			"관리자 사물함 회수" + userName + "(" + userEmail + ")");
+			"관리자 사물함 회수 " + userName + "(" + userEmail + ")");
 	}
 
 	private void save(Locker locker, String userEmail, String userName, LockerLogAction action, String message) {

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/implementation/LockerReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/implementation/LockerReader.java
@@ -35,7 +35,7 @@ public class LockerReader {
 	 */
 	public Locker findById(String lockerId) {
 		return lockerQueryRepository.findLockerById(lockerId)
-				.orElseThrow(LockerErrorCode.LOCKER_NOT_FOUND::toBaseException);
+			.orElseThrow(LockerErrorCode.LOCKER_NOT_FOUND::toBaseException);
 	}
 
 	/**

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/implementation/LockerReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/implementation/LockerReader.java
@@ -27,6 +27,22 @@ public class LockerReader {
 	private final LockerRepository lockerRepository;
 	private final LockerQueryRepository lockerQueryRepository;
 
+	/**
+	 * 사물함 찾기
+	 *
+	 * @param lockerId locker id
+	 * @return Locker 사물함
+	 */
+	public Locker findById(String lockerId) {
+		return lockerQueryRepository.findLockerById(lockerId)
+				.orElseThrow(LockerErrorCode.LOCKER_NOT_FOUND::toBaseException);
+	}
+
+	/**
+	 * 사물함 쓰기용 찾기 (pessimistic lock)
+	 * @param lockerId locker id
+	 * @return 사물함
+	 */
 	public Locker findByIdForWrite(String lockerId) {
 		return lockerRepository.findByIdForWrite(lockerId)
 			.orElseThrow(LockerErrorCode.LOCKER_NOT_FOUND::toBaseException);

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/implementation/LockerValidator.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/implementation/LockerValidator.java
@@ -35,7 +35,7 @@ public class LockerValidator {
 	 * 사물함 반납 기간 검증
 	 */
 	public void validateReturnPeriod(LocalDateTime time) {
-		if (!lockerPeriodResolver.isRegisterActive(time)) {
+		if (!lockerPeriodResolver.isRegisterActive(time) && !lockerPeriodResolver.isExtendActive(time)) {
 			throw LockerErrorCode.LOCKER_RETURN_NOT_ALLOWED.toBaseException();
 		}
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/implementation/LockerValidator.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/service/implementation/LockerValidator.java
@@ -78,7 +78,7 @@ public class LockerValidator {
 	 * 현재 만료일이 연장 목표 만료일과 동일하면 이미 연장된 것
 	 */
 	public void validateNotAlreadyExtended(Locker locker, LocalDateTime nextExpireDate) {
-		if (locker.getExpireDate() != null && locker.getExpireDate().isEqual(nextExpireDate)) {
+		if (locker.isExtended() || (locker.getExpireDate() != null && locker.getExpireDate().isEqual(nextExpireDate))) {
 			throw LockerErrorCode.LOCKER_ALREADY_EXTENDED.toBaseException();
 		}
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/util/LockerMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/util/LockerMapper.java
@@ -19,7 +19,7 @@ public class LockerMapper {
 	public static MyLockerResult toMyLockerResult(Locker locker) {
 		LockerLocation location = locker.getLocation();
 		String displayName = location.getDescription() + " " + locker.getLockerNumber() + "번";
-		return MyLockerResult.of(locker.getId(), displayName, locker.getExpireDate());
+		return MyLockerResult.of(locker.getId(), displayName, locker.getExpireDate(), locker.isExtended());
 	}
 
 	public static List<LockerLocationResult.LockerItemResult> toLockerItemResults(

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/enums/NoticeType.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/enums/NoticeType.java
@@ -20,7 +20,8 @@ public enum NoticeType {
 	COMMUNITY("커뮤니티 알림", "커뮤니티 알림 - v2"),
 	SYSTEM("시스템 알림", "시스템 알림 - v2"),
 	OFFICIAL("공식계정 글 알림", "공식 알림 - v2"),
-	CEREMONY_V2("경조사 알림", "경조사 알림 - v2");
+	CEREMONY_V2("경조사 알림", "경조사 알림 - v2"),
+	LOCKER("사물함 알림", "사물함 알림");
 
 	private final String title;
 	private final String type;

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/event/LockerExpiredEvent.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/event/LockerExpiredEvent.java
@@ -1,0 +1,4 @@
+package net.causw.app.main.domain.notification.notification.event;
+
+public record LockerExpiredEvent(String userId, String lockerId) {
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/implementation/NotificationPushSender.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/implementation/NotificationPushSender.java
@@ -31,6 +31,7 @@ public class NotificationPushSender {
 	 * @param body  알림 내용
 	 */
 	public void sendToUser(User user, String title, String body) {
+		log.debug("단일 유저 푸시알림 전송 요청: userId={}", user.getId());
 		send(user, title, body);
 	}
 
@@ -42,6 +43,7 @@ public class NotificationPushSender {
 	 * @param body  알림 내용
 	 */
 	public void sendToUsers(List<User> users, String title, String body) {
+		log.debug("다중 유저 푸시알림 전송 요청: userCount={}", users.size());
 		users.forEach(user -> send(user, title, body));
 	}
 
@@ -53,10 +55,18 @@ public class NotificationPushSender {
 	 */
 	private void send(User user, String title, String body) {
 		if (user.getFcmTokens() == null) {
+			log.debug("푸시알림 전송 생략: userId={}, reason=fcm_tokens_null", user.getId());
 			return;
 		}
 
 		Set<String> tokens = new HashSet<>(user.getFcmTokens());
+		if (tokens.isEmpty()) {
+			log.debug("푸시알림 전송 생략: userId={}, reason=fcm_tokens_empty", user.getId());
+			return;
+		}
+
+		log.debug("푸시알림 전송 시작: userId={}, tokenCount={}, titleLength={}, bodyLength={}", user.getId(),
+			tokens.size(), title == null ? 0 : title.length(), body == null ? 0 : body.length());
 		tokens.forEach(token -> trySend(user, token, title, body));
 	}
 
@@ -70,13 +80,15 @@ public class NotificationPushSender {
 	 */
 	private void trySend(User user, String token, String title, String body) {
 		try {
+			log.debug("푸시알림 토큰별 전송 시도: userId={}", user.getId());
 			pushNotificationSender.send(token, title, body);
+			log.debug("푸시알림 토큰별 전송 성공: userId={}", user.getId());
 		} catch (FirebaseMessagingException e) {
-			log.error("FCM 전송 실패: {}, 이유: {}", token, e.getMessage());
+			log.error("푸시알림 전송 실패: {}, 이유: {}", token, e.getMessage());
 			userPushTokenWriter.removeFcmToken(user, token);
-			log.info("오류 발생으로 FCM 토큰 제거됨: {}", token);
+			log.info("오류 발생으로 푸시알림 토큰 제거됨: {}", token);
 		} catch (Exception e) {
-			log.error("FCM 전송 중 알 수 없는 예외 발생: {}", e.getMessage(), e);
+			log.error("푸시알림 전송 중 알 수 없는 예외 발생: {}", e.getMessage(), e);
 		}
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/listener/LockerExpiredEventListener.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/listener/LockerExpiredEventListener.java
@@ -50,8 +50,9 @@ public class LockerExpiredEventListener {
 
 		String description = String.format("이용기간이 만료되어 사물함(%s %d번)이 자동으로 반납되었습니다.", location.getDescription(),
 			locker.getLockerNumber());
-		Notification notification = notificationWriter.save(Notification.of(user, description, description, NoticeType.LOCKER, locker.getId(),
-			location.getId()));
+		Notification notification = notificationWriter
+			.save(Notification.of(user, description, description, NoticeType.LOCKER, locker.getId(),
+				location.getId()));
 
 		notificationPushSender.sendToUser(user, description, description);
 		notificationWriter.saveLog(user, notification);

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/listener/LockerExpiredEventListener.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/listener/LockerExpiredEventListener.java
@@ -1,0 +1,50 @@
+package net.causw.app.main.domain.notification.notification.service.listener;
+
+import lombok.RequiredArgsConstructor;
+import net.causw.app.main.domain.asset.locker.entity.Locker;
+import net.causw.app.main.domain.asset.locker.entity.LockerLocation;
+import net.causw.app.main.domain.asset.locker.service.implementation.LockerReader;
+import net.causw.app.main.domain.notification.notification.entity.Notification;
+import net.causw.app.main.domain.notification.notification.enums.NoticeType;
+import net.causw.app.main.domain.notification.notification.event.LockerExpiredEvent;
+import net.causw.app.main.domain.notification.notification.service.implementation.NotificationPushSender;
+import net.causw.app.main.domain.notification.notification.service.implementation.NotificationWriter;
+import net.causw.app.main.domain.user.account.entity.user.User;
+import net.causw.app.main.domain.user.account.service.implementation.UserReader;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class LockerExpiredEventListener {
+
+    private final LockerReader lockerReader;
+    private final UserReader userReader;
+    private final NotificationPushSender notificationPushSender;
+    private final NotificationWriter notificationWriter;
+
+    /**
+     * 반납 완료 시 사물함 반납 완료 안내
+     *
+     * @param event 사물함 만료 반납 이벤트
+     */
+    @Async("asyncExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handle(LockerExpiredEvent event) {
+        Locker locker = lockerReader.findById(event.lockerId());
+        LockerLocation location = locker.getLocation();
+        User user = userReader.findUserById(event.userId());
+
+
+        String description = String.format("이용기간이 만료되어 사물함(%s %d번)이 자동으로 반납되었습니다.", location.getDescription(), locker.getLockerNumber());
+        Notification notification = Notification.of(user, description, description, NoticeType.LOCKER, locker.getId(), location.getId());
+
+        notificationPushSender.sendToUser(user, description, description);
+        notificationWriter.saveLog(user, notification);
+    }
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/listener/LockerExpiredEventListener.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/listener/LockerExpiredEventListener.java
@@ -1,6 +1,12 @@
 package net.causw.app.main.domain.notification.notification.service.listener;
 
-import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
 import net.causw.app.main.domain.asset.locker.entity.Locker;
 import net.causw.app.main.domain.asset.locker.entity.LockerLocation;
 import net.causw.app.main.domain.asset.locker.service.implementation.LockerReader;
@@ -11,40 +17,37 @@ import net.causw.app.main.domain.notification.notification.service.implementatio
 import net.causw.app.main.domain.notification.notification.service.implementation.NotificationWriter;
 import net.causw.app.main.domain.user.account.entity.user.User;
 import net.causw.app.main.domain.user.account.service.implementation.UserReader;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class LockerExpiredEventListener {
 
-    private final LockerReader lockerReader;
-    private final UserReader userReader;
-    private final NotificationPushSender notificationPushSender;
-    private final NotificationWriter notificationWriter;
+	private final LockerReader lockerReader;
+	private final UserReader userReader;
+	private final NotificationPushSender notificationPushSender;
+	private final NotificationWriter notificationWriter;
 
-    /**
-     * 반납 완료 시 사물함 반납 완료 안내
-     *
-     * @param event 사물함 만료 반납 이벤트
-     */
-    @Async("asyncExecutor")
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void handle(LockerExpiredEvent event) {
-        Locker locker = lockerReader.findById(event.lockerId());
-        LockerLocation location = locker.getLocation();
-        User user = userReader.findUserById(event.userId());
+	/**
+	 * 반납 완료 시 사물함 반납 완료 안내
+	 *
+	 * @param event 사물함 만료 반납 이벤트
+	 */
+	@Async("asyncExecutor")
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void handle(LockerExpiredEvent event) {
+		Locker locker = lockerReader.findById(event.lockerId());
+		LockerLocation location = locker.getLocation();
+		User user = userReader.findUserById(event.userId());
 
+		String description = String.format("이용기간이 만료되어 사물함(%s %d번)이 자동으로 반납되었습니다.", location.getDescription(),
+			locker.getLockerNumber());
+		Notification notification = Notification.of(user, description, description, NoticeType.LOCKER, locker.getId(),
+			location.getId());
 
-        String description = String.format("이용기간이 만료되어 사물함(%s %d번)이 자동으로 반납되었습니다.", location.getDescription(), locker.getLockerNumber());
-        Notification notification = Notification.of(user, description, description, NoticeType.LOCKER, locker.getId(), location.getId());
-
-        notificationPushSender.sendToUser(user, description, description);
-        notificationWriter.saveLog(user, notification);
-    }
+		notificationPushSender.sendToUser(user, description, description);
+		notificationWriter.saveLog(user, notification);
+	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/listener/LockerExpiredEventListener.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/listener/LockerExpiredEventListener.java
@@ -40,12 +40,18 @@ public class LockerExpiredEventListener {
 	public void handle(LockerExpiredEvent event) {
 		Locker locker = lockerReader.findById(event.lockerId());
 		LockerLocation location = locker.getLocation();
-		User user = userReader.findUserById(event.userId());
+
+		User user;
+		try {
+			user = userReader.findUserById(event.userId());
+		} catch (Exception e) {
+			return;
+		}
 
 		String description = String.format("이용기간이 만료되어 사물함(%s %d번)이 자동으로 반납되었습니다.", location.getDescription(),
 			locker.getLockerNumber());
-		Notification notification = Notification.of(user, description, description, NoticeType.LOCKER, locker.getId(),
-			location.getId());
+		Notification notification = notificationWriter.save(Notification.of(user, description, description, NoticeType.LOCKER, locker.getId(),
+			location.getId()));
 
 		notificationPushSender.sendToUser(user, description, description);
 		notificationWriter.saveLog(user, notification);

--- a/app-main/src/main/java/net/causw/app/main/shared/exception/errorcode/LockerErrorCode.java
+++ b/app-main/src/main/java/net/causw/app/main/shared/exception/errorcode/LockerErrorCode.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public enum LockerErrorCode implements BaseResponseCode {
 	LOCKER_NOT_FOUND(HttpStatus.NOT_FOUND, "LOCKER_404_001", "존재하지 않는 사물함입니다."),
+	LOCKER_LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "LOCKER_404_002", "존재하지 않는 사물함 층입니다."),
 	LOCKER_NOT_AVAILABLE(HttpStatus.CONFLICT, "LOCKER_409_001", "사용 가능한 상태의 사물함이 아닙니다."),
 	LOCKER_NOT_IN_USE(HttpStatus.CONFLICT, "LOCKER_409_002", "사용중인 사물함이 아닙니다."),
 	LOCKER_USER_ALREADY_HAS_LOCKER(HttpStatus.CONFLICT, "LOCKER_409_003", "해당 사용자는 이미 사물함을 사용중입니다."),

--- a/app-main/src/main/java/net/causw/app/main/shared/infra/firebase/FirebasePushNotificationSender.java
+++ b/app-main/src/main/java/net/causw/app/main/shared/infra/firebase/FirebasePushNotificationSender.java
@@ -1,5 +1,8 @@
 package net.causw.app.main.shared.infra.firebase;
 
+import java.util.Arrays;
+
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 import net.causw.app.main.shared.infra.push.PushNotificationSender;
@@ -8,14 +11,26 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class FirebasePushNotificationSender implements PushNotificationSender {
+
+	private static final String PROD_PROFILE = "prod";
+	private static final String DEV_PROFILE = "dev";
+
+	private final Environment environment;
 
 	@Override
 	public void send(String token, String title, String body) throws Exception {
+		if (!isPushEnabledProfile()) {
+			log.debug("FCM 메시지 발송 생략: activeProfiles={}", Arrays.toString(environment.getActiveProfiles()));
+			return;
+		}
+
 		Notification notification = Notification.builder()
 			.setTitle(title)
 			.setBody(body)
@@ -27,6 +42,11 @@ public class FirebasePushNotificationSender implements PushNotificationSender {
 			.build();
 
 		String response = FirebaseMessaging.getInstance().send(message);
-		log.info("Successfully sent message: {}", response);
+		log.info("FCM 메시지 발송 성공: response={}", response);
+	}
+
+	private boolean isPushEnabledProfile() {
+		return Arrays.stream(environment.getActiveProfiles())
+			.anyMatch(profile -> PROD_PROFILE.equals(profile) || DEV_PROFILE.equals(profile));
 	}
 }

--- a/app-main/src/main/resources/db/migration/V20260630120000__AddIsExtendedToLocker.sql
+++ b/app-main/src/main/resources/db/migration/V20260630120000__AddIsExtendedToLocker.sql
@@ -1,0 +1,17 @@
+-- Migration: AddIsExtendedToLocker
+ALTER TABLE tb_locker
+    ADD COLUMN is_extended BIT(1) NOT NULL DEFAULT b'0';
+
+ALTER TABLE tb_notification
+    MODIFY COLUMN notice_type ENUM(
+        'POST',
+        'COMMENT',
+        'CEREMONY',
+        'BOARD',
+        'ADMISSION',
+        'COMMUNITY',
+        'SYSTEM',
+        'OFFICIAL',
+        'CEREMONY_V2',
+        'LOCKER'
+    ) NULL;

--- a/app-main/src/main/resources/db/migration/V20260630120000__AddIsExtendedToLocker.sql
+++ b/app-main/src/main/resources/db/migration/V20260630120000__AddIsExtendedToLocker.sql
@@ -1,17 +1,3 @@
 -- Migration: AddIsExtendedToLocker
 ALTER TABLE tb_locker
     ADD COLUMN is_extended BIT(1) NOT NULL DEFAULT b'0';
-
-ALTER TABLE tb_notification
-    MODIFY COLUMN notice_type ENUM(
-        'POST',
-        'COMMENT',
-        'CEREMONY',
-        'BOARD',
-        'ADMISSION',
-        'COMMUNITY',
-        'SYSTEM',
-        'OFFICIAL',
-        'CEREMONY_V2',
-        'LOCKER'
-    ) NULL;

--- a/app-main/src/main/resources/db/migration/V20260630221500__AddLockerToNoticeType.sql
+++ b/app-main/src/main/resources/db/migration/V20260630221500__AddLockerToNoticeType.sql
@@ -1,0 +1,14 @@
+-- Migration: AddLockerToNoticeType
+ALTER TABLE tb_notification
+    MODIFY COLUMN notice_type ENUM(
+        'POST',
+        'COMMENT',
+        'CEREMONY',
+        'BOARD',
+        'ADMISSION',
+        'COMMUNITY',
+        'SYSTEM',
+        'OFFICIAL',
+        'CEREMONY_V2',
+        'LOCKER'
+    ) NULL;

--- a/app-main/src/test/java/net/causw/app/main/SchemaValidationTest.java
+++ b/app-main/src/test/java/net/causw/app/main/SchemaValidationTest.java
@@ -63,7 +63,7 @@ public class SchemaValidationTest {
 		public JpaVendorAdapter jpaVendorAdapter() {
 			HibernateJpaVendorAdapter adapter = new HibernateJpaVendorAdapter();
 			adapter.setShowSql(true);
-			adapter.setDatabasePlatform("org.hibernate.dialect.MySQL8Dialect");
+			adapter.setDatabasePlatform("org.hibernate.dialect.MySQLDialect");
 			return adapter;
 		}
 

--- a/app-main/src/test/java/net/causw/app/main/domain/asset/locker/service/LockerAdminServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/asset/locker/service/LockerAdminServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -32,6 +33,7 @@ import net.causw.app.main.domain.asset.locker.service.implementation.LockerLogRe
 import net.causw.app.main.domain.asset.locker.service.implementation.LockerReader;
 import net.causw.app.main.domain.asset.locker.service.implementation.LockerValidator;
 import net.causw.app.main.domain.asset.locker.service.implementation.LockerWriter;
+import net.causw.app.main.domain.notification.notification.event.LockerExpiredEvent;
 import net.causw.app.main.domain.user.account.entity.user.User;
 import net.causw.app.main.domain.user.account.service.implementation.UserReader;
 import net.causw.app.main.shared.exception.BaseRunTimeV2Exception;
@@ -55,6 +57,8 @@ class LockerAdminServiceTest {
 	private LockerWriter lockerWriter;
 	@Mock
 	private AdminAuditLogEventPublisher adminAuditLogEventPublisher;
+	@Mock
+	private ApplicationEventPublisher applicationEventPublisher;
 	@Mock
 	private UserReader userReader;
 
@@ -427,9 +431,11 @@ class LockerAdminServiceTest {
 			verify(lockerReader).findExpiredLockers(any(LocalDateTime.class));
 
 			verify(lockerWriter).releaseLocker(locker1, admin, user1.getEmail(), user1.getName());
-			verify(lockerWriter).releaseLocker(locker2, admin, user2.getEmail(), user2.getName());
-			verify(adminAuditLogEventPublisher).publishLockerReleaseExpired(locker1, admin, Optional.of(user1));
-			verify(adminAuditLogEventPublisher).publishLockerReleaseExpired(locker2, admin, Optional.of(user2));
+				verify(lockerWriter).releaseLocker(locker2, admin, user2.getEmail(), user2.getName());
+				verify(adminAuditLogEventPublisher).publishLockerReleaseExpired(locker1, admin, Optional.of(user1));
+				verify(adminAuditLogEventPublisher).publishLockerReleaseExpired(locker2, admin, Optional.of(user2));
+				verify(applicationEventPublisher).publishEvent(new LockerExpiredEvent(user1.getId(), locker1.getId()));
+				verify(applicationEventPublisher).publishEvent(new LockerExpiredEvent(user2.getId(), locker2.getId()));
+			}
 		}
 	}
-}

--- a/app-main/src/test/java/net/causw/app/main/domain/asset/locker/service/LockerAdminServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/asset/locker/service/LockerAdminServiceTest.java
@@ -431,11 +431,11 @@ class LockerAdminServiceTest {
 			verify(lockerReader).findExpiredLockers(any(LocalDateTime.class));
 
 			verify(lockerWriter).releaseLocker(locker1, admin, user1.getEmail(), user1.getName());
-				verify(lockerWriter).releaseLocker(locker2, admin, user2.getEmail(), user2.getName());
-				verify(adminAuditLogEventPublisher).publishLockerReleaseExpired(locker1, admin, Optional.of(user1));
-				verify(adminAuditLogEventPublisher).publishLockerReleaseExpired(locker2, admin, Optional.of(user2));
-				verify(applicationEventPublisher).publishEvent(new LockerExpiredEvent(user1.getId(), locker1.getId()));
-				verify(applicationEventPublisher).publishEvent(new LockerExpiredEvent(user2.getId(), locker2.getId()));
-			}
+			verify(lockerWriter).releaseLocker(locker2, admin, user2.getEmail(), user2.getName());
+			verify(adminAuditLogEventPublisher).publishLockerReleaseExpired(locker1, admin, Optional.of(user1));
+			verify(adminAuditLogEventPublisher).publishLockerReleaseExpired(locker2, admin, Optional.of(user2));
+			verify(applicationEventPublisher).publishEvent(new LockerExpiredEvent(user1.getId(), locker1.getId()));
+			verify(applicationEventPublisher).publishEvent(new LockerExpiredEvent(user2.getId(), locker2.getId()));
 		}
 	}
+}

--- a/app-main/src/test/java/net/causw/app/main/shared/infra/firebase/FirebasePushNotificationSenderTest.java
+++ b/app-main/src/test/java/net/causw/app/main/shared/infra/firebase/FirebasePushNotificationSenderTest.java
@@ -1,0 +1,60 @@
+package net.causw.app.main.shared.infra.firebase;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+import org.springframework.mock.env.MockEnvironment;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+
+@DisplayName("FirebasePushNotificationSender 단위 테스트")
+class FirebasePushNotificationSenderTest {
+
+	@Test
+	@DisplayName("local profile에서는 Firebase 전송을 수행하지 않는다")
+	void givenLocalProfile_whenSend_thenSkipFirebaseSend() throws Exception {
+		// given
+		MockEnvironment environment = new MockEnvironment();
+		environment.setActiveProfiles("local");
+		FirebasePushNotificationSender sender = new FirebasePushNotificationSender(environment);
+
+		try (MockedStatic<FirebaseMessaging> firebaseMessaging = mockStatic(FirebaseMessaging.class)) {
+			// when
+			sender.send("token", "title", "body");
+
+			// then
+			firebaseMessaging.verifyNoInteractions();
+		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"dev", "prod"})
+	@DisplayName("dev 또는 prod profile에서는 Firebase 전송을 수행한다")
+	void givenDevOrProdProfile_whenSend_thenSendFirebaseMessage(String profile) throws Exception {
+		// given
+		MockEnvironment environment = new MockEnvironment();
+		environment.setActiveProfiles(profile);
+		FirebasePushNotificationSender sender = new FirebasePushNotificationSender(environment);
+		FirebaseMessaging messaging = mock(FirebaseMessaging.class);
+
+		try (MockedStatic<FirebaseMessaging> firebaseMessaging = mockStatic(FirebaseMessaging.class)) {
+			firebaseMessaging.when(FirebaseMessaging::getInstance).thenReturn(messaging);
+			when(messaging.send(any(Message.class))).thenReturn("message-id");
+
+			// when
+			sender.send("token", "title", "body");
+
+			// then
+			verify(messaging).send(any(Message.class));
+		}
+	}
+}

--- a/global/src/main/java/net/causw/global/constant/MessageUtil.java
+++ b/global/src/main/java/net/causw/global/constant/MessageUtil.java
@@ -8,231 +8,36 @@ import lombok.NoArgsConstructor;
 public class MessageUtil {
 
 	// 400
-	public static final String INVALID_PARAMETER = "Invalid action parameter";
-	public static final String INVALID_REFRESH_TOKEN = "RefreshToken 유효성 검증 실패";
 	public static final String INVALID_TOKEN = "잘못된 AccessToken 입니다";
 	public static final String EXPIRED_TOKEN = "만료된 AccessToken 입니다";
-	public static final String DOES_NOT_HAVE_PERMISSION = "권한이 없습니다.";
-	public static final String INVALID_USER_DATA_REQUEST = "유저의 가입 및 수정 정보가 유효하지 않습니다.";
 
 	// Security
 	public static final String ACCESS_DENIED = "접근이 거부되었습니다.";
 
-	// Form
-	public static final String IS_NEED_COUNCIL_FEE_REQUIRED = "학생회비 납부 여부를 선택해 주세요.";
-	public static final String INVALID_REGISTERED_SEMESTER_INFO = "재학/휴학생 답변 가능을 선택했다면 답변할 수 있는 등록 완료 학기에 대한 정보가 필요합니다.";
-	public static final String INVALID_QUESTION_INFO = "유효하지 않은 문항 정보입니다.";
-	public static final String EMPTY_QUESTION_INFO = "문항 정보가 비어있습니다.";
-	public static final String EMPTY_OPTION_INFO = "문항 옵션 정보가 비어있습니다.";
-	public static final String FORM_NOT_FOUND = "신청 폼을 찾을 수 없습니다.";
-	public static final String QUESTION_NOT_FOUND = "질문을 찾을 수 없습니다.";
-	public static final String OPTION_NOT_FOUND = "해당 문항을 찾을 수 없습니다.";
-	public static final String NOT_ALLOWED_TO_REPLY_FORM = "답변이 허용되지 않은 사용자입니다.";
-	public static final String INVALID_REPLY_INFO = "유효하지 않은 신청서 답변 정보입니다.";
-	public static final String ALREADY_REPLIED = "이미 답변한 신청서입니다.";
-	public static final String NOT_ALLOWED_TO_ACCESS_REPLY = "신청서 답변을 조회할 수 없는 사용자입니다.";
-	public static final String FORM_CLOSED = "신청 기간이 종료되었습니다.";
-	public static final String REPLY_SIZE_INVALID = "답변 개수가 유효하지 않습니다.";
-
-	// Calendar & Event
-	public static final String CALENDAR_NOT_FOUND = "캘린더를 찾을 수 없습니다.";
-	public static final String CALENDAR_ALREADY_EXIST = "이미 존재하는 캘린더 입니다.";
-	public static final String EVENT_NOT_FOUND = "이벤트를 찾을 수 없습니다.";
-	public static final String EVENT_MAX_CREATED = "10개의 이벤트가 이미 존재합니다.";
-	public static final String SCHEDULE_NOT_FOUND = "일정을 찾을 수 없습니다.";
-
-	// Circle & Post
-	public static final String NOT_CIRCLE_LEADER = "사용자가 해당 동아리의 동아리장이 아닙니다.";
-	public static final String NOT_CIRCLE_MEMBER = "로그인된 사용자가 동아리 멤버가 아닙니다.";
 	public static final String LOGIN_USER_NOT_FOUND = "로그인된 사용자를 찾을 수 없습니다.";
 	public static final String BOARD_NOT_FOUND = "게시판을 찾을 수 없습니다.";
-	public static final String CIRCLE_LEADER_NOR_FOUND = "해당 동아리의 동아리장을 찾을 수 없습니다.";
-	public static final String CIRCLE_MEMBER_NOT_FOUND = "동아리를 찾을 수 없습니다.";
-	public static final String POST_NOT_FOUND = "게시글을 찾을 수 없습니다.";
-	public static final String COMMENT_NOT_FOUND = "댓글을 찾을 수 없습니다.";
-	public static final String NOTICE_NOT_FOUND = "앱 공지 게시판을 찾을 수 없습니다.";
-	public static final String SMALL_CLUB_NOT_FOUND = "소모임을 찾을 수 없습니다.";
-	public static final String USER_APPLY_NOT_FOUND = "사용자의 가입 신청을 찾을 수 없습니다.";
-	public static final String CIRCLE_WITHOUT_LEADER = "The board has circle without circle leader";
-	public static final String CIRCLE_APPLY_INVALID = "사용자가 가입 신청한 소모임이 아닙니다.";
-	public static final String CIRCLE_DUPLICATE_NAME = "중복된 소모임 이름입니다.";
-	public static final String NEW_CIRCLE_LEADER_NOT_FOUND = "등록할 동아리장을 다시 확인해주세요.";
-	public static final String CIRCLE_NOT_FOUND = "해당 동아리를 찾을 수 없습니다.";
-	public static final String POST_DELETED = "삭제된 게시물입니다.";
-	public static final String BOARD_NAME_ALREADY_EXISTS = "게시판 이름이 이미 존재합니다.";
-	public static final String INVALID_BOARD_CATEGORY = "유효하지 않은 게시판 카테고리입니다.";
-	public static final String ANONYMOUS_NOT_ALLOWED = "익명 게시글을 허용하지 않는 게시판입니다.";
 
-	// Like & favorite
-	public static final String POST_ALREADY_LIKED = "좋아요를 이미 누른 게시글 입니다.";
-	public static final String POST_NOT_LIKED = "좋아요을 누르지 않은 게시글입니다.";
-	public static final String POST_ALREADY_FAVORITED = "즐겨찾기를 이미 누른 게시글 입니다.";
-	public static final String POST_NOT_FAVORITED = "즐겨찾기를 누르지 않은 게시글입니다.";
-	public static final String COMMENT_ALREADY_LIKED = "좋아요를 이미 누른 댓글입니다.";
-	public static final String COMMENT_NOT_LIKED = "좋아요를 누르지 않은 댓글입니다.";
-	public static final String CHILD_COMMENT_NOT_LIKED = "좋아요를 누르지 않은 대댓글입니다.";
-
-	public static final String CHILD_COMMENT_ALREADY_LIKED = "좋아요를 이미 누른 대댓글입니다.";
-	public static final String FAVORITE_POST_NOT_FOUND = "즐겨찾기가 되어 있지 않습니다.";
-	public static final String FAVORITE_POST_ALREADY_DELETED = "즐겨찾기가 이미 취소되어 있습니다.";
-
-	// BoardApply
-	public static final String APPLY_ALREADY_ACCEPTED = "이미 승인된 게시판 신청입니다.";
-	public static final String APPLY_ALREADY_REJECTED = "이미 거부된 게시판 신청입니다.";
-	public static final String APPLY_NOT_FOUND = "게시판 신청을 찾을 수 없습니다.";
-
-	// Locker
-	public static final String LOCKER_WRONG_POSITION = "등록된 사물함 위치가 아닙니다.";
-	public static final String LOCKER_FIRST_CREATED = "사물함 최초 생성";
-	public static final String LOCKER_EXPIRED_ALL_RETURNED = "만료된 사물함 일괄 반납";
-	public static final String LOCKER_NOT_FOUND = "사물함을 찾을 수 없습니다.";
-	public static final String LOCKER_DUPLICATE_NUMBER = "중복된 사물함 번호입니다.";
-	public static final String LOCKER_ALREADY_REGISTERED = "이미 등록된 사물함 위치입니다.";
-	public static final String LOCKER_ALREADY_EXIST = "사물함 위치에 사물함이 존재합니다.";
-	public static final String LOCKER_EXPIRE_TIME_NOT_SET = "사물함 만료 시간이 설정되지 않았습니다.";
-	public static final String LOCKER_NEXT_EXPIRE_TIME_NOT_SET = "사물함 다음 만료 시간이 설정되지 않았습니다.";
-	public static final String LOCKER_UNUSED = "사용 중인 사물함이 아닙니다.";
-	public static final String LOCKER_USED = "사용 중인 사물함입니다.";
-	public static final String LOCKER_DELETED = "사물함 삭제";
-	public static final String LOCKER_ACTION_ERROR = "사물함 액션 실행 중 에러가 발생하였습니다.";
-	public static final String LOCKER_REGISTER_NOT_ALLOWED = "사물함 신청 기간이 아닙니다. 공지를 확인해주세요.";
-	public static final String LOCKER_EXTEND_NOT_ALLOWED = "사물함 연장 신청 기간이 아닙니다. 공지를 확인해주세요.";
-	public static final String LOCKER_INVALID_EXPIRE_DATE = "현재 만료일보다 이전 날짜로 설정할 수 없습니다.";
-	public static final String LOCKER_EXPIRE_DATE_NOT_FOUND = "만료일 정보를 찾을 수 없습니다.";
-	public static final String LOCKER_INVALID_EXTEND_PERIOD = "연장 시작일은 연장 종료일보다 이전 날짜여야 합니다.";
-	public static final String LOCKER_INVALID_NEXT_EXPIRE_DATE = "다음 만료일은 현재 만료일보다 이후 날짜여야 합니다.";
-	public static final String LOCKER_INVALID_REGISTER_PERIOD = "신청 시작일은 신청 종료일보다 이전 날짜여야 합니다.";
-	public static final String LOCKER_ALREADY_EXTENDED = "이미 연장된 사물함입니다.";
-
-	// User
-	public static final String API_NOT_ACCESSIBLE = "접근 권한이 없습니다.";
+	// USER
 	public static final String USER_NOT_FOUND = "해당 사용자를 찾을 수 없습니다.";
-	public static final String ADMISSION_EXCEPTION = "User id of the admission checked, but exception occurred";
-	public static final String NO_ASSIGNED_CIRCLE_FOR_LEADER = "해당 동아리장이 배정된 동아리가 없습니다.";
-	public static final String CIRCLE_ID_REQUIRED_FOR_LEADER_DELEGATION = "소모임장을 위임할 소모임 입력이 필요합니다.";
-	public static final String EMAIL_ALREADY_EXIST = "이미 존재하는 이메일입니다.";
-	public static final String EMAIL_INVALID = "잘못된 이메일입니다.";
-	public static final String USER_ALREADY_APPLY = "이미 신청한 사용자 입니다.";
-	public static final String USER_ALREADY_REGISTERD = "이미 등록된 사용자입니다.";
-	public static final String NO_APPLICATION = "신청서를 작성하지 않았습니다.";
-	public static final String CONCURRENT_JOB_IMPOSSIBLE = "겸직이 불가합니다.";
-	public static final String NICKNAME_ALREADY_EXIST = "이미 존재하는 닉네임입니다.";
-	public static final String USER_ADMISSION_MUST_HAVE_IMAGE = "입학 증빙 사진은 필수 입니다.";
-	public static final String STUDENT_ID_ALREADY_EXIST = "이미 존재하는 학번입니다.";
-	public static final String PHONE_NUMBER_ALREADY_EXIST = "이미 존재하는 전화번호입니다.";
-	public static final String INVALID_USER_APPLICATION_USER_STATE = "사용자 인증을 할 수 없는 상태의 사용자입니다(AWAIT / REJECT 상태만 인증 가능합니다).";
-	public static final String GRANT_ROLE_NOT_ALLOWED = "권한을 부여할 수 없습니다.";
-	public static final String DELEGATE_ROLE_NOT_ALLOWED = "권한을 위임할 수 없습니다.";
 	public static final String USER_DROPPED_CONTACT_EMAIL = "추방된 계정입니다. 재가입 문의는 caucsedongne@gmail.com으로 연락해주세요";
 	public static final String USER_INACTIVE_CAN_REJOIN = "탈퇴한 계정입니다. 계정 복구를 진행해주세요";
-	public static final String USER_RECOVER_INVALID_STATE = "복구할 수 없는 계정 상태입니다.";
-	public static final String USER_DELETED = "삭제된 계정입니다. 회원가입 페이지에서 새로운 정보로 가입해주세요.";
-	public static final String PRIVACY_POLICY_REQUIRED = "개인정보 수집 동의가 필요합니다.";
 	public static final String DEPARTMENT_EXPLICITLY_REQUIRED = "2021년 이후 입학생은 학과/학부를 반드시 선택해야 합니다.";
 	public static final String INVALID_ADMISSION_YEAR = "해당 입학년도에 맞는 학과를 찾을 수 없습니다.";
-
-	// Flag
-	public static final String FLAG_UPDATE_FAILED = "플래그 업데이트에 실패했습니다.";
-	public static final String FLAG_ALREADY_EXIST = "이미 존재하는 플래그 입니다.";
-
-	// UserAcademicRecord
-	public static final String USER_ACADEMIC_RECORD_APPLICATION_NOT_FOUND = "해당 사용자의 학적 변경 신청을 찾을 수 없습니다.";
-	public static final String USER_ACADEMIC_RECORD_APPLICATION_AND_USER_NOT_MATCH = "해당 사용자의 학적 변경 신청이 아닙니다.";
-	public static final String INVALID_ACADEMIC_RECORD_REQUEST_STATUS = "유효하지 않은 학적 인증 변경 목표 상태입니다. (ACCEPT, REJECT 로만 변경이 가능합니다.)";
-
-	public static final String ADMIN_UPDATE_ACADEMIC_RECORD_MESSAGE = "관리자 업데이트";
-
-	// UserAcademicRecordApplication
-	public static final String INVALID_TARGET_COMPLETED_SEMESTER = "유효하지 않은 목표 학기입니다.";
-	public static final String INVALID_TARGET_ACADEMIC_STATUS = "유효하지 않은 목표 학적 상태입니다.";
-	public static final String FILE_UPLOAD_NOT_ALLOWED = "파일 업로드가 허용되지 않습니다.";
-	public static final String FILE_UPLOAD_REQUIRED = "파일 업로드가 필요합니다.";
-	public static final String USER_ACADEMIC_RECORD_APPLICATION_DUPLICATED = "대기 중인 학적 인증 신청이 두 개 이상 존재합니다.";
-	public static final String TARGET_CURRENT_COMPLETED_SEMESTER_NOT_EXIST = "목표 현재 학기가 필요합니다.";
-	public static final String GRADUATION_INFORMATION_NOT_EXIST = "졸업 정보가 필요합니다.";
-	public static final String USER_NOTE_NOW_ALLOWED = "사용자가 노트를 작성할 수 없습니다.";
 
 	// UuidFile
 	public static final String FILE_NOT_FOUND = "파일을 찾을 수 없습니다.";
 	public static final String FILE_IS_NULL = "파일이 비어있습니다.";
-	public static final String IMAGE_MUST_NOT_NULL = "이미지는 필수입니다.";
-	public static final String INVALID_FILE_PATH = "유효하지 않은 파일 경로입니다.";
 	public static final String FILE_SIZE_EXCEEDED = "파일 크기가 초과되었습니다.";
 	public static final String NUMBER_OF_FILES_EXCEEDED = "파일 개수가 초과되었습니다.";
 	public static final String FILE_NAME_IS_NULL = "파일 이름이 비어있습니다.";
 	public static final String FILE_EXTENSION_IS_NULL = "파일 확장자가 비어있습니다.";
 	public static final String INVALID_FILE_EXTENSION = "유효하지 않은 파일 확장자입니다.";
 
-	// Semester
-	public static final String PRIOR_SEMESTER_NOT_FOUND = "이전 학기를 찾을 수 없습니다.";
-	public static final String ACTIVE_SEMESTER_IS_DUPLICATED = "활성화된 학기가 중복되어 있습니다.";
-	public static final String CURRENT_SEMESTER_DOES_NOT_EXIST = "현재 학기가 존재하지 않습니다. 현재 학기를 등록해주세요";
-
-	// UserCouncilFee
-	public static final String INVALID_USER_COUNCIL_FEE_INFO = "유효하지 않은 학생회비 납부자 정보입니다.";
-	public static final String USER_COUNCIL_FEE_NOT_FOUND = "해당 학생회비 납부자 정보를 찾을 수 없습니다.";
-	public static final String USER_ALREADY_EXISTS = "해당 사용자는 이미 동문네트워크 서비스에 가입했습니다.";
-	public static final String REFUND_DATE_IS_NULL = "환불 날짜가 비어있습니다.";
-	public static final String USER_COUNCIL_FEE_INFO_ALREADY_EXISTS = "이미 등록된 학생회비 납부자 정보입니다.";
-
-	// CouncilFeeFakeUser
-	public static final String INVALID_COUNCIL_FEE_FAKE_USER_INFO = "유효하지 않은 가짜 사용자 정보입니다.";
-
-	// Ceremony
-	public static final String CEREMONY_NOT_FOUND = "존재하지 않는 경조사입니다.";
-	public static final String CEREMONY_NOTIFICATION_SETTING_NOT_FOUND = "유저의 경조사 알람 설정이 되어있지 않습니다.";
-	public static final String CEREMONY_INVALID_CONTEXT_VALUE = "유효하지 않은 context 값입니다. 사용 가능한 값: general, my, admin";
-	public static final String CEREMONY_TARGET_ADMISSION_YEARS_REQUIRED = "전체 알림 전송이 false인 경우, 대상 학번은 필수 입력 값입니다.";
-	public static final String CEREMONY_INVALID_ADMISSION_YEAR_FORMAT = "학번은 숫자 2자리로 입력해야 합니다. (ex. 72, 05, 21)";
-	public static final String CEREMONY_ACCESS_MY_ONLY = "본인의 경조사만 상세 조회할 수 있습니다.";
-	public static final String CEREMONY_ACCESS_ADMIN_ONLY = "관리자만 접근할 수 있는 경조사입니다.";
-	public static final String CEREMONY_NOTIFICATION_SUBSCRIPTION_REQUIRED = "setAll이 false인 경우, 구독할 입학년도를 입력해야 합니다.";
-
-	// Notification
-	public static final String NOTIFICATION_NOT_FOUND = "존재하지 않는 알람입니다.";
-	public static final String NOTIFICATION_LOG_NOT_FOUND = "존재하지 않는 알람 로그입니다.";
-
-	// Vote
-	public static final String VOTE_OPTION_NOT_FOUND = "존재하지 않는 투표 옵션입니다.";
-	public static final String VOTE_OPTION_NOT_PROVIDED = "투표 옵션이 제공되지 않았습니다.";
-	public static final String VOTE_NOT_MULTIPLE = "이 투표는 여러 항목을 선택할 수 없습니다.";
-	public static final String VOTE_ALREADY_DONE = "해당 투표에 이미 참여한 이력이 있습니다.";
-	public static final String VOTE_ALREADY_END = "이미 종료된 투표입니다.";
-	public static final String VOTE_NOT_END = "종료되지 않은 투표입니다.";
-
-	public static final String VOTE_NOT_FOUND = "투표가 존재하지 않습니다.";
-	public static final String VOTE_END_NOT_ACCESSIBLE = "투표 종료 권한이 존재하지 않습니다.";
-	public static final String VOTE_RESTART_NOT_ACCESSIBLE = "투표 재시작 권한이 존재하지 않습니다.";
-	public static final String VOTE_START_NOT_ACCESSIBLE = "투표 시작 권한이 존재하지 않습니다.";
-
-	// UserInfo
-	public static final String USER_INFO_NOT_ACCESSIBLE = "해당 사용자의 상세정보에 접근할 수 없습니다.";
-	public static final String USER_CAREER_NOT_FOUND = "해당 커리어 정보를 찾을 수 없습니다.";
-	public static final String INVALID_CAREER_DATE = "커리어 날짜가 유효하지 않습니다.";
-	public static final String INVALID_SOCIAL_LINK = "소셜 링크는 최대 10개까지 지정 가능합니다.";
-
-	// 500
-	public static final String INTERNAL_SERVER_ERROR = "Internal Server Error";
 	public static final String FILE_UPLOAD_FAIL = "파일 업로드에 실패했습니다.";
 	public static final String FILE_DELETE_FAIL = "파일 삭제에 실패했습니다.";
-	public static final String FILE_READ_FAIL = "파일을 읽을 수 없습니다.";
-	public static final String FAIL_TO_GENERATE_EXCEL_FILE = "엑셀 파일 생성에 실패했습니다.";
 	public static final String BATCH_FAIL = "[배치 실행에 실패했습니다.]";
 
 	public static final String FAIL_TO_CRAWL_CAU_SW_NOTICE_SITE = "소프트웨어학부 공지사항 크롤링 실패";
-
-	public static final String USER_CURRENT_COMPLETE_SEMESTER_DOES_NOT_EXIST = "사용자의 현재 등록 완료 학기 정보가 존재하지 않습니다.";
-
-	// Report
-	public static final String REPORT_SUCCESS = "신고가 접수되었습니다. 검토까지는 최대 24시간이 소요됩니다.";
-	public static final String REPORT_ALREADY_REPORTED = "이미 신고한 콘텐츠입니다.";
-	public static final String REPORT_CANNOT_SELF = "자신이 작성한 콘텐츠는 신고할 수 없습니다.";
-	public static final String CHILD_COMMENT_NOT_FOUND = "대댓글을 찾을 수 없습니다.";
-
-	// block
-	public static final String BLOCK_SUCCESS = "차단에 성공했습니다.";
-	public static final String BLOCK_ALREADY_EXIST = "이미 차단한 유저입니다.";
-	public static final String BLOCKED_USERS_CONTENT = "차단한 유저의 컨텐츠입니다.";
 
 	//Hash
 	public static final String HASH_ALGORITHM_NOT_FOUND = "SHA-256 알고리즘을 찾을 수 없습니다";


### PR DESCRIPTION
### 🚩 관련사항
#1396

### 📢 전달사항
사물함 연장/반납 흐름에서 사용자에게 필요한 상태와 알림을 보강했습니다.

사물함 엔티티에 `isExtended` 플래그를 추가하고, 내 사물함 조회 응답에도 연장 여부를 내려주도록 변경했습니다. 사물함 신청/반납/관리자 회수 시에는 연장 상태를 초기화하고, 연장 성공 시에는 `isExtended=true`로 기록합니다. 기존에는 만료일 비교만으로 중복 연장을 판단했지만, 이제 저장된 연장 여부까지 함께 확인해 같은 사물함의 중복 연장을 더 명확하게 차단합니다.

사물함 반납 가능 기간은 기존 신청 기간뿐 아니라 연장 기간에도 허용되도록 조정했습니다. 또한 관리자 만료 사물함 일괄 반납 시 `LockerExpiredEvent`를 발행하고, 커밋 이후 별도 트랜잭션에서 사물함 반납 완료 알림 로그와 푸시 알림을 생성하도록 추가했습니다. 이를 위해 `NoticeType.LOCKER`와 `tb_notification.notice_type` enum 값도 함께 확장했습니다.

FCM 전송은 `dev`, `prod` profile에서만 실제 Firebase 전송을 수행하도록 제한했습니다. local 환경에서는 직접 전송을 생략하고, 푸시 전송 요청/생략/성공/실패 로그를 보강해 개발 중 실수 전송을 막으면서 운영 이슈 추적성을 높였습니다.

리뷰 시에는 다음 부분을 중점적으로 확인 부탁드립니다.
- `tb_locker.is_extended` 추가 마이그레이션과 `tb_notification.notice_type` enum 확장
- 사물함 연장 여부 초기화/설정 시점
- 만료 사물함 일괄 반납 후 알림 발행이 커밋 이후 동작하는 흐름
- local profile에서 FCM 직접 전송이 차단되는 조건

#### 구조 다이어그램

```mermaid
flowchart LR
    LockerAdminService["LockerAdminService.returnAllExpiredLockers"]
    LockerWriter["LockerWriter.releaseLocker"]
    Event["LockerExpiredEvent"]
    Listener["LockerExpiredEventListener"]
    NotificationPushSender["NotificationPushSender"]
    NotificationWriter["NotificationWriter.saveLog"]

    LockerAdminService --> LockerWriter
    LockerAdminService --> Event
    Event --> Listener
    Listener --> NotificationPushSender
    Listener --> NotificationWriter
```

### 📸 스크린샷
N/A

### 📃 진행사항
- [x] 사물함 반납을 연장 기간에도 가능하도록 변경
- [x] 사물함 만료 일괄 반납 시 반납 완료 알림 발행 추가
- [x] 사물함 알림 타입 `LOCKER` 추가
- [x] 사용하지 않는 사물함 관련 코드 및 `MessageUtil` 상수 정리
- [x] 사물함 위치 조회 에러코드 오류 수정
- [x] 내 사물함 조회 응답에 연장 여부 추가
- [x] 사물함 중복 연장 여부 검증 추가
- [x] local profile에서 FCM 직접 전송이 수행되지 않도록 변경
- [x] 사물함 만료 이벤트 발행 및 Firebase 전송 조건 테스트 보강
- [x] Spotless 포맷 반영

### ⚙️ 기타사항

개발기간: 2026-06-30 ~ 2026-06-30

DB 마이그레이션이 포함되어 있어 `db-change` 라벨이 필요합니다.
