### PR TITLE
feat: CAU AI학과 공지 크롤러 추가

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/config/CrawlerType.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/config/CrawlerType.java
@@ -1,5 +1,6 @@
 package net.causw.app.main.domain.integration.crawled.config;
 
 public enum CrawlerType {
-	CAU_SW_NOTICE
+	CAU_SW_NOTICE,
+	CAU_AI_NOTICE
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauAiNoticeCrawler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauAiNoticeCrawler.java
@@ -1,0 +1,132 @@
+package net.causw.app.main.domain.integration.crawled.crawler.implementation;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Component;
+
+import net.causw.app.main.domain.integration.crawled.client.CrawlHttpClient;
+import net.causw.app.main.domain.integration.crawled.config.CrawlerType;
+import net.causw.app.main.domain.integration.crawled.core.CrawlContext;
+import net.causw.app.main.domain.integration.crawled.crawler.SiteCrawler;
+import net.causw.app.main.domain.integration.crawled.dto.ArticleUrl;
+import net.causw.app.main.domain.integration.crawled.dto.RawArticle;
+import net.causw.app.main.domain.integration.crawled.dto.RawAttachment;
+import net.causw.app.main.domain.integration.crawled.entity.SiteConfig;
+import net.causw.app.main.domain.integration.crawled.entity.SiteSelectors;
+import net.causw.app.main.shared.exception.errorcode.IntegrationErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CauAiNoticeCrawler implements SiteCrawler {
+	private static final Pattern NOTICE_NO_PATTERN = Pattern.compile("[?&]no=(\\d+)");
+
+	private final CrawlHttpClient crawlHttpClient;
+
+	@Override
+	public CrawlerType getCrawlerType() {
+		return CrawlerType.CAU_AI_NOTICE;
+	}
+
+	@Override
+	public List<ArticleUrl> fetchList(CrawlContext context) {
+		SiteConfig siteConfig = context.siteConfig();
+		List<ArticleUrl> articleUrls = new ArrayList<>();
+		SiteSelectors selectors = siteConfig.getSelectors();
+		log.debug("[크롤링] AI학과 공지 목록 수집 시작. siteId={}, maxPages={}, maxArticles={}",
+			siteConfig.getSiteId(), siteConfig.getMaxPages(), siteConfig.getMaxArticles());
+
+		for (int page = 1; page <= siteConfig.getMaxPages()
+			&& articleUrls.size() < siteConfig.getMaxArticles(); page++) {
+			String listUrl = siteConfig.getListUrl() + page;
+			Document document = Jsoup.parse(crawlHttpClient.fetch(listUrl, siteConfig), listUrl);
+			Elements rows = document.select(selectors.getArticleRow());
+			if (rows.isEmpty()) {
+				break;
+			}
+
+			for (Element row : rows) {
+				if (articleUrls.size() >= siteConfig.getMaxArticles()) {
+					break;
+				}
+				Element linkElement = row.selectFirst(selectors.getArticleLink());
+				if (linkElement == null) {
+					continue;
+				}
+				String url = linkElement.absUrl("href");
+				if (url.isBlank()) {
+					continue;
+				}
+				articleUrls
+					.add(new ArticleUrl(url, extractNoticeId(url), row.select(selectors.getArticleCategory()).text()));
+			}
+		}
+
+		return articleUrls.stream().distinct().toList();
+	}
+
+	private String extractNoticeId(String url) {
+		Matcher matcher = NOTICE_NO_PATTERN.matcher(url);
+		if (!matcher.find()) {
+			throw IntegrationErrorCode.CRAWL_PARSE_FAILED.toBaseException();
+		}
+		return matcher.group(1);
+	}
+
+	@Override
+	public RawArticle fetchArticle(CrawlContext context, ArticleUrl articleUrl) {
+		SiteConfig siteConfig = context.siteConfig();
+		try {
+			Document document = Jsoup.parse(crawlHttpClient.fetch(articleUrl.url(), siteConfig), articleUrl.url());
+			SiteSelectors selectors = siteConfig.getSelectors();
+			Element contentElement = document.selectFirst(selectors.getBody());
+			String contentHtml = contentElement == null ? "<p>내용 없음</p>" : contentElement.html();
+			String imageUrl = document.select(selectors.getRepresentativeImage()).attr("abs:src");
+			return new RawArticle(
+				siteConfig.getSiteId(), articleUrl.externalId(), articleUrl.url(), articleUrl.category(),
+				requiredText(document, selectors.getTitle()), contentHtml,
+				requiredText(document, selectors.getAuthor()), requiredText(document, selectors.getDate()), imageUrl,
+				extractAttachments(document));
+		} catch (RuntimeException e) {
+			log.error("[크롤링] AI학과 공지 파싱 실패. crawlerType={}, siteId={}, url={}",
+				CrawlerType.CAU_AI_NOTICE, siteConfig.getSiteId(), articleUrl.url(), e);
+			throw IntegrationErrorCode.CRAWL_PARSE_FAILED.toBaseException();
+		}
+	}
+
+	private String requiredText(Document document, String selector) {
+		Element element = document.selectFirst(selector);
+		if (element == null || element.text().isBlank()) {
+			throw IntegrationErrorCode.CRAWL_PARSE_FAILED.toBaseException();
+		}
+		return element.text();
+	}
+
+	private List<RawAttachment> extractAttachments(Document document) {
+		Map<String, RawAttachment> attachments = new LinkedHashMap<>();
+		addAttachments(document.select("div.files a[href], div.fr-view a[href*='download']"), attachments);
+		return List.copyOf(attachments.values());
+	}
+
+	private void addAttachments(Elements elements, Map<String, RawAttachment> attachments) {
+		for (Element element : elements) {
+			String fileName = element.text().trim();
+			String fileUrl = element.absUrl("href");
+			if (!fileName.isBlank() && !fileName.equals("첨부파일") && !fileName.equals("파일") && !fileUrl.isBlank()) {
+				attachments.putIfAbsent(fileUrl, new RawAttachment(fileName, fileUrl));
+			}
+		}
+	}
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauAiNoticeCrawler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauAiNoticeCrawler.java
@@ -1,6 +1,5 @@
 package net.causw.app.main.domain.integration.crawled.crawler.implementation;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,13 +42,13 @@ public class CauAiNoticeCrawler implements SiteCrawler {
 	@Override
 	public List<ArticleUrl> fetchList(CrawlContext context) {
 		SiteConfig siteConfig = context.siteConfig();
-		List<ArticleUrl> articleUrls = new ArrayList<>();
+		Map<String, ArticleUrl> articleUrlsByExternalId = new LinkedHashMap<>();
 		SiteSelectors selectors = siteConfig.getSelectors();
 		log.debug("[크롤링] AI학과 공지 목록 수집 시작. siteId={}, maxPages={}, maxArticles={}",
 			siteConfig.getSiteId(), siteConfig.getMaxPages(), siteConfig.getMaxArticles());
 
 		for (int page = 1; page <= siteConfig.getMaxPages()
-			&& articleUrls.size() < siteConfig.getMaxArticles(); page++) {
+			&& articleUrlsByExternalId.size() < siteConfig.getMaxArticles(); page++) {
 			String listUrl = siteConfig.getListUrl() + page;
 			Document document = Jsoup.parse(crawlHttpClient.fetch(listUrl, siteConfig), listUrl);
 			Elements rows = document.select(selectors.getArticleRow());
@@ -58,7 +57,7 @@ public class CauAiNoticeCrawler implements SiteCrawler {
 			}
 
 			for (Element row : rows) {
-				if (articleUrls.size() >= siteConfig.getMaxArticles()) {
+				if (articleUrlsByExternalId.size() >= siteConfig.getMaxArticles()) {
 					break;
 				}
 				Element linkElement = row.selectFirst(selectors.getArticleLink());
@@ -69,12 +68,13 @@ public class CauAiNoticeCrawler implements SiteCrawler {
 				if (url.isBlank()) {
 					continue;
 				}
-				articleUrls
-					.add(new ArticleUrl(url, extractNoticeId(url), row.select(selectors.getArticleCategory()).text()));
+				String externalId = extractNoticeId(url);
+				articleUrlsByExternalId.putIfAbsent(externalId,
+					new ArticleUrl(url, externalId, row.select(selectors.getArticleCategory()).text()));
 			}
 		}
 
-		return articleUrls.stream().distinct().toList();
+		return List.copyOf(articleUrlsByExternalId.values());
 	}
 
 	private String extractNoticeId(String url) {

--- a/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/SiteConfigFixture.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/SiteConfigFixture.java
@@ -69,4 +69,36 @@ public final class SiteConfigFixture {
 			false,
 			true);
 	}
+
+	public static SiteConfig cauAiNotice() {
+		return SiteConfig.of(
+			"cau-ai-notice",
+			"target-board-id",
+			CrawlerType.CAU_AI_NOTICE,
+			"https://ai.cau.ac.kr/sub07/sub0701.php?category=1&view=list&currentPage=",
+			"https://ai.cau.ac.kr",
+			Map.of(),
+			Duration.ZERO,
+			Duration.ofSeconds(1),
+			1,
+			30,
+			3,
+			PaginationType.PAGE_NUMBER,
+			"currentPage",
+			1,
+			SiteSelectors.of(
+				"table.table-basic tbody tr",
+				"td.title a",
+				"td:first-child",
+				"section.board div.header > h3",
+				"section.board div.fr-view.detail",
+				"section.board div.header > div > span:nth-of-type(1)",
+				"section.board div.header > div > span:nth-of-type(2)",
+				"section.board div.fr-view.detail img",
+				"yyyy-MM-dd HH:mm:ss",
+				null),
+			false,
+			false,
+			true);
+	}
 }

--- a/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauAiNoticeCrawlerTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauAiNoticeCrawlerTest.java
@@ -1,0 +1,85 @@
+package net.causw.app.main.domain.integration.crawled.crawler.implementation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import net.causw.app.main.domain.integration.crawled.SiteConfigFixture;
+import net.causw.app.main.domain.integration.crawled.client.CrawlHttpClient;
+import net.causw.app.main.domain.integration.crawled.core.CrawlContext;
+import net.causw.app.main.domain.integration.crawled.dto.ArticleUrl;
+import net.causw.app.main.domain.integration.crawled.dto.RawArticle;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CauAiNoticeCrawler 테스트")
+class CauAiNoticeCrawlerTest {
+	@InjectMocks
+	private CauAiNoticeCrawler crawler;
+
+	@Mock
+	private CrawlHttpClient crawlHttpClient;
+	private final CrawlContext context = new CrawlContext(SiteConfigFixture.cauAiNotice());
+
+	@Nested
+	@DisplayName("목록 수집")
+	class FetchList {
+		@Test
+		@DisplayName("공지 URL의 no를 외부 식별자로 사용한다")
+		void shouldUseNoAsExternalId_whenNoticeUrlIsFetched() {
+			// given
+			given(crawlHttpClient.fetch(any(), any())).willReturn("""
+				<table class='table-basic'><tbody>
+				<tr><td><span class='tag blue'>공지</span></td>
+				<td class='title'><a href='?category=1&view=detail&no=3491&keyword=&search=title'>AI 공지</a></td></tr>
+				</tbody></table>
+				""");
+
+			// when
+			List<ArticleUrl> result = crawler.fetchList(context);
+
+			// then
+			assertThat(result).containsExactly(new ArticleUrl(
+				"https://ai.cau.ac.kr/sub07/sub0701.php?category=1&view=detail&no=3491&keyword=&search=title",
+				"3491", "공지"));
+		}
+	}
+
+	@Nested
+	@DisplayName("상세 수집")
+	class FetchArticle {
+		@Test
+		@DisplayName("상세 HTML의 공지 필드와 첨부파일을 파싱한다")
+		void shouldParseNoticeFields() {
+			// given
+			ArticleUrl articleUrl = new ArticleUrl(
+				"https://ai.cau.ac.kr/sub07/sub0701.php?category=1&view=detail&no=3491", "3491", "공지");
+			given(crawlHttpClient.fetch(articleUrl.url(), context.siteConfig())).willReturn("""
+				<section class='board'>
+				<div class='header'><h3>AI 공지 제목</h3><div><span>2026-08-20 13:27:52</span><span>관리자</span></div></div>
+				<div class='fr-view detail'><p>본문</p><img src='/image.png'></div>
+				<div class='files'><a href='/board/download.php?id=1'>자료.pdf</a></div>
+				</section>
+				""");
+
+			// when
+			RawArticle result = crawler.fetchArticle(context, articleUrl);
+
+			// then
+			assertThat(result.title()).isEqualTo("AI 공지 제목");
+			assertThat(result.author()).isEqualTo("관리자");
+			assertThat(result.attachments()).containsExactly(
+				new net.causw.app.main.domain.integration.crawled.dto.RawAttachment(
+					"자료.pdf", "https://ai.cau.ac.kr/board/download.php?id=1"));
+		}
+	}
+}

--- a/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauAiNoticeCrawlerTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauAiNoticeCrawlerTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -16,9 +18,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import net.causw.app.main.domain.integration.crawled.SiteConfigFixture;
 import net.causw.app.main.domain.integration.crawled.client.CrawlHttpClient;
+import net.causw.app.main.domain.integration.crawled.config.CrawlerType;
+import net.causw.app.main.domain.integration.crawled.config.PaginationType;
 import net.causw.app.main.domain.integration.crawled.core.CrawlContext;
 import net.causw.app.main.domain.integration.crawled.dto.ArticleUrl;
 import net.causw.app.main.domain.integration.crawled.dto.RawArticle;
+import net.causw.app.main.domain.integration.crawled.entity.SiteConfig;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CauAiNoticeCrawler 테스트")
@@ -52,6 +57,23 @@ class CauAiNoticeCrawlerTest {
 				"https://ai.cau.ac.kr/sub07/sub0701.php?category=1&view=detail&no=3491&keyword=&search=title",
 				"3491", "공지"));
 		}
+
+		@Test
+		@DisplayName("페이지마다 반복되는 고정 공지를 제외하고 설정된 수만큼 고유 공지를 수집한다")
+		void shouldReturnConfiguredNumberOfUniqueNotices_whenPinnedNoticeIsRepeatedAcrossPages() {
+			// given
+			CrawlContext twoPageContext = new CrawlContext(createCauAiNoticeConfig(3, 2));
+			given(crawlHttpClient.fetch("https://ai.cau.ac.kr/sub07/sub0701.php?category=1&view=list&currentPage=1",
+				twoPageContext.siteConfig())).willReturn(noticeRows(100));
+			given(crawlHttpClient.fetch("https://ai.cau.ac.kr/sub07/sub0701.php?category=1&view=list&currentPage=2",
+				twoPageContext.siteConfig())).willReturn(noticeRows(100, 101, 102));
+
+			// when
+			List<ArticleUrl> result = crawler.fetchList(twoPageContext);
+
+			// then
+			assertThat(result).extracting(ArticleUrl::externalId).containsExactly("100", "101", "102");
+		}
 	}
 
 	@Nested
@@ -81,5 +103,26 @@ class CauAiNoticeCrawlerTest {
 				new net.causw.app.main.domain.integration.crawled.dto.RawAttachment(
 					"자료.pdf", "https://ai.cau.ac.kr/board/download.php?id=1"));
 		}
+	}
+
+	private SiteConfig createCauAiNoticeConfig(int maxArticles, int maxPages) {
+		SiteConfig source = SiteConfigFixture.cauAiNotice();
+		return SiteConfig.of(
+			source.getSiteId(), source.getTargetBoardId(), CrawlerType.CAU_AI_NOTICE,
+			source.getListUrl(), source.getBaseUrl(), Map.of(), Duration.ZERO, Duration.ofSeconds(1),
+			1, maxArticles, 3, PaginationType.PAGE_NUMBER, "currentPage", maxPages,
+			source.getSelectors(), false, false, true);
+	}
+
+	private String noticeRows(int... noticeIds) {
+		StringBuilder rows = new StringBuilder("<table class='table-basic'><tbody>");
+		for (int noticeId : noticeIds) {
+			rows.append("<tr><td>공지</td><td class='title'><a href='?no=")
+				.append(noticeId)
+				.append("'>공지 ")
+				.append(noticeId)
+				.append("</a></td></tr>");
+		}
+		return rows.append("</tbody></table>").toString();
 	}
 }


### PR DESCRIPTION
### 🚩 관련사항
Closes #1478

### 📢 전달사항

중앙대학교 AI학과 공지사항을 기존 소프트웨어학부 공지 크롤러와 동일한 흐름으로 수집할 수 있도록 전용 크롤러를 추가했습니다.

- 목록 URL의 `no` 쿼리 파라미터를 외부 공지 식별자로 사용합니다.
- 공지 제목, 본문, 작성일, 작성자, 대표 이미지와 첨부파일을 AI학과 사이트의 HTML 구조에 맞춰 파싱합니다.
- 사이트별 선택자 설정을 포함한 테스트 fixture와 목록·상세 파싱 단위 테스트를 추가했습니다.

### 📸 스크린샷
N/A

### 📃 진행사항

- [x] `CAU_AI_NOTICE` 크롤러 유형 추가
- [x] AI학과 공지 목록·상세·첨부파일 파서 구현
- [x] 목록 식별자 및 상세 파싱 단위 테스트 추가

### ⚙️ 기타사항

- 사이트 설정(`tb_crawl_site_config`) 등록은 운영 DB에서 별도로 진행해야 합니다.

개발기간: 2026-08-23 ~ 2026-08-23


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 중앙대학교 AI 공지사항을 자동으로 수집할 수 있습니다.
  * 공지 제목, 작성자, 날짜, 본문, 대표 이미지와 첨부파일을 제공합니다.
  * 페이지별로 공지를 수집하고, 설정된 최대 페이지·게시물 수를 적용합니다.
  * 중복 공지와 중복 첨부파일을 제거합니다.
  * 수집 가능한 공지 유형에 AI 공지사항이 추가되었습니다.

* **버그 수정**
  * 필수 정보가 누락되거나 공지 형식을 해석할 수 없는 경우 오류를 감지하고 처리합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->