### PR TITLE
feat: PR 리뷰 자동화 워크플로우 추가

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,15 @@
+addReviewers: true
+addAssignees: false
+reviewers:
+  - kyh0726
+  - gomx3
+  - Head-ddy
+  - MlNTYS
+  - lee0jae330
+  - clue31415
+  - fresh-woo
+  - plamingo509
+numberOfReviewers: 2
+useReviewGroups: false
+skipKeywords:
+  - hotfix

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,15 +1,16 @@
 addReviewers: true
 addAssignees: false
 reviewers:
-  - kyh0726
-  - gomx3
-  - Head-ddy
-  - MlNTYS
-  - lee0jae330
-  - clue31415
-  - fresh-woo
-  - plamingo509
-numberOfReviewers: 2
+  - riadan710
+  - bingle625
+  - kyeoungwoon
+  - glucosei
+  - KEEKE132
+  - chaeyeonlee898
+  - wldy4627
+  - yvngyeong
+  - sopp1313
+numberOfReviewers: 1
 useReviewGroups: false
 skipKeywords:
   - hotfix

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,4 +1,4 @@
-name: PR 리뷰어 2명 랜덤 지정
+name: PR 리뷰어 1명 랜덤 지정
 
 on:
   pull_request:

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,14 @@
+name: PR 리뷰어 2명 랜덤 지정
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR Reviewer Random Assignment
+        uses: kentaro-m/auto-assign-action@v2.0.0
+        with:
+          configuration-path: .github/auto_assign.yml

--- a/.github/workflows/pr-review-notification.yml
+++ b/.github/workflows/pr-review-notification.yml
@@ -15,8 +15,8 @@ jobs:
     steps:
       - name: Send Discord Notification
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_BACKEND_GIT_WEBHOOK_URL }}
-          DISCORD_ROLE_ID: ${{ vars.DISCORD_ROLE_ID }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_BACKEND_PR_WEBHOOK_URL }}
+          DISCORD_BACKEND_ROLE_ID: ${{ vars.DISCORD_BACKEND_ROLE_ID }}
           REVIEW_STATE: ${{ github.event.review.state }}
           REVIEW_BODY: ${{ github.event.review.body }}
           REVIEW_AUTHOR: ${{ github.event.review.user.login }}
@@ -30,12 +30,12 @@ jobs:
             "approved")
               REVIEW_TYPE="✅ 승인"
               EMBED_COLOR=3066993
-              MESSAGE="<@&${DISCORD_ROLE_ID}> **${PR_AUTHOR}**님의 PR이 승인되었습니다!"
+              MESSAGE="<@&${DISCORD_BACKEND_ROLE_ID}> **${PR_AUTHOR}**님의 PR이 승인되었습니다!"
               ;;
             "changes_requested")
               REVIEW_TYPE="🔄 변경 요청"
               EMBED_COLOR=15158332
-              MESSAGE="<@&${DISCORD_ROLE_ID}> **${PR_AUTHOR}**님에게 변경 요청이 있습니다!"
+              MESSAGE="<@&${DISCORD_BACKEND_ROLE_ID}> **${PR_AUTHOR}**님에게 변경 요청이 있습니다!"
               ;;
           esac
 

--- a/.github/workflows/pr-review-notification.yml
+++ b/.github/workflows/pr-review-notification.yml
@@ -1,0 +1,81 @@
+name: 디스코드 PR 리뷰 승인 및 변경 요청에 대한 알림
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  notify:
+    # 봇이 작성한 리뷰와 일반 코멘트 리뷰는 알림 제외
+    if: >-
+      github.event.review.user.type != 'Bot' &&
+      (github.event.review.state == 'approved' ||
+      github.event.review.state == 'changes_requested')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Discord Notification
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_BACKEND_GIT_WEBHOOK_URL }}
+          DISCORD_ROLE_ID: ${{ vars.DISCORD_ROLE_ID }}
+          REVIEW_STATE: ${{ github.event.review.state }}
+          REVIEW_BODY: ${{ github.event.review.body }}
+          REVIEW_AUTHOR: ${{ github.event.review.user.login }}
+          REVIEW_URL: ${{ github.event.review.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          # 리뷰 상태에 따른 메시지 및 색상 설정
+          case "$REVIEW_STATE" in
+            "approved")
+              REVIEW_TYPE="✅ 승인"
+              EMBED_COLOR=3066993
+              MESSAGE="<@&${DISCORD_ROLE_ID}> **${PR_AUTHOR}**님의 PR이 승인되었습니다!"
+              ;;
+            "changes_requested")
+              REVIEW_TYPE="🔄 변경 요청"
+              EMBED_COLOR=15158332
+              MESSAGE="<@&${DISCORD_ROLE_ID}> **${PR_AUTHOR}**님에게 변경 요청이 있습니다!"
+              ;;
+          esac
+
+          # 리뷰 내용 처리 (비어있을 수 있음)
+          if [ -n "$REVIEW_BODY" ]; then
+            REVIEW_PREVIEW=$(echo "$REVIEW_BODY" | head -c 500)
+            if [ ${#REVIEW_BODY} -gt 500 ]; then
+              REVIEW_PREVIEW="${REVIEW_PREVIEW}..."
+            fi
+            REVIEW_PREVIEW=$(echo "$REVIEW_PREVIEW" | jq -Rs .)
+            DESCRIPTION="**리뷰어**: ${REVIEW_AUTHOR}\n**상태**: ${REVIEW_TYPE}\n\n> ${REVIEW_PREVIEW}"
+          else
+            DESCRIPTION="**리뷰어**: ${REVIEW_AUTHOR}\n**상태**: ${REVIEW_TYPE}\n\n_코멘트 없음_"
+          fi
+
+          # JSON escape
+          PR_TITLE_ESCAPED=$(echo "$PR_TITLE" | jq -Rs .)
+          DESCRIPTION_ESCAPED=$(echo "$DESCRIPTION" | jq -Rs .)
+
+          # Discord webhook 전송
+          curl -X POST -H "Content-Type: application/json" -d '{
+            "content": "'"$MESSAGE"'",
+            "embeds": [
+              {
+                "title": '"$PR_TITLE_ESCAPED"',
+                "url": "'"$PR_URL"'",
+                "description": '"$DESCRIPTION_ESCAPED"',
+                "color": '"$EMBED_COLOR"',
+                "fields": [
+                  {
+                    "name": "PR 작성자",
+                    "value": "'"$PR_AUTHOR"'",
+                    "inline": true
+                  },
+                  {
+                    "name": "링크",
+                    "value": "[리뷰 바로가기]('"$REVIEW_URL"')",
+                    "inline": true
+                  }
+                ]
+              }
+            ]
+          }' "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
### 🚩 관련사항

- Close #1411

### 📢 전달사항

PR 생성 시 리뷰어가 수동으로 지정되기를 기다리지 않고 바로 리뷰가 배분되도록 자동 지정 워크플로우를 추가했습니다.

`CAUSW-frontend-v3`에서 사용 중인 설정을 기준으로 `kentaro-m/auto-assign-action@v2.0.0`을 적용했습니다. PR이 새로 열리거나 Draft에서 리뷰 가능 상태로 전환될 때 백엔드 리뷰어 후보 9명 중 1명을 무작위 지정하며, 제목 또는 본문에 `hotfix` 키워드가 포함된 PR은 자동 지정을 건너뜁니다.

또한 PR 리뷰가 제출되면 승인 또는 변경 요청 내용을 Discord로 전달하는 워크플로우를 추가했습니다. 백엔드 저장소에 등록된 `DISCORD_BACKEND_GIT_WEBHOOK_URL` secret을 사용하며, 멘션할 역할 ID는 하드코딩하지 않고 repository variable `DISCORD_ROLE_ID`를 참조합니다.

리뷰 시에는 `.github/auto_assign.yml`의 리뷰어 후보가 현재 백엔드 리뷰 참여자와 일치하는지, `opened`와 `ready_for_review` 두 이벤트가 원하는 자동화 범위인지 확인 부탁드립니다.

### 📸 스크린샷
N/A

### 📃 진행사항

- [x] PR 리뷰어 후보 및 랜덤 지정 인원 설정
- [x] PR 생성·리뷰 준비 이벤트 기반 자동 지정 워크플로우 추가
- [x] `hotfix` PR 자동 지정 제외
- [x] PR 리뷰 승인·변경 요청 Discord 알림 워크플로우 추가
- [x] Discord 역할 ID를 repository variable로 분리
- [x] YAML 파싱 및 Git diff 공백 검사

### ⚙️ 기타사항

- 애플리케이션 코드와 DB 스키마 변경은 없습니다.
- PR 머지 전 repository variable에 `DISCORD_ROLE_ID`를 등록해야 합니다.
- 로컬에 `actionlint`가 설치되어 있지 않아 YAML 파싱과 `git diff --check`로 정적 검증했습니다.

개발기간: 2026-07-23 ~ 2026-07-23
