### PR TITLE
infra: PR 생성 Discord 알림 워크플로 추가

### DIFF
--- a/.github/workflows/pr-discord-notification.yml
+++ b/.github/workflows/pr-discord-notification.yml
@@ -1,0 +1,44 @@
+name: 디스코드 PR 생성 알림
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  notify:
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.ref != 'dev' &&
+      github.event.pull_request.head.ref != 'main' &&
+      !startsWith(github.event.pull_request.head.ref, 'chore') &&
+      !startsWith(github.event.pull_request.head.ref, 'hotfix')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Discord Notification
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_BACKEND_PR_WEBHOOK_URL }}
+          DISCORD_BACKEND_ROLE_ID: ${{ vars.DISCORD_BACKEND_ROLE_ID }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          jq -n \
+            --arg role_id "$DISCORD_BACKEND_ROLE_ID" \
+            --arg title "$PR_TITLE" \
+            --arg pr_url "$PR_URL" \
+            --arg pr_author "$PR_AUTHOR" \
+            --arg pr_body "$PR_BODY" \
+            '{
+              content: ("<@&" + $role_id + "> **" + $pr_author + "**님의 새로운 PR이 생성되었습니다! 리뷰 부탁드립니다."),
+              embeds: [{
+                title: $title,
+                url: $pr_url,
+                description: ("작성자: **" + $pr_author + "**\n\n" + ($pr_body | .[0:500]) + (if ($pr_body | length) > 500 then "..." else "" end))
+              }]
+            }' > payload.json
+
+          curl --fail-with-body \
+            -H "Content-Type: application/json" \
+            -d @payload.json \
+            "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
### 🚩 관련사항

Closes #1426

### 📢 전달사항

백엔드 PR이 생성되거나 재오픈될 때 담당 Discord 역할을 멘션해 리뷰를 요청할 수 있도록 GitHub Actions 워크플로를 추가했습니다.

기존 PR 리뷰 알림과 동일한 `DISCORD_BACKEND_PR_WEBHOOK_URL` Secret 및 `DISCORD_BACKEND_ROLE_ID` Repository Variable을 재사용합니다. PR 제목, 작성자, 링크와 최대 500자의 본문 미리보기를 JSON-safe한 Discord Embed로 전송합니다.

불필요한 알림을 방지하기 위해 Draft PR과 `dev`, `main`, `chore*`, `hotfix*` 브랜치에서 생성된 PR은 실행 대상에서 제외했습니다.

### 📸 스크린샷

N/A

### 📃 진행사항

- [x] PR 생성 및 재오픈 Discord 알림 워크플로 추가
- [x] 백엔드 Discord Webhook Secret 및 역할 ID Variable 연동
- [x] Draft 및 알림 제외 브랜치 조건 적용
- [x] YAML 구문과 Spotless 검사

### ⚙️ 기타사항

- 추가 GitHub Secret 또는 Repository Variable 등록은 필요하지 않습니다.
- DB 및 `.env.example` 변경은 없습니다.

개발기간: 2026-07-27 ~ 2026-07-27
