### PR TITLE
feat: 크롤링 하드코딩 해결

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/CrawledToPostTransferService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/CrawledToPostTransferService.java
@@ -46,12 +46,12 @@ public class CrawledToPostTransferService {
 	@Transactional
 	public void transferToPosts() {
 		Board board = getBoard();
-		User adminUser = getAdminUser();
+		User systemUser = getSystemUser();
 		List<CrawledNotice> updatedNotices = getUpdatedNotices();
 
 		int savedCount = 0;
 		for (CrawledNotice notice : updatedNotices) {
-			if (processUpdatedNotice(notice, board, adminUser)) {
+			if (processUpdatedNotice(notice, board, systemUser)) {
 				notice.setIsUpdated(false);
 				crawledNoticeRepository.save(notice);
 				savedCount++;
@@ -67,8 +67,8 @@ public class CrawledToPostTransferService {
 	}
 
 	//관리자 조회
-	private User getAdminUser() {
-		return userRepository.findByStudentId(StaticValue.ADMIN_STUDENT_ID)
+	private User getSystemUser() {
+		return userRepository.findByEmail(StaticValue.SYSTEM_CRAWLER_ACCOUNT)
 			.orElseThrow(() -> new BadRequestException(
 				ErrorCode.ROW_DOES_NOT_EXIST, MessageUtil.USER_NOT_FOUND));
 	}

--- a/app-main/src/main/resources/db/migration/V20260727181056__CreateCrawlerSystemUser.sql
+++ b/app-main/src/main/resources/db/migration/V20260727181056__CreateCrawlerSystemUser.sql
@@ -1,0 +1,49 @@
+-- Migration: CreateCrawlerSystemUser
+
+-- 1. 크롤링 시스템 계정 생성
+INSERT INTO tb_user (
+                     id,
+                     email,
+                     name,
+                     nickname,
+                     password,
+                     state,
+                     academic_status,
+                     profile_image_type,
+                     is_v2,
+                     is_email_verified,
+                     report_count,
+                     created_at,
+                     updated_at
+)
+SELECT
+    'system-crawler-id',
+    'SYSTEM_CRAWLER_ACCOUNT',
+    '크롤링 시스템 계정',
+    '동네 크롤러',
+    'LOGIN_DISABLED',
+    'ACTIVE',
+    'ENROLLED',
+    'UNSET',
+    true,
+    false,
+    0,
+    NOW(),
+    NOW()
+WHERE NOT EXISTS (
+    SELECT 1 FROM tb_user WHERE email = 'SYSTEM_CRAWLER_ACCOUNT'
+);
+
+
+-- 2. 크롤링 시스템 계정 권한 부여
+INSERT INTO user_roles (user_id, role)
+SELECT 'system-crawler-id', 'ADMIN'
+WHERE NOT EXISTS (
+    SELECT 1 FROM user_roles WHERE user_id = 'system-crawler-id' AND role = 'ADMIN'
+);
+
+
+-- 3. 기존 크롤링 게시물의 작성자 변경
+UPDATE tb_post
+SET user_id = 'system-crawler-id'
+WHERE is_crawled = true;

--- a/app-main/src/main/resources/db/migration/V20260727181056__CreateCrawlerSystemUser.sql
+++ b/app-main/src/main/resources/db/migration/V20260727181056__CreateCrawlerSystemUser.sql
@@ -37,13 +37,19 @@ WHERE NOT EXISTS (
 
 -- 2. 크롤링 시스템 계정 권한 부여
 INSERT INTO user_roles (user_id, role)
-SELECT 'system-crawler-id', 'ADMIN'
-WHERE NOT EXISTS (
-    SELECT 1 FROM user_roles WHERE user_id = 'system-crawler-id' AND role = 'ADMIN'
-);
+SELECT u.id, 'ADMIN'
+FROM tb_user u
+WHERE u.email = 'SYSTEM_CRAWLER_ACCOUNT'
+    AND NOT EXISTS (
+        SELECT 1
+        FROM user_roles ur
+        WHERE ur.user_id = u.id AND ur.role = 'ADMIN'
+    );
 
 
 -- 3. 기존 크롤링 게시물의 작성자 변경
 UPDATE tb_post
-SET user_id = 'system-crawler-id'
+SET user_id = (
+    SELECT id FROM tb_user WHERE email = 'SYSTEM_CRAWLER_ACCOUNT'
+    )
 WHERE is_crawled = true;

--- a/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/service/CrawledToPostTransferServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/service/CrawledToPostTransferServiceTest.java
@@ -69,7 +69,7 @@ public class CrawledToPostTransferServiceTest {
 
 		given(boardRepository.findByName(StaticValue.CrawlingBoard))
 			.willReturn(Optional.of(mockBoard));
-		given(userRepository.findByStudentId(StaticValue.ADMIN_STUDENT_ID))
+		given(userRepository.findByEmail(StaticValue.SYSTEM_CRAWLER_ACCOUNT))
 			.willReturn(Optional.of(mockUser));
 		given(crawledNoticeRepository.findTop30ByIsUpdatedTrueOrderByLastModifiedDesc())
 			.willReturn(List.of(newNotice));
@@ -97,7 +97,7 @@ public class CrawledToPostTransferServiceTest {
 
 		given(boardRepository.findByName(StaticValue.CrawlingBoard))
 			.willReturn(Optional.of(mockBoard));
-		given(userRepository.findByStudentId(StaticValue.ADMIN_STUDENT_ID))
+		given(userRepository.findByEmail(StaticValue.SYSTEM_CRAWLER_ACCOUNT))
 			.willReturn(Optional.of(mockUser));
 		given(crawledNoticeRepository.findTop30ByIsUpdatedTrueOrderByLastModifiedDesc())
 			.willReturn(List.of(updatedNotice));
@@ -121,7 +121,7 @@ public class CrawledToPostTransferServiceTest {
 
 		given(boardRepository.findByName(StaticValue.CrawlingBoard))
 			.willReturn(Optional.of(mockBoard));
-		given(userRepository.findByStudentId(StaticValue.ADMIN_STUDENT_ID))
+		given(userRepository.findByEmail(StaticValue.SYSTEM_CRAWLER_ACCOUNT))
 			.willReturn(Optional.of(mockUser));
 		given(crawledNoticeRepository.findTop30ByIsUpdatedTrueOrderByLastModifiedDesc())
 			.willReturn(Collections.emptyList());
@@ -141,7 +141,7 @@ public class CrawledToPostTransferServiceTest {
 
 	private User createMockUser() {
 		User user = mock(User.class);
-		when(user.getStudentId()).thenReturn(StaticValue.ADMIN_STUDENT_ID);
+		when(user.getEmail()).thenReturn(StaticValue.SYSTEM_CRAWLER_ACCOUNT);
 		return user;
 	}
 

--- a/global/src/main/java/net/causw/global/constant/StaticValue.java
+++ b/global/src/main/java/net/causw/global/constant/StaticValue.java
@@ -93,7 +93,7 @@ public class StaticValue {
 	public static final String ORIGINAL_NOTICE_SITE_NAME = "중앙대학교 소프트웨어학부 공지사항";
 	public static final String CAU_CSE_BASE_URL = "https://cse.cau.ac.kr/sub05/sub0501.php?offset=";
 	public static final String CAU_CSE_DOWNLOAD_URL_FORMAT = "https://cse.cau.ac.kr/_module/bbs/download.php?uid=%s&code=%s";
-	public static final String ADMIN_STUDENT_ID = "20220881";
+	public static final String SYSTEM_CRAWLER_ACCOUNT = "SYSTEM_CRAWLER_ACCOUNT";
 	public static final int CRAWLING_MAX_NOTICES = 30;
 	public static final int CRAWLING_MAX_RETRIES = 3;
 	public static final int CRAWLING_REQUEST_DELAY_MS = 2000;


### PR DESCRIPTION
### 🚩 관련사항
#1423 


### 📢 전달사항
* 기존 크롤링 스케줄러가 게시글(`Post`)을 생성할 때, 특정 사용자(`sokft`)의 학번(`StaticValue.ADMIN_STUDENT_ID = "20220881"`)이 하드코딩되어 있었습니다.
* 해당 유저가 탈퇴하거나 정보가 변경되어 DB 조회에 실패할 경우, 예외가 발생하여 **크롤링 스케줄러 로직 전체가 중단되는 치명적인 잠재적 장애(SPOF)** 위험이 있었습니다.

**변경 사항**

* **크롤링 시스템 전용 계정 도입:** 크롤링 시스템 전용 계정(`SYSTEM_CRAWLER_ACCOUNT`)을 신설했습니다.
* **Flyway 마이그레이션 적용:** 마이그레이션 스크립트를 추가하여 다음 작업을 자동화했습니다.
1. `tb_user`에 크롤러 계정(로그인 불가, 이메일 검증 우회) 추가
2. `tb_user_roles`에 해당 계정의 `ADMIN` 권한 부여
3. `tb_post`에서 기존 크롤링 게시물(`is_crawled = true`)의 소유권을 모두 크롤러 계정으로 일괄 이관


* 부수적 효과: 시스템 계정을 DB 쿼리로 직접 삽입함으로써 정식적인 회원가입 절차를 따르지 않게 되었습니다. 덕분에 동문수첩에서 크롤러 계정이 노출되지 않습니다.



### 📸 스크린샷
<img width="1542" height="122" alt="image" src="https://github.com/user-attachments/assets/ae43b2a4-7839-479e-b084-4e29515405ce" />

로컬DB에서 크롤러 계정이 잘 생성된 모습

### 📃 진행사항
* [x] `StaticValue.ADMIN_STUDENT_ID` 특정 유저 학번 하드코딩 제거
* [x] `StaticValue.SYSTEM_CRAWLER_ACCOUNT` 고정 식별자(이메일 형식 우회) 상수 추가
* [x] Flyway 마이그레이션 스크립트 작성 (계정 생성, 권한 부여, 기존 게시물 소유권 이관)
* [x] `CrawledToPostTransferService` 시스템 계정 조회 로직 리팩토링
* [x] `CrawledToPostTransferServiceTest` 단위 테스트 모킹 대상 변경 및 통과 확인


### ⚙️ 기타사항
* **참고사항:** 기존 1차 PR(#1342)에서 우려되었던 '관리자 로그인 시 내가 작성한 글에 크롤링 게시물이 도배되는 현상'은 봇 계정으로 게시물 소유권을 모두 이전함에 따라 자연스럽게 해결되었습니다. 본 PR은 시스템 크리티컬 오류인 SPOF 해결에 집중하며, Role 분리 등 추가 권한 관리는 다음 PR로 분리하여 진행할 예정입니다.
* **개발기간:** 2026-07-27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 크롤러가 생성한 게시물을 위한 전용 시스템 계정을 추가했습니다.
  - 기존 크롤링 게시물도 시스템 크롤러 계정에 연결됩니다.

- **버그 수정**
  - 새 게시물과 수정 게시물이 관리자 계정이 아닌 시스템 계정으로 일관되게 등록됩니다.

- **테스트**
  - 게시물 전송 과정에서 시스템 계정이 사용되는 시나리오를 검증하도록 테스트를 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->