### PR TITLE
feat: 서버 오류 알림 테스트 엔드포인트 추가

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/admin/monitoring/api/v2/controller/ServerErrorAlertTestController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/admin/monitoring/api/v2/controller/ServerErrorAlertTestController.java
@@ -1,0 +1,32 @@
+package net.causw.app.main.domain.admin.monitoring.api.v2.controller;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import net.causw.app.main.shared.dto.ApiResponse;
+import net.causw.global.exception.ErrorCode;
+import net.causw.global.exception.ServiceUnavailableException;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@RequestMapping("/api/v2/admin/system-error-tests")
+@PreAuthorize("@security.hasRole(@Role.ADMIN)")
+@Tag(name = "System Error Alert Test v2", description = "서버 오류 알림 검증 API")
+public class ServerErrorAlertTestController {
+
+	@PostMapping("/internal-server-error")
+	@Operation(summary = "HTTP 500 알림 테스트", description = "미처리 서버 예외를 발생시켜 오류 알림을 검증합니다.")
+	public ApiResponse<Void> throwInternalServerError() {
+		throw new IllegalStateException("Alert test: internal server error");
+	}
+
+	@PostMapping("/service-unavailable")
+	@Operation(summary = "HTTP 503 알림 테스트", description = "서비스 불가 예외를 발생시켜 오류 알림을 검증합니다.")
+	public ApiResponse<Void> throwServiceUnavailable() {
+		throw new ServiceUnavailableException(ErrorCode.SERVICE_UNAVAILABLE, "Alert test: service unavailable");
+	}
+}

--- a/app-main/src/test/java/net/causw/app/main/domain/admin/monitoring/api/v2/controller/ServerErrorAlertTestControllerTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/admin/monitoring/api/v2/controller/ServerErrorAlertTestControllerTest.java
@@ -1,0 +1,60 @@
+package net.causw.app.main.domain.admin.monitoring.api.v2.controller;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import net.causw.app.main.domain.user.account.enums.user.Role;
+import net.causw.app.main.domain.user.auth.service.SecurityService;
+import net.causw.app.main.shared.exception.GlobalV2ExceptionHandler;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(ServerErrorAlertTestController.class)
+@Import({
+	SecurityService.class,
+	Role.RoleComponent.class,
+	GlobalV2ExceptionHandler.class,
+	ServerErrorAlertTestControllerTest.MethodSecurityTestConfig.class
+})
+class ServerErrorAlertTestControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@WithMockUser(roles = "ADMIN")
+	@DisplayName("ADMIN 권한이면 미처리 예외를 발생시켜 HTTP 500을 반환한다")
+	void givenAdmin_whenThrowInternalServerError_thenReturnInternalServerError() throws Exception {
+		// when & then
+		mockMvc.perform(post("/api/v2/admin/system-error-tests/internal-server-error").with(csrf()))
+			.andExpect(status().isInternalServerError())
+			.andExpect(jsonPath("$.code").value("G50001"));
+	}
+
+	@Test
+	@WithMockUser(roles = "ADMIN")
+	@DisplayName("ADMIN 권한이면 서비스 불가 예외를 발생시켜 HTTP 503을 반환한다")
+	void givenAdmin_whenThrowServiceUnavailable_thenReturnServiceUnavailable() throws Exception {
+		// when & then
+		mockMvc.perform(post("/api/v2/admin/system-error-tests/service-unavailable").with(csrf()))
+			.andExpect(status().isServiceUnavailable())
+			.andExpect(jsonPath("$.code").value("G50301"));
+	}
+
+	@TestConfiguration
+	@EnableMethodSecurity
+	static class MethodSecurityTestConfig {}
+}


### PR DESCRIPTION
### 🚩 관련사항
Closes #1481

### 📢 전달사항
Loki 기반 서버 오류 알림 규칙을 실제 배포 환경에서 검증할 수 있도록 관리자 전용 테스트 API를 추가했습니다.

`POST /api/v2/admin/system-error-tests/internal-server-error`는 처리되지 않은 예외를 발생시켜 `GlobalV2ExceptionHandler`의 `Internal server error` 로그와 HTTP 500 응답을 재현합니다. `POST /api/v2/admin/system-error-tests/service-unavailable`는 `ServiceUnavailableException`을 발생시켜 `Service unavailable` 로그와 HTTP 503 응답을 재현합니다.

두 API는 ADMIN 권한으로 제한했습니다. 리뷰 시 의도적으로 서버 오류를 발생시키는 관리 기능임과 전역 예외 처리 경로가 그대로 사용되는지 확인 부탁드립니다.

### 📸 스크린샷
N/A

### 📃 진행사항
- [x] HTTP 500 미처리 서버 예외 알림 테스트 API 추가
- [x] HTTP 503 서비스 불가 알림 테스트 API 추가
- [x] ADMIN 권한 제한 적용
- [x] MVC 테스트로 오류 상태 및 공통 오류 코드 검증

### ⚙️ 기타사항

검증:
- `JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home ./gradlew :app-main:test --tests "net.causw.app.main.domain.admin.monitoring.api.v2.controller.ServerErrorAlertTestControllerTest"`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home ./gradlew :app-main:spotlessCheck`

개발기간: 2026-08-23 ~ 2026-08-23
