### PR TITLE
Feat/#1435 fix wrong user login

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/core/security/JwtTokenProvider.java
+++ b/app-main/src/main/java/net/causw/app/main/core/security/JwtTokenProvider.java
@@ -3,6 +3,7 @@ package net.causw.app.main.core.security;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import javax.crypto.SecretKey;
@@ -65,6 +66,8 @@ public class JwtTokenProvider {
 		Date now = new Date();
 
 		return Jwts.builder()
+			.id(UUID.randomUUID().toString())
+			.issuedAt(now)
 			.expiration(new Date(now.getTime() + StaticValue.JWT_REFRESH_TOKEN_VALID_TIME))
 			.signWith(secretKey, Jwts.SIG.HS256)
 			.compact();

--- a/app-main/src/main/java/net/causw/app/main/domain/user/auth/handler/OAuth2SuccessHandler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/auth/handler/OAuth2SuccessHandler.java
@@ -149,7 +149,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 	/**
 	 * 인증 principal 타입에 맞춰 도메인 사용자 엔티티를 조회합니다.
 	 * <p>
-	 * Apple OIDC의 경우 email 우선 조회 후, email 누락 시 socialId(sub)로 fallback 조회합니다.
+	 * OIDC의 경우 {@link net.causw.app.main.domain.user.auth.service.CustomOAuth2UserService}의
+	 * 사용자 확정 정책과 동일하게 socialId(sub) 우선 조회 후, 미존재 시 email로 fallback 조회합니다.
 	 *
 	 * @param authentication 인증 컨텍스트
 	 * @return 로그인 대상 사용자 엔티티
@@ -162,10 +163,11 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 		}
 
 		if (principal instanceof OidcUser oidcUser) {
-			Optional<User> userByEmail = findByEmail(oidcUser.getEmail());
-			return userByEmail.orElseGet(
-				() -> userReader.findBySocialTypeAndSocialId(SocialType.APPLE, oidcUser.getSubject())
-					.orElseThrow(AuthErrorCode.INVALID_TOKEN::toBaseException));
+			SocialType socialType = SocialType.from(
+				((OAuth2AuthenticationToken)authentication).getAuthorizedClientRegistrationId());
+			return userReader.findBySocialTypeAndSocialId(socialType, oidcUser.getSubject())
+				.or(() -> findByEmail(oidcUser.getEmail()))
+				.orElseThrow(AuthErrorCode.INVALID_TOKEN::toBaseException);
 		}
 
 		if (principal instanceof OAuth2User oAuth2User) {

--- a/app-main/src/main/java/net/causw/app/main/shared/infra/redis/CollidedRefreshTokenCleanupRunner.java
+++ b/app-main/src/main/java/net/causw/app/main/shared/infra/redis/CollidedRefreshTokenCleanupRunner.java
@@ -1,0 +1,28 @@
+package net.causw.app.main.shared.infra.redis;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "redis.migration.collided-refresh-token-cleanup", name = "enabled", havingValue = "true")
+public class CollidedRefreshTokenCleanupRunner {
+
+	private final RedisUtils redisUtils;
+
+	@EventListener(ApplicationReadyEvent.class)
+	public void purgeCollidedRefreshTokens() {
+		try {
+			int purgedCount = redisUtils.purgeCollidedRefreshTokens();
+			log.info("[Redis Migration] 중복 발급된 refresh token 정리 완료. purgedCount={}", purgedCount);
+		} catch (Exception e) {
+			log.error("[Redis Migration] 중복 발급된 refresh token 정리 실패. 재시도가 필요합니다.", e);
+		}
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/shared/infra/redis/RedisUtils.java
+++ b/app-main/src/main/java/net/causw/app/main/shared/infra/redis/RedisUtils.java
@@ -1,5 +1,8 @@
 package net.causw.app.main.shared.infra.redis;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -21,6 +24,7 @@ public class RedisUtils {
 	// 사용자별 refresh token 목록 key prefix
 	private static final String USER_REFRESH_TOKENS_PREFIX = "UserRefreshTokens:";
 	private static final String REFRESH_TOKEN_USER_INDEX_MIGRATION_KEY = "Migration:RefreshTokenUserIndex:v1";
+	private static final String COLLIDED_REFRESH_TOKEN_CLEANUP_KEY = "Migration:CollidedRefreshTokenCleanup:v1";
 	private static final String BLACKLIST_PREFIX = "Blacklist";
 
 	private final RedisTemplate<String, Object> redisTemplate;
@@ -138,6 +142,71 @@ public class RedisUtils {
 			}
 		}
 		return migratedCount;
+	}
+
+	/**
+	 * 서로 다른 사용자에게 중복 발급된 refresh token을 찾아 폐기합니다.
+	 * <p>
+	 * jti 도입 이전에는 같은 초에 발급된 token 문자열이 동일해 {@code RefreshToken:{refreshToken} -> userId}
+	 * 매핑이 덮어써졌습니다. {@code UserRefreshTokens:{userId}}는 Set이라 충돌한 token이 양쪽 인덱스에
+	 * 남아 있으므로, 2명 이상에게 매핑된 token만 선별 폐기합니다.
+	 *
+	 * @return 폐기된 refresh token 개수
+	 */
+	public int purgeCollidedRefreshTokens() {
+		if (redisTemplate.hasKey(COLLIDED_REFRESH_TOKEN_CLEANUP_KEY)) {
+			return 0;
+		}
+
+		int purgedCount = scanUserIndexAndPurgeCollidedTokens();
+		redisTemplate.opsForValue().set(COLLIDED_REFRESH_TOKEN_CLEANUP_KEY, "DONE");
+		return purgedCount;
+	}
+
+	private int scanUserIndexAndPurgeCollidedTokens() {
+		int purgedCount = 0;
+
+		for (Map.Entry<String, Set<String>> entry : collectUserIdsByRefreshToken().entrySet()) {
+			Set<String> userIds = entry.getValue();
+			if (userIds.size() < 2) {
+				continue;
+			}
+
+			String refreshToken = entry.getKey();
+			redisTemplate.delete(REFRESH_TOKEN_PREFIX + refreshToken);
+			userIds.forEach(
+				userId -> redisTemplate.opsForSet().remove(USER_REFRESH_TOKENS_PREFIX + userId, refreshToken));
+			purgedCount++;
+		}
+
+		return purgedCount;
+	}
+
+	private Map<String, Set<String>> collectUserIdsByRefreshToken() {
+		ScanOptions scanOptions = ScanOptions.scanOptions()
+			.match(USER_REFRESH_TOKENS_PREFIX + "*")
+			.count(1000)
+			.build();
+
+		Map<String, Set<String>> userIdsByRefreshToken = new HashMap<>();
+		try (Cursor<String> cursor = redisTemplate.scan(scanOptions)) {
+			while (cursor.hasNext()) {
+				String userRefreshTokensKey = cursor.next();
+				String userId = userRefreshTokensKey.substring(USER_REFRESH_TOKENS_PREFIX.length());
+
+				Set<Object> refreshTokens = redisTemplate.opsForSet().members(userRefreshTokensKey);
+				if (refreshTokens == null) {
+					continue;
+				}
+
+				for (Object refreshToken : refreshTokens) {
+					if (refreshToken instanceof String refreshTokenValue) {
+						userIdsByRefreshToken.computeIfAbsent(refreshTokenValue, key -> new HashSet<>()).add(userId);
+					}
+				}
+			}
+		}
+		return userIdsByRefreshToken;
 	}
 
 	private void syncUserRefreshTokenIndexTtl(String refreshTokenKey, String userRefreshTokensKey) {

--- a/app-main/src/main/resources/application.yml
+++ b/app-main/src/main/resources/application.yml
@@ -6,3 +6,5 @@ redis:
   migration:
     refresh-token-user-index:
       enabled: false
+    collided-refresh-token-cleanup:
+      enabled: false

--- a/app-main/src/test/java/net/causw/app/main/core/security/JwtTokenProviderTest.java
+++ b/app-main/src/test/java/net/causw/app/main/core/security/JwtTokenProviderTest.java
@@ -1,0 +1,71 @@
+package net.causw.app.main.core.security;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.crypto.spec.SecretKeySpec;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import net.causw.app.main.domain.user.auth.userdetails.CustomUserDetailsService;
+import net.causw.app.main.shared.infra.redis.RedisUtils;
+
+import io.jsonwebtoken.Jwts;
+
+@ExtendWith(MockitoExtension.class)
+class JwtTokenProviderTest {
+
+	private static final String SECRET = "test-secret-key-for-jwt-token-provider-unit-test";
+
+	@Mock
+	private CustomUserDetailsService userDetailsService;
+
+	@Mock
+	private RedisUtils redisUtils;
+
+	private JwtTokenProvider jwtTokenProvider;
+
+	@BeforeEach
+	void setUp() {
+		jwtTokenProvider = new JwtTokenProvider(userDetailsService, redisUtils);
+		ReflectionTestUtils.setField(jwtTokenProvider, "secret", SECRET);
+		jwtTokenProvider.init();
+	}
+
+	@Test
+	@DisplayName("같은 초에 연속 발급해도 리프레시 토큰 문자열은 서로 겹치지 않는다")
+	void createRefreshToken_neverCollides() {
+		int issueCount = 1000;
+
+		Set<String> refreshTokens = new HashSet<>();
+		for (int i = 0; i < issueCount; i++) {
+			refreshTokens.add(jwtTokenProvider.createRefreshToken());
+		}
+
+		assertEquals(issueCount, refreshTokens.size());
+	}
+
+	@Test
+	@DisplayName("리프레시 토큰은 jti를 가지며 사용자 식별 정보를 담지 않는다")
+	void createRefreshToken_hasJtiWithoutSubject() {
+		String refreshToken = jwtTokenProvider.createRefreshToken();
+
+		var claims = Jwts.parser()
+			.verifyWith(new SecretKeySpec(SECRET.getBytes(StandardCharsets.UTF_8), "HmacSHA256"))
+			.build()
+			.parseSignedClaims(refreshToken)
+			.getPayload();
+
+		assertNotNull(claims.getId());
+		assertNull(claims.getSubject());
+	}
+}

--- a/app-main/src/test/java/net/causw/app/main/domain/user/auth/handler/OAuth2SuccessHandlerTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/user/auth/handler/OAuth2SuccessHandlerTest.java
@@ -1,0 +1,162 @@
+package net.causw.app.main.domain.user.auth.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseCookie;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import net.causw.app.main.domain.user.account.entity.user.User;
+import net.causw.app.main.domain.user.account.enums.user.SocialType;
+import net.causw.app.main.domain.user.account.service.implementation.UserReader;
+import net.causw.app.main.domain.user.auth.service.dto.CustomOAuth2User;
+import net.causw.app.main.domain.user.auth.service.implementation.AuthTokenManager;
+import net.causw.app.main.domain.user.auth.service.implementation.SocialAccountOauthRefreshStore;
+import net.causw.app.main.domain.user.auth.util.OAuthRedirectResolver;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2SuccessHandlerTest {
+
+	private static final String REDIRECT_BASE = "https://front.test/callback";
+
+	@Mock
+	private AuthTokenManager authTokenManager;
+
+	@Mock
+	private UserReader userReader;
+
+	@Mock
+	private OAuthRedirectResolver oAuthRedirectResolver;
+
+	@Mock
+	private SocialAccountOauthRefreshStore socialAccountOauthRefreshStore;
+
+	@InjectMocks
+	private OAuth2SuccessHandler oAuth2SuccessHandler;
+
+	@Test
+	@DisplayName("OIDC 로그인은 email보다 socialId(sub)로 먼저 유저를 조회한다")
+	void handleLoginSuccess_resolvesOidcUserBySocialIdFirst() throws Exception {
+		//given: email claim은 다른 유저를 가리키지만, socialId로 확정된 유저는 userB
+		User resolvedUser = mock(User.class);
+		given(resolvedUser.getId()).willReturn("user-b");
+
+		OidcIdToken idToken = new OidcIdToken(
+			"apple-id-token",
+			Instant.now(),
+			Instant.MAX,
+			Map.of(
+				"sub", "apple-social-id",
+				"email", "shared@test.com"));
+		OidcUser principal = new DefaultOidcUser(Collections.singleton(() -> "ROLE_USER"), idToken, "sub");
+
+		Authentication authentication = new OAuth2AuthenticationToken(
+			principal, principal.getAuthorities(), "apple");
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		given(userReader.findBySocialTypeAndSocialId(SocialType.APPLE, "apple-social-id"))
+			.willReturn(Optional.of(resolvedUser));
+		given(oAuthRedirectResolver.resolveRedirectBase(request)).willReturn(REDIRECT_BASE);
+		given(oAuthRedirectResolver.clearEnvCookie(request))
+			.willReturn(ResponseCookie.from("oauth_env", "").maxAge(0).build());
+		given(authTokenManager.createRefreshToken("user-b")).willReturn("issued-refresh-token");
+
+		//when
+		oAuth2SuccessHandler.onAuthenticationSuccess(request, response, authentication);
+
+		//then
+		verify(authTokenManager).createRefreshToken("user-b");
+		verify(userReader, never()).findByEmail(any());
+		verify(userReader, never()).findByEmailOrElseThrow(any());
+		assertTrue(response.getRedirectedUrl().contains("refreshToken=issued-refresh-token"));
+	}
+
+	@Test
+	@DisplayName("OIDC 로그인에서 socialId로 못 찾으면 email로 fallback 조회한다")
+	void handleLoginSuccess_fallsBackToEmailForOidcUser() throws Exception {
+		User userByEmail = mock(User.class);
+		given(userByEmail.getId()).willReturn("user-a");
+
+		OidcIdToken idToken = new OidcIdToken(
+			"google-id-token",
+			Instant.now(),
+			Instant.MAX,
+			Map.of(
+				"sub", "google-social-id",
+				"email", "plain@test.com"));
+		OidcUser principal = new DefaultOidcUser(Collections.singleton(() -> "ROLE_USER"), idToken, "sub");
+
+		Authentication authentication = new OAuth2AuthenticationToken(
+			principal, principal.getAuthorities(), "google");
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		given(userReader.findBySocialTypeAndSocialId(SocialType.GOOGLE, "google-social-id"))
+			.willReturn(Optional.empty());
+		given(userReader.findByEmail("plain@test.com")).willReturn(Optional.of(userByEmail));
+		given(oAuthRedirectResolver.resolveRedirectBase(request)).willReturn(REDIRECT_BASE);
+		given(oAuthRedirectResolver.clearEnvCookie(request))
+			.willReturn(ResponseCookie.from("oauth_env", "").maxAge(0).build());
+		given(authTokenManager.createRefreshToken("user-a")).willReturn("issued-refresh-token");
+
+		//when
+		oAuth2SuccessHandler.onAuthenticationSuccess(request, response, authentication);
+
+		//then
+		verify(userReader).findBySocialTypeAndSocialId(SocialType.GOOGLE, "google-social-id");
+		verify(userReader).findByEmail("plain@test.com");
+		verify(authTokenManager).createRefreshToken("user-a");
+	}
+
+	@Test
+	@DisplayName("카카오(CustomOAuth2User) 로그인 경로는 기존 동작을 그대로 유지한다")
+	void handleLoginSuccess_keepsExistingPathForCustomOAuth2User() throws Exception {
+		User kakaoUser = mock(User.class);
+		given(kakaoUser.getEmail()).willReturn("kakao@test.com");
+		given(kakaoUser.getId()).willReturn("user-kakao");
+
+		CustomOAuth2User principal = new CustomOAuth2User(
+			kakaoUser,
+			Map.of("id", "kakao-social-id"),
+			"id");
+
+		Authentication authentication = new OAuth2AuthenticationToken(
+			principal, Collections.singleton(() -> "ROLE_USER"), "kakao");
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		given(userReader.findByEmailOrElseThrow("kakao@test.com")).willReturn(kakaoUser);
+		given(oAuthRedirectResolver.resolveRedirectBase(request)).willReturn(REDIRECT_BASE);
+		given(oAuthRedirectResolver.clearEnvCookie(request))
+			.willReturn(ResponseCookie.from("oauth_env", "").maxAge(0).build());
+		given(authTokenManager.createRefreshToken("user-kakao")).willReturn("issued-refresh-token");
+
+		oAuth2SuccessHandler.onAuthenticationSuccess(request, response, authentication);
+
+		verify(userReader).findByEmailOrElseThrow("kakao@test.com");
+		verify(authTokenManager).createRefreshToken("user-kakao");
+	}
+}

--- a/app-main/src/test/java/net/causw/app/main/shared/infra/redis/RedisUtilsTest.java
+++ b/app-main/src/test/java/net/causw/app/main/shared/infra/redis/RedisUtilsTest.java
@@ -1,0 +1,87 @@
+package net.causw.app.main.shared.infra.redis;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.ValueOperations;
+
+@ExtendWith(MockitoExtension.class)
+class RedisUtilsTest {
+
+	private static final String CLEANUP_KEY = "Migration:CollidedRefreshTokenCleanup:v1";
+
+	@Mock
+	private RedisTemplate<String, Object> redisTemplate;
+
+	@Mock
+	private SetOperations<String, Object> setOperations;
+
+	@Mock
+	private ValueOperations<String, Object> valueOperations;
+
+	@InjectMocks
+	private RedisUtils redisUtils;
+
+	@Test
+	@DisplayName("두 사용자에게 중복 발급된 refresh token만 폐기하고 정상 토큰은 유지한다")
+	void purgeCollidedRefreshTokens_purgesOnlyCollidedTokens() {
+		//given
+		Cursor<String> cursor = cursorOf("UserRefreshTokens:userA", "UserRefreshTokens:userB");
+
+		given(redisTemplate.hasKey(CLEANUP_KEY)).willReturn(false);
+		given(redisTemplate.scan(any(ScanOptions.class))).willReturn(cursor);
+		given(redisTemplate.opsForSet()).willReturn(setOperations);
+		given(setOperations.members("UserRefreshTokens:userA"))
+			.willReturn(Set.of("collided-token", "userA-only-token"));
+		given(setOperations.members("UserRefreshTokens:userB"))
+			.willReturn(Set.of("collided-token"));
+		given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+		//when
+		int purgedCount = redisUtils.purgeCollidedRefreshTokens();
+
+		//then
+		assertEquals(1, purgedCount);
+		verify(redisTemplate).delete("RefreshToken:collided-token");
+		verify(redisTemplate, never()).delete("RefreshToken:userA-only-token");
+		verify(setOperations).remove("UserRefreshTokens:userA", "collided-token");
+		verify(setOperations).remove("UserRefreshTokens:userB", "collided-token");
+		verify(valueOperations).set(CLEANUP_KEY, "DONE");
+	}
+
+	@Test
+	@DisplayName("이미 정리가 수행된 경우 다시 스캔하지 않는다")
+	void purgeCollidedRefreshTokens_skipsWhenAlreadyDone() {
+		given(redisTemplate.hasKey(CLEANUP_KEY)).willReturn(true);
+
+		int purgedCount = redisUtils.purgeCollidedRefreshTokens();
+
+		assertEquals(0, purgedCount);
+		verify(redisTemplate, never()).scan(any(ScanOptions.class));
+	}
+
+	@SuppressWarnings("unchecked")
+	private Cursor<String> cursorOf(String... keys) {
+		Cursor<String> cursor = mock(Cursor.class);
+		Iterator<String> iterator = List.of(keys).iterator();
+		given(cursor.hasNext()).willAnswer(invocation -> iterator.hasNext());
+		given(cursor.next()).willAnswer(invocation -> iterator.next());
+		return cursor;
+	}
+}


### PR DESCRIPTION
### 🚩 관련사항
#1435 


### 📢 전달사항
다른 유저로 로그인되는 이슈에 관련하여, 두 가지 원인에 대한 수정을 진행했습니다.

**1. 리프레시 토큰 문자열 충돌**
- 문제상황: 토큰 payload에 `exp`뿐이라 같은 초에 로그인한 유저들이 동일한 토큰을 받고, Redis 매핑이 덮어써져 다른 유저로 재발급될 수 있습니다.
-> `jti` (UUID)를 추가해 토큰 유일성을 보장합니다.

**2. OIDC 유저 조회 순서 불일치**
- 문제상황: `saveOrUpdate()`는 socialId 우선으로 유저를 확정하는데, `OAuth2SuccessHandler`는 email 우선으로 재조회했습니다. email claim이 바뀌는 경우(애플 이메일 가리기 해제 등) 다른 유저에게 토큰이 발급될 수 있습니다.
-> 핸들러 조회 순서를 socialId(sub) → email로 변경했습니다. 이 과정에서 fallback의 `SocialType.APPLE` 하드코딩(구글은 socialId 조회 불가)도 함께 수정했습니다.
*이슈에는 '확정한 사용자를 principal로 직접 전달'로 적었으나, 조회 순서 변경만으로 결과가 동일하고 변경 범위가 훨씬 작아 이 방식으로 구현했습니다.

**3. 기존 오염 데이터 정리 (1회성 러너)**
- 이미 충돌한 채 살아있는 토큰을 위해, 2명 이상에게 매핑된 토큰만 선별 폐기하는 러너를 추가했습니다. 정상 세션은 유지됩니다.
- 기본 상태는 비활성으로 두었고, github secret의 env 플래그로 1회 실행하면 될 것 같습니다.

### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [x] 리프레시 토큰 jti 추가 + 테스트
- [x] OIDC socialId 우선 조회 + 테스트
- [x] 충돌 토큰 정리 러너 + 테스트
- [ ] 운영에서 정리 러너 1회 실행 및 확인


### ⚙️ 기타사항
**배포 시 적용 절차(1회)**
1. 배포 env에 아래 한 줄 추가 후 배포
`REDIS_MIGRATION_COLLIDED_REFRESH_TOKEN_CLEANUP_ENABLED=true`
2. 로그에서 아래 내용 확인 (N=0이어도 정상)
`[Redis Migration] 중복 발급된 refresh token 정리 완료. purgedCount=N`
4. (선택) 확인 후 배포 env에 적용했던 설정 삭제

개발기간: 2026.08.01 ~ 2026.08.02

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 리프레시 토큰이 발급될 때마다 고유 식별자가 부여되어 중복 발급 가능성이 줄어듭니다.
  - OIDC 로그인 시 소셜 식별자를 우선 확인하고, 필요하면 이메일로 보완 조회합니다.
  - 잘못된 사용자 인증 정보는 더욱 명확하게 처리됩니다.

- **버그 수정**
  - 중복 발급된 리프레시 토큰을 자동으로 정리할 수 있습니다.
  - 정리 작업은 설정에 따라 한 번만 실행되며, 정상 토큰은 유지됩니다.

- **테스트**
  - 토큰 고유성, OIDC 로그인 흐름 및 중복 토큰 정리 동작에 대한 검증이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->