### PR TITLE
feat: API 로그 경로를 라우팅 템플릿 URI로 정규화

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/core/datasourceProxy/ApiQueryLoggingAspect.java
+++ b/app-main/src/main/java/net/causw/app/main/core/datasourceProxy/ApiQueryLoggingAspect.java
@@ -8,12 +8,12 @@ import org.aspectj.lang.annotation.Aspect;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.servlet.HandlerMapping;
 
 import net.causw.app.main.core.datasourceProxy.QueryContext.QueryInfo;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.servlet.HandlerMapping;
 
 @Aspect
 @Component
@@ -36,12 +36,11 @@ public class ApiQueryLoggingAspect {
 			method = request.getMethod();
 
 			// 정규화된 URI 형태로 가공
-			Object matchedPattern =
-					request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+			Object matchedPattern = request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
 
 			path = matchedPattern != null
-					? matchedPattern.toString()
-					: request.getRequestURI();
+				? matchedPattern.toString()
+				: request.getRequestURI();
 		}
 
 		if (!path.startsWith("/api/v2")) {

--- a/app-main/src/main/java/net/causw/app/main/core/datasourceProxy/ApiQueryLoggingAspect.java
+++ b/app-main/src/main/java/net/causw/app/main/core/datasourceProxy/ApiQueryLoggingAspect.java
@@ -13,6 +13,7 @@ import net.causw.app.main.core.datasourceProxy.QueryContext.QueryInfo;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerMapping;
 
 @Aspect
 @Component
@@ -33,7 +34,14 @@ public class ApiQueryLoggingAspect {
 		if (attributes != null) {
 			HttpServletRequest request = attributes.getRequest();
 			method = request.getMethod();
-			path = request.getRequestURI();
+
+			// 정규화된 URI 형태로 가공
+			Object matchedPattern =
+					request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+
+			path = matchedPattern != null
+					? matchedPattern.toString()
+					: request.getRequestURI();
 		}
 
 		if (!path.startsWith("/api/v2")) {

--- a/app-main/src/main/java/net/causw/app/main/core/filter/RequestLoggingFilter.java
+++ b/app-main/src/main/java/net/causw/app/main/core/filter/RequestLoggingFilter.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerMapping;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -73,16 +74,19 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
 			// MDC를 clear하지 않으면 스레드 풀 재사용 시 이전 요청 정보가 남아 오염됨
 			long duration = System.currentTimeMillis() - start;
 			int status = wrappedResponse.getStatus();
+			String normalizedPath = resolveNormalizedPath(request);
+			MDC.put("path", normalizedPath);
 			MDC.put("status", String.valueOf(status));
 			MDC.put("duration", String.valueOf(duration));
 
 			// 응답 상태 코드에 따라 로그 레벨 분기
 			if (status >= 500) {
-				log.error("Request processed [{} {}] status={} duration={}ms", method, requestURI, status, duration);
+				log.error("Request processed [{} {}] status={} duration={}ms", method, normalizedPath, status,
+					duration);
 			} else if (status >= 400) {
-				log.warn("Request processed [{} {}] status={} duration={}ms", method, requestURI, status, duration);
+				log.warn("Request processed [{} {}] status={} duration={}ms", method, normalizedPath, status, duration);
 			} else {
-				log.info("Request processed [{} {}] status={} duration={}ms", method, requestURI, status, duration);
+				log.info("Request processed [{} {}] status={} duration={}ms", method, normalizedPath, status, duration);
 			}
 
 			MDC.clear();
@@ -104,6 +108,11 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
 		}
 
 		return !uri.toLowerCase().startsWith("/api/v2");
+	}
+
+	private static String resolveNormalizedPath(HttpServletRequest request) {
+		Object matchedPattern = request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+		return matchedPattern != null ? matchedPattern.toString() : request.getRequestURI();
 	}
 
 	/**


### PR DESCRIPTION
### 🚩 관련사항
Closes #1424

### 📢 전달사항
API 요청 및 쿼리 로그가 실제 요청 URI를 그대로 기록하면서 리소스 식별자마다 로그 집계 경로가 분산되는 문제를 개선했습니다.

`RequestLoggingFilter`와 `ApiQueryLoggingAspect`에서 Spring MVC의 `HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE`를 사용해 `/api/v2/users/123` 같은 실제 URI를 `/api/v2/users/{id}` 형태의 라우팅 템플릿으로 기록합니다. 매칭된 패턴이 없는 요청은 기존 `request.getRequestURI()`를 사용해 동작 호환성을 유지합니다.

리뷰 시 요청 처리 완료 시점에 라우팅 패턴이 MDC의 `path`에 반영되는지와, 요청 로그와 쿼리 로그가 동일한 정규화 기준을 사용하는지 확인해 주세요.

### 📸 스크린샷
N/A

### 📃 진행사항
- [x] 요청 로그 경로 정규화
- [x] API 쿼리 로그 경로 정규화
- [x] 라우팅 패턴 미존재 시 기존 URI fallback

### ⚙️ 기타사항

DB 및 환경 변수 변경은 없습니다.

개발기간: 2026-07-27 ~ 2026-07-27


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API request logs by using normalized route patterns instead of full request paths when available.
  * Preserved fallback logging for requests without a matched route.
  * Made request paths more consistent across informational, warning, and error logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->