### PR TITLE
Feat/#1456: 게시글 제목 추가

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/request/PostCreateRequest.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/request/PostCreateRequest.java
@@ -9,7 +9,7 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "게시글 생성 요청. multipart/form-data 형식으로 'request' 파트(JSON)와 'images' 파트(파일 배열)로 구성됩니다.")
 public record PostCreateRequest(
-	@Schema(description = "게시글 제목. 선택 사항이며 입력하지 않을 경우 null로 저장됩니다.", example = "학생회 공지사항", nullable = true) String title,
+	@Schema(description = "게시글 제목. 선택 사항이며 생략하거나 null로 전달하면 제목 없이 게시글이 생성되며, 빈 문자열도 제목 없음으로 처리됩니다.", example = "학생회 공지사항", nullable = true) String title,
 
 	@NotBlank(message = "게시글 내용을 입력해 주세요.") @Schema(description = "게시글 내용", example = "안녕하세요. 학생회입니다. 공지사항입니다.") String content,
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/request/PostCreateRequest.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/request/PostCreateRequest.java
@@ -9,8 +9,7 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "게시글 생성 요청. multipart/form-data 형식으로 'request' 파트(JSON)와 'images' 파트(파일 배열)로 구성됩니다.")
 public record PostCreateRequest(
-	@Schema(description = "게시글 제목. 선택 사항이며 입력하지 않을 경우 null로 저장됩니다.", example = "학생회 공지사항")
-	String title,
+	@Schema(description = "게시글 제목. 선택 사항이며 입력하지 않을 경우 null로 저장됩니다.", example = "학생회 공지사항") String title,
 
 	@NotBlank(message = "게시글 내용을 입력해 주세요.") @Schema(description = "게시글 내용", example = "안녕하세요. 학생회입니다. 공지사항입니다.") String content,
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/request/PostCreateRequest.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/request/PostCreateRequest.java
@@ -9,6 +9,9 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "게시글 생성 요청. multipart/form-data 형식으로 'request' 파트(JSON)와 'images' 파트(파일 배열)로 구성됩니다.")
 public record PostCreateRequest(
+	@Schema(description = "게시글 제목. 선택 사항이며 입력하지 않을 경우 null로 저장됩니다.", example = "학생회 공지사항")
+	String title,
+
 	@NotBlank(message = "게시글 내용을 입력해 주세요.") @Schema(description = "게시글 내용", example = "안녕하세요. 학생회입니다. 공지사항입니다.") String content,
 
 	@NotBlank(message = "게시판 id를 입력해 주세요.") @Schema(description = "게시판 id", example = "uuid 형식의 String 값입니다.") String boardId,

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/request/PostCreateRequest.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/request/PostCreateRequest.java
@@ -9,7 +9,7 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "게시글 생성 요청. multipart/form-data 형식으로 'request' 파트(JSON)와 'images' 파트(파일 배열)로 구성됩니다.")
 public record PostCreateRequest(
-	@Schema(description = "게시글 제목. 선택 사항이며 입력하지 않을 경우 null로 저장됩니다.", example = "학생회 공지사항") String title,
+	@Schema(description = "게시글 제목. 선택 사항이며 입력하지 않을 경우 null로 저장됩니다.", example = "학생회 공지사항", nullable = true) String title,
 
 	@NotBlank(message = "게시글 내용을 입력해 주세요.") @Schema(description = "게시글 내용", example = "안녕하세요. 학생회입니다. 공지사항입니다.") String content,
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/request/PostUpdateRequest.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/request/PostUpdateRequest.java
@@ -11,7 +11,7 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "게시글 수정 요청. multipart/form-data 형식으로 'request' 파트(JSON)와 'images' 파트(새 파일 배열)로 구성됩니다.")
 public record PostUpdateRequest(
-	@Schema(description = "게시글 제목. 선택 사항이며 입력하지 않을 경우 null로 처리됩니다.", example = "수정된 게시글 제목", nullable = true) String title,
+	@Schema(description = "게시글 제목. 생략하거나 null이면 기존 제목을 유지하며, 빈 문자열이면 제목을 삭제합니다.", example = "수정된 게시글 제목", nullable = true) String title,
 
 	@NotNull(message = "익명글 여부를 선택해 주세요.") @Schema(description = "익명글 여부", example = "false") Boolean isAnonymous,
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/request/PostUpdateRequest.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/request/PostUpdateRequest.java
@@ -11,6 +11,9 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "게시글 수정 요청. multipart/form-data 형식으로 'request' 파트(JSON)와 'images' 파트(새 파일 배열)로 구성됩니다.")
 public record PostUpdateRequest(
+	@Schema(description = "게시글 제목. 선택 사항이며 입력하지 않을 경우 null로 처리됩니다.", example = "수정된 게시글 제목")
+	String title,
+
 	@NotNull(message = "익명글 여부를 선택해 주세요.") @Schema(description = "익명글 여부", example = "false") Boolean isAnonymous,
 
 	@NotBlank(message = "게시글 내용을 입력해 주세요.") @Schema(description = "게시글 내용", example = "수정된 게시글 내용입니다.") String content,

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/request/PostUpdateRequest.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/request/PostUpdateRequest.java
@@ -11,8 +11,7 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "게시글 수정 요청. multipart/form-data 형식으로 'request' 파트(JSON)와 'images' 파트(새 파일 배열)로 구성됩니다.")
 public record PostUpdateRequest(
-	@Schema(description = "게시글 제목. 선택 사항이며 입력하지 않을 경우 null로 처리됩니다.", example = "수정된 게시글 제목")
-	String title,
+	@Schema(description = "게시글 제목. 선택 사항이며 입력하지 않을 경우 null로 처리됩니다.", example = "수정된 게시글 제목") String title,
 
 	@NotNull(message = "익명글 여부를 선택해 주세요.") @Schema(description = "익명글 여부", example = "false") Boolean isAnonymous,
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/request/PostUpdateRequest.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/request/PostUpdateRequest.java
@@ -11,7 +11,7 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "게시글 수정 요청. multipart/form-data 형식으로 'request' 파트(JSON)와 'images' 파트(새 파일 배열)로 구성됩니다.")
 public record PostUpdateRequest(
-	@Schema(description = "게시글 제목. 선택 사항이며 입력하지 않을 경우 null로 처리됩니다.", example = "수정된 게시글 제목") String title,
+	@Schema(description = "게시글 제목. 선택 사항이며 입력하지 않을 경우 null로 처리됩니다.", example = "수정된 게시글 제목", nullable = true) String title,
 
 	@NotNull(message = "익명글 여부를 선택해 주세요.") @Schema(description = "익명글 여부", example = "false") Boolean isAnonymous,
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/response/PostCreateResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/response/PostCreateResponse.java
@@ -10,6 +10,8 @@ import lombok.Builder;
 public record PostCreateResponse(
 	@Schema(description = "게시글 id", example = "uuid 형식의 String 값입니다.") String id,
 
+	@Schema(description = "게시글 제목", example = "학생회 공지사항") String title,
+
 	@Schema(description = "게시글 내용", example = "안녕하세요. 학생회입니다. 공지사항입니다.") String content,
 
 	@Schema(description = "첨부파일", example = "첨부파일 url 작성") List<String> fileUrlList,

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/response/PostListResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/response/PostListResponse.java
@@ -15,6 +15,7 @@ public record PostListResponse(
 	@Schema(description = "게시글 아이템")
 	public record PostItemResponse(
 		@Schema(description = "게시글 ID") String postId,
+		@Schema(description = "게시글 제목") String title,
 		@Schema(description = "내용") String content,
 		@Schema(description = "댓글 수") long numComment,
 		@Schema(description = "좋아요 수") long numLike,

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/response/PostResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/response/PostResponse.java
@@ -10,6 +10,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record PostResponse(
 	@Schema(description = "게시글 id", example = "uuid 형식의 String 값입니다.") String id,
 
+	@Schema(description = "게시글 제목", example = "학생회 공지사항") String title,
+
 	@Schema(description = "게시글 내용", example = "안녕하세요. 학생회입니다. 공지사항입니다.") String content,
 
 	@Schema(description = "게시글 삭제여부", example = "false") Boolean isDeleted,

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/response/PostUpdateResponse.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/response/PostUpdateResponse.java
@@ -8,6 +8,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record PostUpdateResponse(
 	@Schema(description = "게시글 id", example = "uuid 형식의 String 값입니다.") String id,
 
+	@Schema(description = "게시글 제목", example = "학생회 공지사항") String title,
+
 	@Schema(description = "게시글 내용", example = "수정된 게시글 내용입니다.") String content,
 
 	@Schema(description = "작성자 Id", example = "uuid-uuid") String writerId,

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/mapper/PostDtoMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/mapper/PostDtoMapper.java
@@ -39,6 +39,7 @@ public interface PostDtoMapper {
 				.toList();
 		}
 		return new PostCreateCommand(
+			request.title(),
 			request.content(),
 			request.boardId(),
 			request.isAnonymous(),
@@ -64,6 +65,7 @@ public interface PostDtoMapper {
 		}
 		return new PostUpdateCommand(
 			postId,
+			request.title(),
 			request.content(),
 			request.isAnonymous(),
 			user,

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/entity/Post.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/entity/Post.java
@@ -151,7 +151,7 @@ public class Post extends BaseEntity {
 	}
 
 	public void update(String title, String content, Boolean isAnonymous, List<PostAttachImage> postAttachImageList) {
-		this.title = title;
+		this.title = title != null ? title : this.title;
 		this.content = content;
 		this.isAnonymous = (isAnonymous != null) ? isAnonymous : this.isAnonymous;
 		this.postAttachImageList.clear();

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/entity/Post.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/entity/Post.java
@@ -150,10 +150,10 @@ public class Post extends BaseEntity {
 		return post;
 	}
 
-	public void update(String title, String content, Form form, List<PostAttachImage> postAttachImageList) {
+	public void update(String title, String content, Boolean isAnonymous, List<PostAttachImage> postAttachImageList) {
 		this.title = title;
 		this.content = content;
-		this.form = form;
+		this.isAnonymous = (isAnonymous != null) ? isAnonymous : this.isAnonymous;
 		this.postAttachImageList.clear();
 		this.postAttachImageList.addAll(postAttachImageList);
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/entity/Post.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/entity/Post.java
@@ -42,7 +42,7 @@ import lombok.NoArgsConstructor;
 	@Index(name = "post_cursor_index", columnList = "created_at, id")
 })
 public class Post extends BaseEntity {
-	@Deprecated
+
 	@Column(name = "title", nullable = true)
 	private String title;
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/repository/query/PostCursorResult.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/repository/query/PostCursorResult.java
@@ -12,6 +12,7 @@ import com.querydsl.core.annotations.QueryProjection;
  */
 public record PostCursorResult(
 	String postId,
+	String title,
 	String content,
 	long numComment,
 	long numLike,

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/repository/query/PostQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/repository/query/PostQueryRepository.java
@@ -449,7 +449,7 @@ public class PostQueryRepository {
 			.where(upi.user.id.eq(post.writer.id));
 
 		return new QPostCursorResult(
-			post.id, post.content,
+			post.id, post.title, post.content,
 			totalCommentCount, likeCount,
 			post.isAnonymous, post.vote.id, post.isDeleted,
 			post.isCrawled,

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/PostService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/PostService.java
@@ -148,8 +148,12 @@ public class PostService {
 			post, command.newImageFiles(), command.imageMetas());
 
 		// 게시글 업데이트
-		Post updatedPost = postWriter.updateContentAndImages(
-			post, command.content(), command.isAnonymous(), imageResult.finalImages());
+		Post updatedPost = postWriter.update(
+			post,
+			command.title(),
+			command.content(),
+			post.getForm(),
+			imageResult.finalImages());
 
 		List<String> imageUrls = imageResult.finalImages().stream()
 			.map(img -> img.getUuidFile().getFileUrl())

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/PostService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/PostService.java
@@ -152,7 +152,7 @@ public class PostService {
 			post,
 			command.title(),
 			command.content(),
-			post.getForm(),
+			command.isAnonymous(),
 			imageResult.finalImages());
 
 		List<String> imageUrls = imageResult.finalImages().stream()

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/dto/PostCreateCommand.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/dto/PostCreateCommand.java
@@ -7,6 +7,7 @@ import org.springframework.web.multipart.MultipartFile;
 import net.causw.app.main.domain.user.account.entity.user.User;
 
 public record PostCreateCommand(
+	String title,
 	String content,
 	String boardId,
 	Boolean isAnonymous,

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/dto/PostCreateResult.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/dto/PostCreateResult.java
@@ -10,6 +10,8 @@ import lombok.Builder;
 public record PostCreateResult(
 	@Schema(description = "게시글 id", example = "uuid 형식의 String 값입니다.") String id,
 
+	@Schema(description = "게시글 제목", example = "학생회 공지사항") String title,
+
 	@Schema(description = "게시글 내용", example = "안녕하세요. 학생회입니다. 공지사항입니다.") String content,
 
 	@Schema(description = "작성자 Id", example = "uuid-uuid]") String writerId,

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/dto/PostDetailResult.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/dto/PostDetailResult.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 @Builder
 public record PostDetailResult(
 	String id,
+	String title,
 	String content,
 	Boolean isDeleted,
 	String displayWriterNickname,

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/dto/PostListResult.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/dto/PostListResult.java
@@ -15,6 +15,7 @@ public record PostListResult(
 
 	public record PostItem(
 		String postId,
+		String title,
 		String content,
 		long numComment,
 		long numLike,
@@ -36,6 +37,7 @@ public record PostListResult(
 		boolean isOfficial) {
 		public static PostItem of(
 			String postId,
+			String title,
 			String content,
 			long numComment,
 			long numLike,
@@ -56,7 +58,7 @@ public record PostListResult(
 			boolean deletable,
 			boolean isOfficial) {
 			return new PostItem(
-				postId, content, numComment, numLike,
+				postId, title, content, numComment, numLike,
 				isAnonymous, voteId, isDeleted, isCrawled,
 				writerNickname, writerProfileImage,
 				createdAt, updatedAt, postImageUrls,

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/dto/PostUpdateCommand.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/dto/PostUpdateCommand.java
@@ -8,6 +8,7 @@ import net.causw.app.main.domain.user.account.entity.user.User;
 
 public record PostUpdateCommand(
 	String postId,
+	String title,
 	String content,
 	Boolean isAnonymous,
 	User updater,

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/dto/PostUpdateResult.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/dto/PostUpdateResult.java
@@ -10,6 +10,8 @@ import lombok.Builder;
 public record PostUpdateResult(
 	@Schema(description = "게시글 id", example = "uuid 형식의 String 값입니다.") String id,
 
+	@Schema(description = "게시글 제목", example = "학생회 공지사항") String title,
+
 	@Schema(description = "게시글 내용", example = "수정된 게시글 내용입니다.") String content,
 
 	@Schema(description = "작성자 Id", example = "uuid-uuid") String writerId,

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/implementation/PostWriter.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/implementation/PostWriter.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import net.causw.app.main.domain.asset.file.entity.joinEntity.PostAttachImage;
-import net.causw.app.main.domain.community.form.entity.Form;
 import net.causw.app.main.domain.community.form.repository.FormRepository;
 import net.causw.app.main.domain.community.post.entity.Post;
 import net.causw.app.main.domain.community.post.repository.PostRepository;
@@ -42,12 +41,13 @@ public class PostWriter {
 	 * @param post 수정할 Post
 	 * @param title 제목
 	 * @param content 내용
-	 * @param form Form Entity
+	 * @param isAnonymous 익명 여부 (null 허용 - null이면 기존 값 유지)
 	 * @param postAttachImageList 첨부 이미지 리스트
 	 * @return 수정된 Post Entity
 	 */
-	public Post update(Post post, String title, String content, Form form, List<PostAttachImage> postAttachImageList) {
-		post.update(title, content, form, postAttachImageList);
+	public Post update(Post post, String title, String content, Boolean isAnonymous,
+		List<PostAttachImage> postAttachImageList) {
+		post.update(title, content, isAnonymous, postAttachImageList);
 		return postRepository.save(post);
 	}
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/mapper/PostMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/mapper/PostMapper.java
@@ -26,7 +26,8 @@ public class PostMapper {
 
 	public static Post fromCreateCommand(PostCreateCommand command, User writer, Board board,
 		List<UuidFile> images) {
-		return Post.of(null,
+		return Post.of(
+			command.title(),
 			command.content(),
 			writer,
 			command.isAnonymous(),
@@ -37,6 +38,7 @@ public class PostMapper {
 	public static PostCreateResult toCreateResult(Post post, List<String> images) {
 		return PostCreateResult.builder()
 			.id(post.getId())
+			.title(post.getTitle())
 			.content(post.getContent())
 			.isAnonymous(post.getIsAnonymous())
 			.fileUrlList(images)
@@ -50,6 +52,7 @@ public class PostMapper {
 	public static PostUpdateResult toUpdateResult(Post post, List<String> images) {
 		return PostUpdateResult.builder()
 			.id(post.getId())
+			.title(post.getTitle())
 			.content(post.getContent())
 			.isAnonymous(post.getIsAnonymous())
 			.fileUrlList(images)
@@ -95,6 +98,7 @@ public class PostMapper {
 
 		return PostListResult.PostItem.of(
 			result.postId(),
+			result.title(),
 			result.content(),
 			result.numComment(),
 			result.numLike(),
@@ -172,6 +176,7 @@ public class PostMapper {
 
 		return PostDetailResult.builder()
 			.id(post.getId())
+			.title(post.getTitle())
 			.content(post.getContent())
 			.isDeleted(post.getIsDeleted())
 			.displayWriterNickname(displayWriterNickname)

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/mapper/PostMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/mapper/PostMapper.java
@@ -26,8 +26,11 @@ public class PostMapper {
 
 	public static Post fromCreateCommand(PostCreateCommand command, User writer, Board board,
 		List<UuidFile> images) {
+
+		String title = command.title();
+
 		return Post.of(
-			command.title(),
+			title == null || title.isBlank() ? null : title,
 			command.content(),
 			writer,
 			command.isAnonymous(),

--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/CrawledToPostTransferService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/CrawledToPostTransferService.java
@@ -94,7 +94,8 @@ public class CrawledToPostTransferService {
 
 		if (existingPost != null) {
 			// 기존 Post 업데이트
-			existingPost.update(title, contentHtml, existingPost.getForm(), existingPost.getPostAttachImageList());
+			existingPost.update(title, contentHtml, existingPost.getIsAnonymous(),
+				existingPost.getPostAttachImageList());
 			postRepository.save(existingPost);
 
 			// 기존 크롤링 이미지 교체

--- a/app-main/src/test/java/net/causw/app/main/domain/community/post/service/PostServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/community/post/service/PostServiceTest.java
@@ -150,6 +150,7 @@ public class PostServiceTest {
 		void createPost_shouldSucceed_withoutImages() {
 			// given
 			PostCreateCommand command = new PostCreateCommand(
+				"테스트 게시글 제목",
 				"테스트 게시글 내용",
 				boardId,
 				false,
@@ -157,7 +158,7 @@ public class PostServiceTest {
 				null,
 				null);
 
-			Post mockPost = Post.of(null, "테스트 게시글 내용", writer, false, board, List.of());
+			Post mockPost = Post.of("테스트 게시글 제목", "테스트 게시글 내용", writer, false, board, List.of());
 			ReflectionTestUtils.setField(mockPost, "id", "post-id");
 			ReflectionTestUtils.setField(mockPost, "createdAt", LocalDateTime.now());
 			ReflectionTestUtils.setField(mockPost, "updatedAt", LocalDateTime.now());
@@ -176,6 +177,7 @@ public class PostServiceTest {
 			assertAll(
 				() -> assertThat(result).isNotNull(),
 				() -> assertThat(result.id()).isEqualTo("post-id"),
+				() -> assertThat(result.title()).isEqualTo("테스트 게시글 제목"),
 				() -> assertThat(result.content()).isEqualTo("테스트 게시글 내용"),
 				() -> assertThat(result.writerId()).isEqualTo("writer-id"),
 				() -> assertThat(result.isAnonymous()).isFalse(),
@@ -198,6 +200,7 @@ public class PostServiceTest {
 				new ImageCreateMeta(0, 0, true));
 
 			PostCreateCommand command = new PostCreateCommand(
+				"테스트 게시글 제목",
 				"테스트 게시글 내용",
 				boardId,
 				false,
@@ -215,7 +218,7 @@ public class PostServiceTest {
 
 			PostAttachImage mockAttachImage = PostAttachImage.of(null, mockUuidFile, 0, true);
 
-			Post mockPost = Post.of(null, "테스트 게시글 내용", writer, false, board, List.of());
+			Post mockPost = Post.of("테스트 게시글 제목", "테스트 게시글 내용", writer, false, board, List.of());
 			ReflectionTestUtils.setField(mockPost, "id", "post-id");
 			ReflectionTestUtils.setField(mockPost, "createdAt", LocalDateTime.now());
 			ReflectionTestUtils.setField(mockPost, "updatedAt", LocalDateTime.now());
@@ -234,6 +237,7 @@ public class PostServiceTest {
 			assertAll(
 				() -> assertThat(result).isNotNull(),
 				() -> assertThat(result.id()).isEqualTo("post-id"),
+				() -> assertThat(result.title()).isEqualTo("테스트 게시글 제목"),
 				() -> assertThat(result.content()).isEqualTo("테스트 게시글 내용"),
 				() -> assertThat(result.fileUrlList()).hasSize(1),
 				() -> assertThat(result.fileUrlList().get(0)).isEqualTo("https://example.com/image.jpg"));
@@ -247,6 +251,7 @@ public class PostServiceTest {
 		void createPost_shouldSucceed_asAnonymous() {
 			// given
 			PostCreateCommand command = new PostCreateCommand(
+				"익명 게시글 제목",
 				"익명 게시글",
 				boardId,
 				true,
@@ -254,7 +259,7 @@ public class PostServiceTest {
 				null,
 				null);
 
-			Post mockPost = Post.of(null, "익명 게시글", writer, true, board, List.of());
+			Post mockPost = Post.of("익명 게시글 제목", "익명 게시글", writer, true, board, List.of());
 			ReflectionTestUtils.setField(mockPost, "id", "post-id");
 			ReflectionTestUtils.setField(mockPost, "createdAt", LocalDateTime.now());
 			ReflectionTestUtils.setField(mockPost, "updatedAt", LocalDateTime.now());
@@ -294,6 +299,7 @@ public class PostServiceTest {
 				null);
 
 			PostCreateCommand command = new PostCreateCommand(
+				"익명 게시글 제목",
 				"익명 게시글",
 				boardId,
 				true, // 익명으로 작성 시도
@@ -451,7 +457,7 @@ public class PostServiceTest {
 			boardId = "board-id";
 			board = ObjectFixtures.getBoardV2WithId(boardId);
 			postId = "post-id";
-			post = Post.of(null, "원본 내용", updater, false, board, List.of());
+			post = Post.of("원본 제목", "원본 내용", updater, false, board, List.of());
 			ReflectionTestUtils.setField(post, "id", postId);
 			ReflectionTestUtils.setField(post, "createdAt", LocalDateTime.now());
 			ReflectionTestUtils.setField(post, "updatedAt", LocalDateTime.now());
@@ -463,6 +469,7 @@ public class PostServiceTest {
 			// given
 			PostUpdateCommand command = new PostUpdateCommand(
 				postId,
+				"수정된 제목",
 				"수정된 내용",
 				false,
 				updater,
@@ -486,8 +493,12 @@ public class PostServiceTest {
 			given(boardConfigReader.getAdminIdsByBoardId(boardId)).willReturn(boardAdminIds);
 			given(postImageManager.mergeAndBuildForUpdate(eq(post), isNull(), isNull()))
 				.willReturn(new PostImageManager.ImageUpdateResult(List.of(), List.of()));
-			given(postWriter.updateContentAndImages(eq(post), eq("수정된 내용"), eq(false), anyList()))
-				.willReturn(post);
+			given(postWriter.update(
+				eq(post),
+				eq("수정된 제목"),
+				eq("수정된 내용"),
+				eq(false),
+				anyList())).willReturn(post);
 
 			// when
 			PostUpdateResult result = postService.update(command);
@@ -497,7 +508,11 @@ public class PostServiceTest {
 				() -> assertThat(result).isNotNull(),
 				() -> assertThat(result.id()).isEqualTo(postId));
 
-			verify(postWriter, times(1)).updateContentAndImages(eq(post), eq("수정된 내용"), eq(false),
+			verify(postWriter, times(1)).update(
+				eq(post),
+				eq("수정된 제목"),
+				eq("수정된 내용"),
+				eq(false),
 				anyList());
 		}
 
@@ -521,6 +536,7 @@ public class PostServiceTest {
 
 			PostUpdateCommand command = new PostUpdateCommand(
 				postId,
+				null,
 				"수정된 내용",
 				false,
 				updater,
@@ -550,8 +566,12 @@ public class PostServiceTest {
 			given(postImageManager.mergeAndBuildForUpdate(eq(post), eq(newImageFiles), eq(imageMetas)))
 				.willReturn(new PostImageManager.ImageUpdateResult(
 					List.of(newAttachImage), List.of("old-file-id")));
-			given(postWriter.updateContentAndImages(eq(post), eq("수정된 내용"), eq(false), anyList()))
-				.willReturn(post);
+			given(postWriter.update(
+				eq(post),
+				isNull(),
+				eq("수정된 내용"),
+				eq(false),
+				anyList())).willReturn(post);
 
 			// when
 			PostUpdateResult result = postService.update(command);
@@ -573,6 +593,7 @@ public class PostServiceTest {
 
 			PostUpdateCommand command = new PostUpdateCommand(
 				postId,
+				null,
 				"수정된 내용",
 				true, // 익명으로 변경 시도
 				updater,
@@ -599,7 +620,7 @@ public class PostServiceTest {
 			assertThatThrownBy(() -> postService.update(command))
 				.hasMessageContaining("비익명 게시판에서 익명으로 작성할 수 없습니다.");
 
-			verify(postWriter, never()).updateContentAndImages(any(), any(), any(), anyList());
+			verify(postWriter, never()).update(any(), any(), any(), any(), anyList());
 		}
 	}
 
@@ -670,6 +691,7 @@ public class PostServiceTest {
 
 			PostCursorResult postCursorResult = new PostCursorResult(
 				"post-id",
+				"테스트 제목",
 				"게시글 내용",
 				5L,
 				10L,
@@ -729,6 +751,7 @@ public class PostServiceTest {
 			PostListQuery query = PostListQuery.of(viewer, List.of(boardId), null, 20, null);
 			PostCursorResult deletedPostResult = new PostCursorResult(
 				"deleted-post-id",
+				"테스트 제목",
 				"삭제된 게시글",
 				0L,
 				0L,
@@ -791,6 +814,7 @@ public class PostServiceTest {
 
 			PostCursorResult postCursorResult1 = new PostCursorResult(
 				"post-id-1",
+				"테스트 제목",
 				"게시판1 게시글 내용",
 				5L,
 				10L,
@@ -813,6 +837,7 @@ public class PostServiceTest {
 
 			PostCursorResult postCursorResult2 = new PostCursorResult(
 				"post-id-2",
+				"테스트 제목",
 				"게시판2 게시글 내용",
 				3L,
 				8L,
@@ -888,6 +913,7 @@ public class PostServiceTest {
 
 			PostCursorResult postCursorResult = new PostCursorResult(
 				"post-id-2",
+				"게시글 제목",
 				"게시글 내용",
 				5L,
 				10L,
@@ -956,6 +982,7 @@ public class PostServiceTest {
 
 			PostCursorResult postCursorResult = new PostCursorResult(
 				"post-id",
+				"검색 결과 제목",
 				"검색어가 포함된 게시글 내용",
 				5L,
 				10L,
@@ -1011,6 +1038,7 @@ public class PostServiceTest {
 
 			PostCursorResult postCursorResult = new PostCursorResult(
 				"post-id",
+				"테스트 제목",
 				"게시글 내용",
 				5L,
 				10L,
@@ -1145,6 +1173,7 @@ public class PostServiceTest {
 
 			PostCursorResult anonymousPostResult = new PostCursorResult(
 				"post-id",
+				"익명 게시글 제목",
 				"익명 게시글 내용",
 				5L,
 				10L,
@@ -1204,6 +1233,7 @@ public class PostServiceTest {
 
 			PostCursorResult normalPostResult = new PostCursorResult(
 				"post-id-1",
+				"일반 게시글 제목",
 				"일반 게시글 내용",
 				5L,
 				10L,
@@ -1226,6 +1256,7 @@ public class PostServiceTest {
 
 			PostCursorResult anonymousPostResult = new PostCursorResult(
 				"post-id-2",
+				"익명 게시글 제목",
 				"익명 게시글 내용",
 				3L,
 				8L,


### PR DESCRIPTION
### 🚩 관련사항
Closes #1456 


### 📢 전달사항
기존 커뮤니티 탭이 소식 탭으로 변경됨에 따라, Post마다 제목이 추가되었고 이를 위해 deprecated 되었던 제목(title)을 추가해 게시글 생성, 수정, 조회 과정에서 제목을 함께 관리할 수 있도록 변경했습니다.

주요 변경 사항은 다음과 같습니다.

* 게시글 생성 시 제목 저장
* 게시글 수정 시 제목 수정 지원
* 게시글 목록 조회 시 제목 반환
* 게시글 상세 조회 시 제목 반환
* 크롤링 게시글 생성 및 수정 과정에서 제목 처리
* 게시글 생성/수정 관련 테스트에 제목 검증 추가
* 기존 게시글 수정 로직과의 호환성 확인

#### 집중적으로 확인해 주실 부분

* 게시글 생성/수정 시 title이 정상적으로 저장되는지
* 목록/상세 조회에서 제목이 정상적으로 반환되는지
* 기존 크롤링 게시글 수정 로직에 영향이 없는지
* 제목이 nullable인 기존 게시글 데이터와의 호환성


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [x] 게시글 Entity에 제목 필드 deprecated 삭제
- [x] 게시글 생성 로직에 제목 반영
- [x] 게시글 수정 로직에 제목 반영
- [x] 게시글 목록 조회에 제목 반영
- [x] 게시글 상세 조회에 제목 반영
- [x] 크롤링 게시글 처리 로직에 제목 반영
- [x] 게시글 관련 테스트 수정 및 추가


### ⚙️ 기타사항
- 기존 게시글의 제목 데이터가 없는 경우를 고려하여 기존 데이터와의 호환성을 유지합니다.

개발기간: 2026.08.14 ~ 2026.08.15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 게시글 작성 및 수정 시 선택적으로 제목을 입력할 수 있습니다.
  * 게시글 생성, 상세 조회, 목록 조회 및 수정 결과에 제목이 표시됩니다.
  * 제목을 입력하지 않으면 제목 없이 게시글이 생성되며, Swagger 문서에 입력 설명과 예시가 제공됩니다.

* **버그 수정**
  * 게시글 수정 시 익명 여부를 지정하지 않으면 기존 설정이 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->