### PR TITLE
fix: 동문수첩 경력/프로젝트 정렬 미적용 버그 수정

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/mapper/UserInfoMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/mapper/UserInfoMapper.java
@@ -35,8 +35,8 @@ public interface UserInfoMapper extends UuidFileToUrlDtoMapper {
 	@Mapping(target = "email", source = "userInfo.user.email")
 	@Mapping(target = "socialLinks", source = "userInfo.socialLinks", qualifiedByName = "sortSocialLinksByDomain")
 	@Mapping(target = "userTechStack", source = "userInfo.userTechStack", qualifiedByName = "sortStringsAsc")
-	@Mapping(target = "userCareer", source = "userInfo.userCareer")
-	@Mapping(target = "userProject", source = "userInfo.userProject")
+	@Mapping(target = "userCareer", source = "userInfo.userCareer", qualifiedByName = "sortUserCareer")
+	@Mapping(target = "userProject", source = "userInfo.userProject", qualifiedByName = "sortUserProject")
 	@Mapping(target = "userInterestTech", source = "userInfo.userInterestTech", qualifiedByName = "sortStringsAsc")
 	@Mapping(target = "userInterestDomain", source = "userInfo.userInterestDomain", qualifiedByName = "sortStringsAsc")
 	UserInfoDetailResult toDetailResult(UserInfo userInfo, UserProfileImage userProfileImage);
@@ -53,8 +53,8 @@ public interface UserInfoMapper extends UuidFileToUrlDtoMapper {
 	@Mapping(target = "isPhoneNumberVisible", source = "userInfo.phoneNumberVisible")
 	@Mapping(target = "socialLinks", source = "userInfo.socialLinks", qualifiedByName = "sortSocialLinksByDomain")
 	@Mapping(target = "userTechStack", source = "userInfo.userTechStack", qualifiedByName = "sortStringsAsc")
-	@Mapping(target = "userCareer", source = "userInfo.userCareer")
-	@Mapping(target = "userProject", source = "userInfo.userProject")
+	@Mapping(target = "userCareer", source = "userInfo.userCareer", qualifiedByName = "sortUserCareer")
+	@Mapping(target = "userProject", source = "userInfo.userProject", qualifiedByName = "sortUserProject")
 	@Mapping(target = "userInterestTech", source = "userInfo.userInterestTech", qualifiedByName = "sortStringsAsc")
 	@Mapping(target = "userInterestDomain", source = "userInfo.userInterestDomain", qualifiedByName = "sortStringsAsc")
 	UserInfoDetailResult toMyDetailResult(UserInfo userInfo, UserProfileImage userProfileImage);


### PR DESCRIPTION
### 🚩 관련사항
close #1398

### 📢 전달사항
동문 수첩 상세 조회 시 경력사항(`userCareer`)과 프로젝트(`userProject`)가 정렬 기준대로 내려오지 않고 DB 저장 순서 그대로 응답되는 버그를 수정했습니다.

`UserInfoMapper`에 LinkedIn 방식의 정렬 메서드(`sortUserCareer`, `sortUserProject`)가 구현되어 있었으나, `@Mapping` 어노테이션에 `qualifiedByName` 속성이 누락되어 MapStruct가 해당 메서드를 호출하지 않고 있었습니다. `toDetailResult`, `toMyDetailResult` 두 매핑 메서드 모두 동일하게 누락되어 있었으며, 이번 수정에서 양쪽 모두 `qualifiedByName`을 추가했습니다.

정렬 기준은 아래와 같습니다.
1. 현재 진행 중인 항목 (종료년월 없음) → 최상단
2. 종료년월 최신순
3. 시작년월 최신순

`UserInfoMapper.java`의 `@Mapping` 어노테이션 4줄만 변경된 최소 수정입니다.

### 📸 스크린샷
N/A

### 📃 진행사항
- [x] `toDetailResult` 매핑에 `qualifiedByName = "sortUserCareer"` / `"sortUserProject"` 추가
- [x] `toMyDetailResult` 매핑에 `qualifiedByName = "sortUserCareer"` / `"sortUserProject"` 추가

### ⚙️ 기타사항

개발기간: 2026-07-02 ~ 2026-07-02