### PR TITLE
Fix: 소셜 로그인 사용자 추방 후 복구 오류 해결

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/user/DroppedUserIdentifierRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/user/DroppedUserIdentifierRepository.java
@@ -12,4 +12,6 @@ public interface DroppedUserIdentifierRepository extends JpaRepository<DroppedUs
 	boolean existsByIdentifierTypeAndIdentifierHash(DroppedIdentifierType identifierType, String identifierHash);
 
 	List<DroppedUserIdentifier> findAllByUserId(String userId);
+
+	void deleteAllByUserId(String userId);
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAdminService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/UserAdminService.java
@@ -101,6 +101,7 @@ public class UserAdminService {
 		Set<Role> beforeRoles = new HashSet<>(targetUser.getRoles());
 
 		User restoredUser = userWriter.restore(targetUser);
+		droppedUserIdentifierWriter.deleteDroppedIdentifiers(restoredUser);
 		userAdminActionLogWriter.logRestore(adminUser, restoredUser, beforeState, beforeRoles);
 		return UserRestoreResult.from(restoredUser);
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/implementation/DroppedUserIdentifierWriter.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/implementation/DroppedUserIdentifierWriter.java
@@ -26,6 +26,11 @@ public class DroppedUserIdentifierWriter {
 		save(user.getId(), DroppedIdentifierType.STUDENT_ID, user.getStudentId(), user.getRejectionOrDropReason());
 	}
 
+	@Transactional
+	public void deleteDroppedIdentifiers(User user) {
+		droppedUserIdentifierRepository.deleteAllByUserId(user.getId());
+	}
+
 	private void save(String userId, DroppedIdentifierType type, String raw, String reason) {
 		if (raw == null || raw.isBlank()) {
 			return;

--- a/app-main/src/test/java/net/causw/app/main/domain/user/account/service/UserAdminServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/user/account/service/UserAdminServiceTest.java
@@ -291,6 +291,7 @@ class UserAdminServiceTest {
 
 			// then
 			verify(userWriter).restore(user);
+			verify(droppedUserIdentifierWriter).deleteDroppedIdentifiers(user);
 			verify(userAdminActionLogWriter).logRestore(any(), any(), any(), any());
 		}
 


### PR DESCRIPTION
### 🚩 관련사항
Closed #1400 


### 📢 전달사항
사용자 복구 시 `DroppedUserIdentifier`가 삭제되지 않아, 복구된 소셜 로그인 사용자가 로그인 과정에서 `USER_DROPPED` 예외가 발생하는 문제가 있었습니다.

이를 해결하기 위해 사용자 복구(`restoreUser`) 시 추방 시 저장된 `DroppedUserIdentifier`를 함께 삭제하도록 수정했습니다.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [x] `DroppedUserIdentifier` 삭제 기능 추가
- [x] `restoreUser()`에서 사용자 복구 후 `DroppedUserIdentifier` 삭제 로직 추가
- [x] 복구 후 소셜 로그인 정상 동작 검증


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 2026.07.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restoring a previously deleted user now also removes their stored dropped-user identifiers.
  * Prevents outdated identifier records from remaining after account restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->