### PR TITLE
[FIX] FCM 기본 FirebaseApp 초기화 오류 수정

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/shared/infra/firebase/FirebaseConfig.java
+++ b/app-main/src/main/java/net/causw/app/main/shared/infra/firebase/FirebaseConfig.java
@@ -5,14 +5,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Base64;
 
-import javax.annotation.PostConstruct;
-
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -23,28 +23,42 @@ public class FirebaseConfig {
 	@Value("${fcm.firebase-key-base64}")
 	private String firebaseKeyBase64;
 
-	@PostConstruct
-	public void initialize() {
+	@Bean
+	public FirebaseApp firebaseApp() {
 		try {
-			if (FirebaseApp.getApps().isEmpty()) {
-				if (firebaseKeyBase64 == null || firebaseKeyBase64.isBlank()) {
-					throw new RuntimeException("Firebase 초기화 실패: FCM_FIREBASE_KEY_BASE64 환경변수가 없습니다.");
-				}
-				byte[] decodedKey = Base64.getMimeDecoder().decode(firebaseKeyBase64.trim());
+			FirebaseApp firebaseApp = FirebaseApp.getInstance();
+			log.info("기본 FirebaseApp이 이미 초기화되어 있습니다.");
+			return firebaseApp;
+		} catch (IllegalStateException e) {
+			return initializeDefaultFirebaseApp();
+		}
+	}
 
-				// 디코딩된 키를 InputStream으로 변환하여 Firebase에 주입
-				try (InputStream credentialStream = new ByteArrayInputStream(decodedKey)) {
-					FirebaseOptions options = FirebaseOptions.builder()
-						.setCredentials(GoogleCredentials.fromStream(credentialStream))
-						.build();
+	@Bean
+	public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
+		return FirebaseMessaging.getInstance(firebaseApp);
+	}
 
-					FirebaseApp.initializeApp(options);
-					log.info("Firebase가 성공적으로 초기화되었습니다.");
-				}
+	private FirebaseApp initializeDefaultFirebaseApp() {
+		if (firebaseKeyBase64 == null || firebaseKeyBase64.isBlank()) {
+			throw new IllegalStateException("Firebase 초기화 실패: FCM_FIREBASE_KEY_BASE64 환경변수가 없습니다.");
+		}
+
+		try {
+			byte[] decodedKey = Base64.getMimeDecoder().decode(firebaseKeyBase64.trim());
+
+			try (InputStream credentialStream = new ByteArrayInputStream(decodedKey)) {
+				FirebaseOptions options = FirebaseOptions.builder()
+					.setCredentials(GoogleCredentials.fromStream(credentialStream))
+					.build();
+
+				FirebaseApp firebaseApp = FirebaseApp.initializeApp(options);
+				log.info("기본 FirebaseApp이 성공적으로 초기화되었습니다.");
+				return firebaseApp;
 			}
 		} catch (IOException | IllegalArgumentException e) {
 			log.error("Firebase 초기화 중 에러 발생", e);
-			throw new RuntimeException("Firebase 초기화 실패", e);
+			throw new IllegalStateException("Firebase 초기화 실패", e);
 		}
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/shared/infra/firebase/FirebasePushNotificationSender.java
+++ b/app-main/src/main/java/net/causw/app/main/shared/infra/firebase/FirebasePushNotificationSender.java
@@ -11,18 +11,22 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class FirebasePushNotificationSender implements PushNotificationSender {
 
 	private static final String PROD_PROFILE = "prod";
 	private static final String DEV_PROFILE = "dev";
 
 	private final Environment environment;
+	private final FirebaseMessaging firebaseMessaging;
+
+	public FirebasePushNotificationSender(Environment environment, FirebaseMessaging firebaseMessaging) {
+		this.environment = environment;
+		this.firebaseMessaging = firebaseMessaging;
+	}
 
 	@Override
 	public void send(String token, String title, String body) throws Exception {
@@ -41,7 +45,7 @@ public class FirebasePushNotificationSender implements PushNotificationSender {
 			.setNotification(notification)
 			.build();
 
-		String response = FirebaseMessaging.getInstance().send(message);
+		String response = firebaseMessaging.send(message);
 		log.info("FCM 메시지 발송 성공: response={}", response);
 	}
 

--- a/app-main/src/test/java/net/causw/app/main/shared/infra/firebase/FirebaseConfigTest.java
+++ b/app-main/src/test/java/net/causw/app/main/shared/infra/firebase/FirebaseConfigTest.java
@@ -1,0 +1,72 @@
+package net.causw.app.main.shared.infra.firebase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+
+@DisplayName("FirebaseConfig 단위 테스트")
+class FirebaseConfigTest {
+
+	@Test
+	@DisplayName("기본 FirebaseApp이 존재하면 기존 앱을 반환한다")
+	void givenDefaultFirebaseApp_whenCreateBean_thenReturnExistingApp() {
+		// given
+		FirebaseConfig firebaseConfig = new FirebaseConfig();
+		FirebaseApp existingApp = mock(FirebaseApp.class);
+
+		try (MockedStatic<FirebaseApp> firebaseApp = mockStatic(FirebaseApp.class)) {
+			firebaseApp.when(FirebaseApp::getInstance).thenReturn(existingApp);
+
+			// when
+			FirebaseApp result = firebaseConfig.firebaseApp();
+
+			// then
+			assertThat(result).isSameAs(existingApp);
+			firebaseApp.verify(FirebaseApp::getInstance);
+			firebaseApp.verifyNoMoreInteractions();
+		}
+	}
+
+	@Test
+	@DisplayName("이름이 지정된 앱만 있고 기본 FirebaseApp이 없으면 기본 앱을 초기화한다")
+	void givenNoDefaultFirebaseApp_whenCreateBean_thenInitializeDefaultApp() {
+		// given
+		FirebaseConfig firebaseConfig = new FirebaseConfig();
+		String credentialJson = "{\"type\":\"service_account\"}";
+		String encodedCredential = Base64.getEncoder()
+			.encodeToString(credentialJson.getBytes(StandardCharsets.UTF_8));
+		ReflectionTestUtils.setField(firebaseConfig, "firebaseKeyBase64", encodedCredential);
+
+		FirebaseApp initializedApp = mock(FirebaseApp.class);
+		GoogleCredentials googleCredentials = mock(GoogleCredentials.class);
+
+		try (
+			MockedStatic<FirebaseApp> firebaseApp = mockStatic(FirebaseApp.class);
+			MockedStatic<GoogleCredentials> credentials = mockStatic(GoogleCredentials.class)) {
+			firebaseApp.when(FirebaseApp::getInstance)
+				.thenThrow(new IllegalStateException("FirebaseApp with name [DEFAULT] doesn't exist."));
+			firebaseApp.when(() -> FirebaseApp.initializeApp(any(FirebaseOptions.class))).thenReturn(initializedApp);
+			credentials.when(() -> GoogleCredentials.fromStream(any())).thenReturn(googleCredentials);
+
+			// when
+			FirebaseApp result = firebaseConfig.firebaseApp();
+
+			// then
+			assertThat(result).isSameAs(initializedApp);
+			firebaseApp.verify(() -> FirebaseApp.initializeApp(any(FirebaseOptions.class)));
+		}
+	}
+}

--- a/app-main/src/test/java/net/causw/app/main/shared/infra/firebase/FirebasePushNotificationSenderTest.java
+++ b/app-main/src/test/java/net/causw/app/main/shared/infra/firebase/FirebasePushNotificationSenderTest.java
@@ -2,15 +2,14 @@ package net.causw.app.main.shared.infra.firebase;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.MockedStatic;
 import org.springframework.mock.env.MockEnvironment;
 
 import com.google.firebase.messaging.FirebaseMessaging;
@@ -25,15 +24,14 @@ class FirebasePushNotificationSenderTest {
 		// given
 		MockEnvironment environment = new MockEnvironment();
 		environment.setActiveProfiles("local");
-		FirebasePushNotificationSender sender = new FirebasePushNotificationSender(environment);
+		FirebaseMessaging firebaseMessaging = mock(FirebaseMessaging.class);
+		FirebasePushNotificationSender sender = new FirebasePushNotificationSender(environment, firebaseMessaging);
 
-		try (MockedStatic<FirebaseMessaging> firebaseMessaging = mockStatic(FirebaseMessaging.class)) {
-			// when
-			sender.send("token", "title", "body");
+		// when
+		sender.send("token", "title", "body");
 
-			// then
-			firebaseMessaging.verifyNoInteractions();
-		}
+		// then
+		verifyNoInteractions(firebaseMessaging);
 	}
 
 	@ParameterizedTest
@@ -43,18 +41,14 @@ class FirebasePushNotificationSenderTest {
 		// given
 		MockEnvironment environment = new MockEnvironment();
 		environment.setActiveProfiles(profile);
-		FirebasePushNotificationSender sender = new FirebasePushNotificationSender(environment);
 		FirebaseMessaging messaging = mock(FirebaseMessaging.class);
+		FirebasePushNotificationSender sender = new FirebasePushNotificationSender(environment, messaging);
+		when(messaging.send(any(Message.class))).thenReturn("message-id");
 
-		try (MockedStatic<FirebaseMessaging> firebaseMessaging = mockStatic(FirebaseMessaging.class)) {
-			firebaseMessaging.when(FirebaseMessaging::getInstance).thenReturn(messaging);
-			when(messaging.send(any(Message.class))).thenReturn("message-id");
+		// when
+		sender.send("token", "title", "body");
 
-			// when
-			sender.send("token", "title", "body");
-
-			// then
-			verify(messaging).send(any(Message.class));
-		}
+		// then
+		verify(messaging).send(any(Message.class));
 	}
 }


### PR DESCRIPTION
### 🚩 관련사항

Closes #1432

### 📢 전달사항

운영 서버에서 FCM 푸시 발송 시 `[DEFAULT]` FirebaseApp을 찾지 못해 발생하는 예외를 수정합니다.

기존 코드는 등록된 FirebaseApp 목록이 비어 있을 때만 초기화했습니다. 이름이 지정된 다른 앱만 존재하는 경우에도 초기화를 건너뛸 수 있었고, 이후 `FirebaseMessaging.getInstance()`가 `[DEFAULT]` 앱을 조회하면서 예외가 발생할 수 있었습니다.

이번 변경에서는 서버 시작 시 `[DEFAULT]` FirebaseApp을 직접 조회하고, 존재하지 않을 때 서비스 계정으로 기본 앱을 생성합니다. 초기화된 `FirebaseApp`으로 `FirebaseMessaging` Bean을 만들고 `FirebasePushNotificationSender`에 주입하여, 푸시 발송 시점의 전역 정적 조회를 제거했습니다.

Firebase 키 또는 초기화 문제가 있으면 실제 푸시 발송 시점이 아니라 애플리케이션 시작 단계에서 확인할 수 있습니다.

### 📸 스크린샷

N/A

### 📃 진행사항

- [x] `[DEFAULT]` FirebaseApp 존재 여부를 기준으로 초기화
- [x] `FirebaseApp` 및 `FirebaseMessaging` Spring Bean 등록
- [x] `FirebasePushNotificationSender`에 초기화된 `FirebaseMessaging` 주입
- [x] 기존 기본 앱 재사용 및 기본 앱 신규 초기화 테스트 추가
- [x] local/dev/prod 프로필별 푸시 발송 테스트 수정

### ⚙️ 기타사항

- DB 및 환경변수 스키마 변경 없음
- Firebase 관련 단위 테스트 5개 통과
- `:app-main:spotlessCheck` 통과

개발기간: 2026-07-29 ~ 2026-07-29
