### PR TITLE
feat: 경조사 신청 결과 알림 발송

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/enums/CeremonyContext.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/enums/CeremonyContext.java
@@ -7,8 +7,7 @@ import lombok.Getter;
 @Getter
 public enum CeremonyContext {
 	GENERAL("general", "전체 알림 페이지에서 접근"),
-	MY("my", "나의 경조사 페이지에서 접근"),
-	ADMIN("admin", "경조사 관리 페이지에서 접근");
+	MY("my", "나의 경조사 페이지에서 접근");
 
 	private final String value;
 	private final String description;

--- a/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/service/CeremonyAdminService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/service/CeremonyAdminService.java
@@ -14,7 +14,9 @@ import net.causw.app.main.domain.community.ceremony.service.implementation.Cerem
 import net.causw.app.main.domain.community.ceremony.service.implementation.CeremonyWriter;
 import net.causw.app.main.domain.community.ceremony.service.mapper.CeremonyMapper;
 import net.causw.app.main.domain.community.ceremony.util.CeremonyValidator;
+import net.causw.app.main.domain.notification.notification.event.CeremonyApprovedEvent;
 import net.causw.app.main.domain.notification.notification.event.CeremonyNotificationEvent;
+import net.causw.app.main.domain.notification.notification.event.CeremonyRejectedEvent;
 import net.causw.app.main.shared.exception.errorcode.CeremonyErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -54,9 +56,10 @@ public class CeremonyAdminService {
 		ceremonyValidator.validateAwaiting(ceremony);
 		ceremonyWriter.approve(ceremony);
 
-		// 승인 시 알림 발송
+		// 대상 학번 유저들에게 경조사 공지 알림
 		eventPublisher.publishEvent(new CeremonyNotificationEvent(ceremonyId));
-
+		// 신청자에게 승인 결과 알림
+		eventPublisher.publishEvent(new CeremonyApprovedEvent(ceremonyId));
 	}
 
 	@Transactional
@@ -66,5 +69,8 @@ public class CeremonyAdminService {
 
 		ceremonyValidator.validateAwaiting(ceremony);
 		ceremonyWriter.reject(ceremony, rejectReason);
+
+		// 신청자에게 거절 결과 알림
+		eventPublisher.publishEvent(new CeremonyRejectedEvent(ceremonyId, rejectReason));
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/event/CeremonyApprovedEvent.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/event/CeremonyApprovedEvent.java
@@ -1,0 +1,4 @@
+package net.causw.app.main.domain.notification.notification.event;
+
+public record CeremonyApprovedEvent(String ceremonyId) {
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/event/CeremonyRejectedEvent.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/event/CeremonyRejectedEvent.java
@@ -1,0 +1,4 @@
+package net.causw.app.main.domain.notification.notification.event;
+
+public record CeremonyRejectedEvent(String ceremonyId, String rejectReason) {
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/listener/CeremonyNotificationListener.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/listener/CeremonyNotificationListener.java
@@ -84,7 +84,7 @@ public class CeremonyNotificationListener {
 	 * 관리자가 경조사를 승인하면 신청자에게 승인 결과 알림을 발송합니다.
 	 * <ul>
 	 *   <li>대상: 경조사 신청자 본인</li>
-	 *   <li>필터: 서비스 공지 알림 설정 ON ({@link UserNotificationSettingKey#SERVICE_NOTICE_ENABLED})</li>
+	 *   <li>필터: 경조사 알림 설정 ON ({@link UserNotificationSettingKey#CEREMONY_NOTIFICATION_ENABLED})</li>
 	 * </ul>
 	 *
 	 * @param event 경조사 승인 이벤트
@@ -98,7 +98,7 @@ public class CeremonyNotificationListener {
 		User applicant = ceremony.getUser();
 
 		UserNotificationSettingMap settingMap = notificationSettingReader.findSettingMap(applicant.getId());
-		if (!settingMap.get(UserNotificationSettingKey.SERVICE_NOTICE_ENABLED)) {
+		if (!settingMap.get(UserNotificationSettingKey.CEREMONY_NOTIFICATION_ENABLED)) {
 			return;
 		}
 
@@ -107,7 +107,7 @@ public class CeremonyNotificationListener {
 		String serviceTitle = "경조사 신청이 승인되었습니다.";
 
 		Notification notification = notificationWriter.save(
-			Notification.of(applicant, serviceTitle, body, NoticeType.SYSTEM, ceremony.getId(), null));
+			Notification.of(applicant, serviceTitle, body, NoticeType.CEREMONY_V2, ceremony.getId(), null));
 
 		notificationPushSender.sendToUser(applicant, pushTitle, body);
 		notificationWriter.saveLog(applicant, notification);
@@ -119,7 +119,7 @@ public class CeremonyNotificationListener {
 	 * 관리자가 경조사를 거절하면 신청자에게 거절 사유와 함께 알림을 발송합니다.
 	 * <ul>
 	 *   <li>대상: 경조사 신청자 본인</li>
-	 *   <li>필터: 서비스 공지 알림 설정 ON ({@link UserNotificationSettingKey#SERVICE_NOTICE_ENABLED})</li>
+	 *   <li>필터: 경조사 알림 설정 ON ({@link UserNotificationSettingKey#CEREMONY_NOTIFICATION_ENABLED})</li>
 	 * </ul>
 	 *
 	 * @param event 경조사 거절 이벤트 (거절 사유 포함)
@@ -133,7 +133,7 @@ public class CeremonyNotificationListener {
 		User applicant = ceremony.getUser();
 
 		UserNotificationSettingMap settingMap = notificationSettingReader.findSettingMap(applicant.getId());
-		if (!settingMap.get(UserNotificationSettingKey.SERVICE_NOTICE_ENABLED)) {
+		if (!settingMap.get(UserNotificationSettingKey.CEREMONY_NOTIFICATION_ENABLED)) {
 			return;
 		}
 
@@ -142,7 +142,7 @@ public class CeremonyNotificationListener {
 		String serviceTitle = String.format("경조사 신청이 거절되었습니다. 사유: %s", event.rejectReason());
 
 		Notification notification = notificationWriter.save(
-			Notification.of(applicant, serviceTitle, body, NoticeType.SYSTEM, ceremony.getId(), null));
+			Notification.of(applicant, serviceTitle, body, NoticeType.CEREMONY_V2, ceremony.getId(), null));
 
 		notificationPushSender.sendToUser(applicant, pushTitle, body);
 		notificationWriter.saveLog(applicant, notification);

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/listener/CeremonyNotificationListener.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/service/listener/CeremonyNotificationListener.java
@@ -19,7 +19,10 @@ import net.causw.app.main.domain.community.ceremony.service.implementation.Cerem
 import net.causw.app.main.domain.notification.notification.entity.Notification;
 import net.causw.app.main.domain.notification.notification.enums.NoticeType;
 import net.causw.app.main.domain.notification.notification.enums.UserNotificationSettingKey;
+import net.causw.app.main.domain.notification.notification.event.CeremonyApprovedEvent;
 import net.causw.app.main.domain.notification.notification.event.CeremonyNotificationEvent;
+import net.causw.app.main.domain.notification.notification.event.CeremonyRejectedEvent;
+import net.causw.app.main.domain.notification.notification.service.dto.UserNotificationSettingMap;
 import net.causw.app.main.domain.notification.notification.service.implementation.NotificationPushSender;
 import net.causw.app.main.domain.notification.notification.service.implementation.NotificationSettingReader;
 import net.causw.app.main.domain.notification.notification.service.implementation.NotificationWriter;
@@ -73,6 +76,76 @@ public class CeremonyNotificationListener {
 
 		notificationPushSender.sendToUsers(targets, pushTitle, pushBody);
 		notificationWriter.saveLogs(targets, notification);
+	}
+
+	/**
+	 * 경조사 승인 알림 이벤트 핸들러.
+	 * <p>
+	 * 관리자가 경조사를 승인하면 신청자에게 승인 결과 알림을 발송합니다.
+	 * <ul>
+	 *   <li>대상: 경조사 신청자 본인</li>
+	 *   <li>필터: 서비스 공지 알림 설정 ON ({@link UserNotificationSettingKey#SERVICE_NOTICE_ENABLED})</li>
+	 * </ul>
+	 *
+	 * @param event 경조사 승인 이벤트
+	 */
+	@Async("asyncExecutor")
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void handleApproved(CeremonyApprovedEvent event) {
+		Ceremony ceremony = ceremonyReader.findById(event.ceremonyId())
+			.orElseThrow(CeremonyErrorCode.CEREMONY_NOT_FOUND::toBaseException);
+		User applicant = ceremony.getUser();
+
+		UserNotificationSettingMap settingMap = notificationSettingReader.findSettingMap(applicant.getId());
+		if (!settingMap.get(UserNotificationSettingKey.SERVICE_NOTICE_ENABLED)) {
+			return;
+		}
+
+		String pushTitle = "경조사 신청 승인";
+		String body = "경조사 신청이 승인되었습니다.";
+		String serviceTitle = "경조사 신청이 승인되었습니다.";
+
+		Notification notification = notificationWriter.save(
+			Notification.of(applicant, serviceTitle, body, NoticeType.SYSTEM, ceremony.getId(), null));
+
+		notificationPushSender.sendToUser(applicant, pushTitle, body);
+		notificationWriter.saveLog(applicant, notification);
+	}
+
+	/**
+	 * 경조사 거절 알림 이벤트 핸들러.
+	 * <p>
+	 * 관리자가 경조사를 거절하면 신청자에게 거절 사유와 함께 알림을 발송합니다.
+	 * <ul>
+	 *   <li>대상: 경조사 신청자 본인</li>
+	 *   <li>필터: 서비스 공지 알림 설정 ON ({@link UserNotificationSettingKey#SERVICE_NOTICE_ENABLED})</li>
+	 * </ul>
+	 *
+	 * @param event 경조사 거절 이벤트 (거절 사유 포함)
+	 */
+	@Async("asyncExecutor")
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void handleRejected(CeremonyRejectedEvent event) {
+		Ceremony ceremony = ceremonyReader.findById(event.ceremonyId())
+			.orElseThrow(CeremonyErrorCode.CEREMONY_NOT_FOUND::toBaseException);
+		User applicant = ceremony.getUser();
+
+		UserNotificationSettingMap settingMap = notificationSettingReader.findSettingMap(applicant.getId());
+		if (!settingMap.get(UserNotificationSettingKey.SERVICE_NOTICE_ENABLED)) {
+			return;
+		}
+
+		String pushTitle = "경조사 신청 거절";
+		String body = "경조사 신청이 거절되었습니다.";
+		String serviceTitle = String.format("경조사 신청이 거절되었습니다. 사유: %s", event.rejectReason());
+
+		Notification notification = notificationWriter.save(
+			Notification.of(applicant, serviceTitle, body, NoticeType.SYSTEM, ceremony.getId(), null));
+
+		notificationPushSender.sendToUser(applicant, pushTitle, body);
+		notificationWriter.saveLog(applicant, notification);
 	}
 
 	/**

--- a/app-main/src/test/java/net/causw/app/main/domain/community/ceremony/service/CeremonyAdminServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/community/ceremony/service/CeremonyAdminServiceTest.java
@@ -30,7 +30,9 @@ import net.causw.app.main.domain.community.ceremony.service.implementation.Cerem
 import net.causw.app.main.domain.community.ceremony.service.implementation.CeremonyWriter;
 import net.causw.app.main.domain.community.ceremony.service.mapper.CeremonyMapper;
 import net.causw.app.main.domain.community.ceremony.util.CeremonyValidator;
+import net.causw.app.main.domain.notification.notification.event.CeremonyApprovedEvent;
 import net.causw.app.main.domain.notification.notification.event.CeremonyNotificationEvent;
+import net.causw.app.main.domain.notification.notification.event.CeremonyRejectedEvent;
 import net.causw.app.main.shared.exception.BaseRunTimeV2Exception;
 import net.causw.app.main.shared.exception.errorcode.CeremonyErrorCode;
 
@@ -189,6 +191,7 @@ class CeremonyAdminServiceTest {
 			then(ceremonyWriter).should(times(1)).approve(ceremony);
 
 			verify(eventPublisher).publishEvent(any(CeremonyNotificationEvent.class));
+			verify(eventPublisher).publishEvent(any(CeremonyApprovedEvent.class));
 		}
 
 		@Test
@@ -243,6 +246,8 @@ class CeremonyAdminServiceTest {
 			// then
 			then(ceremonyValidator).should(times(1)).validateAwaiting(ceremony);
 			then(ceremonyWriter).should(times(1)).reject(ceremony, "요건에 부합하지 않습니다.");
+
+			verify(eventPublisher).publishEvent(any(CeremonyRejectedEvent.class));
 		}
 
 		@Test

--- a/app-main/src/test/java/net/causw/app/main/domain/notification/notification/service/listener/CeremonyNotificationListenerTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/notification/notification/service/listener/CeremonyNotificationListenerTest.java
@@ -2,10 +2,12 @@ package net.causw.app.main.domain.notification.notification.service.listener;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -21,6 +23,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Map;
+
 import net.causw.app.main.domain.community.ceremony.entity.Ceremony;
 import net.causw.app.main.domain.community.ceremony.enums.CeremonyCategory;
 import net.causw.app.main.domain.community.ceremony.enums.CeremonyType;
@@ -28,7 +32,10 @@ import net.causw.app.main.domain.community.ceremony.enums.RelationType;
 import net.causw.app.main.domain.community.ceremony.service.implementation.CeremonyReader;
 import net.causw.app.main.domain.notification.notification.entity.Notification;
 import net.causw.app.main.domain.notification.notification.enums.UserNotificationSettingKey;
+import net.causw.app.main.domain.notification.notification.event.CeremonyApprovedEvent;
 import net.causw.app.main.domain.notification.notification.event.CeremonyNotificationEvent;
+import net.causw.app.main.domain.notification.notification.event.CeremonyRejectedEvent;
+import net.causw.app.main.domain.notification.notification.service.dto.UserNotificationSettingMap;
 import net.causw.app.main.domain.notification.notification.service.implementation.NotificationPushSender;
 import net.causw.app.main.domain.notification.notification.service.implementation.NotificationSettingReader;
 import net.causw.app.main.domain.notification.notification.service.implementation.NotificationWriter;
@@ -152,6 +159,111 @@ class CeremonyNotificationListenerTest {
 		}
 	}
 
+	@Nested
+	@DisplayName("경조사 승인 결과 알림 (handleApproved)")
+	class HandleApprovedTest {
+
+		@Test
+		@DisplayName("성공: SERVICE_NOTICE_ENABLED ON이면 신청자에게 푸시 + 서비스 알림 발송")
+		void givenServiceNoticeOn_whenHandleApproved_thenSendToApplicant() {
+			// given
+			User applicant = mock(User.class);
+			given(applicant.getId()).willReturn("userId");
+
+			Ceremony ceremony = mock(Ceremony.class);
+			given(ceremony.getId()).willReturn("ceremonyId");
+			given(ceremony.getUser()).willReturn(applicant);
+
+			given(ceremonyReader.findById("ceremonyId")).willReturn(Optional.of(ceremony));
+			given(notificationSettingReader.findSettingMap("userId"))
+				.willReturn(serviceNoticeOn());
+			given(notificationWriter.save(any())).willReturn(mock(Notification.class));
+
+			// when
+			handler.handleApproved(new CeremonyApprovedEvent("ceremonyId"));
+
+			// then
+			verify(notificationPushSender).sendToUser(eq(applicant), eq("경조사 신청 승인"), any());
+			verify(notificationWriter).saveLog(eq(applicant), any());
+		}
+
+		@Test
+		@DisplayName("스킵: SERVICE_NOTICE_ENABLED OFF이면 알림 발송하지 않음")
+		void givenServiceNoticeOff_whenHandleApproved_thenSkip() {
+			// given
+			User applicant = mock(User.class);
+			given(applicant.getId()).willReturn("userId");
+
+			Ceremony ceremony = mock(Ceremony.class);
+			given(ceremony.getUser()).willReturn(applicant);
+
+			given(ceremonyReader.findById("ceremonyId")).willReturn(Optional.of(ceremony));
+			given(notificationSettingReader.findSettingMap("userId"))
+				.willReturn(serviceNoticeOff());
+
+			// when
+			handler.handleApproved(new CeremonyApprovedEvent("ceremonyId"));
+
+			// then
+			verify(notificationPushSender, never()).sendToUser(any(), any(), any());
+			verify(notificationWriter, never()).saveLog(any(), any());
+		}
+
+	}
+
+	@Nested
+	@DisplayName("경조사 거절 결과 알림 (handleRejected)")
+	class HandleRejectedTest {
+
+		@Test
+		@DisplayName("성공: SERVICE_NOTICE_ENABLED ON이면 신청자에게 푸시 발송하고 서비스 알림 제목에 거절 사유 포함")
+		void givenServiceNoticeOn_whenHandleRejected_thenSendToApplicantAndIncludeRejectReason() {
+			// given
+			User applicant = mock(User.class);
+			given(applicant.getId()).willReturn("userId");
+
+			Ceremony ceremony = mock(Ceremony.class);
+			given(ceremony.getId()).willReturn("ceremonyId");
+			given(ceremony.getUser()).willReturn(applicant);
+
+			given(ceremonyReader.findById("ceremonyId")).willReturn(Optional.of(ceremony));
+			given(notificationSettingReader.findSettingMap("userId"))
+				.willReturn(serviceNoticeOn());
+			given(notificationWriter.save(any())).willReturn(mock(Notification.class));
+
+			// when
+			handler.handleRejected(new CeremonyRejectedEvent("ceremonyId", "요건에 부합하지 않습니다."));
+
+			// then
+			verify(notificationPushSender).sendToUser(eq(applicant), eq("경조사 신청 거절"), eq("경조사 신청이 거절되었습니다."));
+			verify(notificationWriter).save(argThat(n -> n.getTitle().contains("요건에 부합하지 않습니다.")));
+			verify(notificationWriter).saveLog(eq(applicant), any());
+		}
+
+		@Test
+		@DisplayName("스킵: SERVICE_NOTICE_ENABLED OFF이면 알림 발송하지 않음")
+		void givenServiceNoticeOff_whenHandleRejected_thenSkip() {
+			// given
+			User applicant = mock(User.class);
+			given(applicant.getId()).willReturn("userId");
+
+			Ceremony ceremony = mock(Ceremony.class);
+			given(ceremony.getUser()).willReturn(applicant);
+
+			given(ceremonyReader.findById("ceremonyId")).willReturn(Optional.of(ceremony));
+			given(notificationSettingReader.findSettingMap("userId"))
+				.willReturn(serviceNoticeOff());
+
+			// when
+			handler.handleRejected(new CeremonyRejectedEvent("ceremonyId", "사유"));
+
+			// then
+			verify(notificationPushSender, never()).sendToUser(any(), any(), any());
+			verify(notificationWriter, never()).saveLog(any(), any());
+		}
+
+	}
+
 	// ─────────────────────────────────────────────────
 	// 헬퍼
 	// ─────────────────────────────────────────────────
@@ -180,6 +292,16 @@ class CeremonyNotificationListenerTest {
 		given(ceremony.isSetAll()).willReturn(false);
 		given(ceremony.getTargetAdmissionYears()).willReturn(targetYears);
 		return ceremony;
+	}
+
+	private UserNotificationSettingMap serviceNoticeOn() {
+		return UserNotificationSettingMap.ofFull(
+			Map.of(UserNotificationSettingKey.SERVICE_NOTICE_ENABLED, true));
+	}
+
+	private UserNotificationSettingMap serviceNoticeOff() {
+		return UserNotificationSettingMap.ofFull(
+			Map.of(UserNotificationSettingKey.SERVICE_NOTICE_ENABLED, false));
 	}
 
 	/** 조사(CONDOLENCE, FUNERAL), isSetAll=true */

--- a/app-main/src/test/java/net/causw/app/main/domain/notification/notification/service/listener/CeremonyNotificationListenerTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/notification/notification/service/listener/CeremonyNotificationListenerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.never;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -22,8 +23,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Map;
 
 import net.causw.app.main.domain.community.ceremony.entity.Ceremony;
 import net.causw.app.main.domain.community.ceremony.enums.CeremonyCategory;

--- a/app-main/src/test/java/net/causw/app/main/domain/notification/notification/service/listener/CeremonyNotificationListenerTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/notification/notification/service/listener/CeremonyNotificationListenerTest.java
@@ -163,8 +163,8 @@ class CeremonyNotificationListenerTest {
 	class HandleApprovedTest {
 
 		@Test
-		@DisplayName("성공: SERVICE_NOTICE_ENABLED ON이면 신청자에게 푸시 + 서비스 알림 발송")
-		void givenServiceNoticeOn_whenHandleApproved_thenSendToApplicant() {
+		@DisplayName("성공: CEREMONY_NOTIFICATION_ENABLED ON이면 신청자에게 푸시 + 서비스 알림 발송")
+		void givenCeremonyNotificationOn_whenHandleApproved_thenSendToApplicant() {
 			// given
 			User applicant = mock(User.class);
 			given(applicant.getId()).willReturn("userId");
@@ -175,7 +175,7 @@ class CeremonyNotificationListenerTest {
 
 			given(ceremonyReader.findById("ceremonyId")).willReturn(Optional.of(ceremony));
 			given(notificationSettingReader.findSettingMap("userId"))
-				.willReturn(serviceNoticeOn());
+				.willReturn(ceremonyNotificationOn());
 			given(notificationWriter.save(any())).willReturn(mock(Notification.class));
 
 			// when
@@ -187,8 +187,8 @@ class CeremonyNotificationListenerTest {
 		}
 
 		@Test
-		@DisplayName("스킵: SERVICE_NOTICE_ENABLED OFF이면 알림 발송하지 않음")
-		void givenServiceNoticeOff_whenHandleApproved_thenSkip() {
+		@DisplayName("스킵: CEREMONY_NOTIFICATION_ENABLED OFF이면 알림 발송하지 않음")
+		void givenCeremonyNotificationOff_whenHandleApproved_thenSkip() {
 			// given
 			User applicant = mock(User.class);
 			given(applicant.getId()).willReturn("userId");
@@ -198,7 +198,7 @@ class CeremonyNotificationListenerTest {
 
 			given(ceremonyReader.findById("ceremonyId")).willReturn(Optional.of(ceremony));
 			given(notificationSettingReader.findSettingMap("userId"))
-				.willReturn(serviceNoticeOff());
+				.willReturn(ceremonyNotificationOff());
 
 			// when
 			handler.handleApproved(new CeremonyApprovedEvent("ceremonyId"));
@@ -215,8 +215,8 @@ class CeremonyNotificationListenerTest {
 	class HandleRejectedTest {
 
 		@Test
-		@DisplayName("성공: SERVICE_NOTICE_ENABLED ON이면 신청자에게 푸시 발송하고 서비스 알림 제목에 거절 사유 포함")
-		void givenServiceNoticeOn_whenHandleRejected_thenSendToApplicantAndIncludeRejectReason() {
+		@DisplayName("성공: CEREMONY_NOTIFICATION_ENABLED ON이면 신청자에게 푸시 발송하고 서비스 알림 제목에 거절 사유 포함")
+		void givenCeremonyNotificationOn_whenHandleRejected_thenSendToApplicantAndIncludeRejectReason() {
 			// given
 			User applicant = mock(User.class);
 			given(applicant.getId()).willReturn("userId");
@@ -227,7 +227,7 @@ class CeremonyNotificationListenerTest {
 
 			given(ceremonyReader.findById("ceremonyId")).willReturn(Optional.of(ceremony));
 			given(notificationSettingReader.findSettingMap("userId"))
-				.willReturn(serviceNoticeOn());
+				.willReturn(ceremonyNotificationOn());
 			given(notificationWriter.save(any())).willReturn(mock(Notification.class));
 
 			// when
@@ -240,8 +240,8 @@ class CeremonyNotificationListenerTest {
 		}
 
 		@Test
-		@DisplayName("스킵: SERVICE_NOTICE_ENABLED OFF이면 알림 발송하지 않음")
-		void givenServiceNoticeOff_whenHandleRejected_thenSkip() {
+		@DisplayName("스킵: CEREMONY_NOTIFICATION_ENABLED OFF이면 알림 발송하지 않음")
+		void givenCeremonyNotificationOff_whenHandleRejected_thenSkip() {
 			// given
 			User applicant = mock(User.class);
 			given(applicant.getId()).willReturn("userId");
@@ -251,7 +251,7 @@ class CeremonyNotificationListenerTest {
 
 			given(ceremonyReader.findById("ceremonyId")).willReturn(Optional.of(ceremony));
 			given(notificationSettingReader.findSettingMap("userId"))
-				.willReturn(serviceNoticeOff());
+				.willReturn(ceremonyNotificationOff());
 
 			// when
 			handler.handleRejected(new CeremonyRejectedEvent("ceremonyId", "사유"));
@@ -293,14 +293,14 @@ class CeremonyNotificationListenerTest {
 		return ceremony;
 	}
 
-	private UserNotificationSettingMap serviceNoticeOn() {
+	private UserNotificationSettingMap ceremonyNotificationOn() {
 		return UserNotificationSettingMap.ofFull(
-			Map.of(UserNotificationSettingKey.SERVICE_NOTICE_ENABLED, true));
+			Map.of(UserNotificationSettingKey.CEREMONY_NOTIFICATION_ENABLED, true));
 	}
 
-	private UserNotificationSettingMap serviceNoticeOff() {
+	private UserNotificationSettingMap ceremonyNotificationOff() {
 		return UserNotificationSettingMap.ofFull(
-			Map.of(UserNotificationSettingKey.SERVICE_NOTICE_ENABLED, false));
+			Map.of(UserNotificationSettingKey.CEREMONY_NOTIFICATION_ENABLED, false));
 	}
 
 	/** 조사(CONDOLENCE, FUNERAL), isSetAll=true */


### PR DESCRIPTION
### 🚩 관련사항
close #1417 


### 📢 전달사항

이번 PR에서는 경조사 도메인의 두 가지 문제를 수정합니다.

**1. 공개 경조사 상세 조회 API에서 admin context 접근 차단**

`GET /api/v2/ceremonies/{ceremonyId}?context=admin` 파라미터가 인증/인가 없이 허용되어 있었습니다. 
admin 상세 조회는 이미 `/api/v2/admin/ceremonies/{ceremonyId}`로 별도 엔드포인트가 존재하므로, `CeremonyContext` enum에서 `ADMIN` 값을 제거해 공개 API에서 해당 context로의 접근 자체를 차단했습니다.

**2. 경조사 승인/거절 시 신청자에게 결과 알림 발송 누락**

기존에는 경조사 승인 시 대상 학번 유저들에게 공지 알림만 발송되고, 신청자 본인에게는 아무런 결과 알림이 없었습니다. 
신청자 입장에서 본인 신청의 처리 결과를 알 수 없는 문제였습니다.

- `CeremonyApprovedEvent`, `CeremonyRejectedEvent` 이벤트 레코드를 각각 추가
- `CeremonyNotificationListener`에 `handleApproved`, `handleRejected` 핸들러 추가
  - 알림 필터: ~~`SERVICE_NOTICE_ENABLED` (경조사 공지 알림이 아닌 본인 신청 결과이므로)~~ → `CEREMONY_NOTIFICATION_ENABLED`(알림 딥링크 고려해서 변경)
  - ~~`NoticeType.SYSTEM` 사용 (`AdmissionNotificationListener` 승인/거절 패턴과 동일)~~ → `NoticeType.CEREMONY_V2`(알림 딥링크 고려)
  - 푸시 알림: 짧은 결과 메시지 / 서비스 알림(앱 내 알림함): 거절 사유 포함 상세 메시지
- `CeremonyAdminService.approve()`, `reject()`에서 각 이벤트 발행

### 📸 스크린샷

N/A

### 📃 진행사항

- [x] `CeremonyContext.ADMIN` 제거로 공개 API admin context 접근 차단
- [x] `CeremonyApprovedEvent`, `CeremonyRejectedEvent` 이벤트 레코드 추가
- [x] `CeremonyNotificationListener`에 승인/거절 결과 알림 핸들러 추가
- [x] `CeremonyAdminService` 승인/거절 시 결과 이벤트 발행
- [x] 관련 테스트 코드 작성 (리스너 케이스 추가, 서비스 기존 테스트 업데이트)

### ⚙️ 기타사항

개발기간: 2026-07-25 ~ 2026-07-25


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added push notifications for ceremony approval and rejection outcomes.
  * Rejection notifications now include the provided rejection reason.
  * Notifications respect each applicant’s ceremony notification settings.
  * Added notification records for approval and rejection events.

* **Changes**
  * Removed the administrator ceremony context; the personal ceremony context remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->