### PR TITLE
fix: 오래된 크롤링 공지 수집 및 전송 방지

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauAiNoticeCrawler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauAiNoticeCrawler.java
@@ -1,5 +1,10 @@
 package net.causw.app.main.domain.integration.crawled.crawler.implementation;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +35,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class CauAiNoticeCrawler implements SiteCrawler {
+	private static final ZoneId KOREA_ZONE_ID = ZoneId.of("Asia/Seoul");
+	private static final DateTimeFormatter LIST_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 	private static final Pattern NOTICE_NO_PATTERN = Pattern.compile("[?&]no=(\\d+)");
 
 	private final CrawlHttpClient crawlHttpClient;
@@ -60,6 +67,9 @@ public class CauAiNoticeCrawler implements SiteCrawler {
 				if (articleUrlsByExternalId.size() >= siteConfig.getMaxArticles()) {
 					break;
 				}
+				if (!isWithinScanRange(row, siteConfig)) {
+					continue;
+				}
 				Element linkElement = row.selectFirst(selectors.getArticleLink());
 				if (linkElement == null) {
 					continue;
@@ -75,6 +85,22 @@ public class CauAiNoticeCrawler implements SiteCrawler {
 		}
 
 		return List.copyOf(articleUrlsByExternalId.values());
+	}
+
+	private boolean isWithinScanRange(Element row, SiteConfig siteConfig) {
+		Element dateElement = row.selectFirst("td:nth-last-child(2)");
+		if (dateElement == null || dateElement.text().isBlank()) {
+			throw IntegrationErrorCode.CRAWL_PARSE_FAILED.toBaseException();
+		}
+		try {
+			LocalDate announceDate = LocalDateTime.parse(dateElement.text().trim(), LIST_DATE_FORMATTER)
+				.toLocalDate();
+			LocalDate today = LocalDate.now(KOREA_ZONE_ID);
+			return !announceDate.isBefore(today.minusDays(siteConfig.getMaxScanRangeDays()))
+				&& !announceDate.isAfter(today);
+		} catch (DateTimeParseException e) {
+			throw IntegrationErrorCode.CRAWL_PARSE_FAILED.toBaseException();
+		}
 	}
 
 	private String extractNoticeId(String url) {

--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauSwNoticeCrawler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauSwNoticeCrawler.java
@@ -1,5 +1,9 @@
 package net.causw.app.main.domain.integration.crawled.crawler.implementation;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -32,6 +36,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class CauSwNoticeCrawler implements SiteCrawler {
+	private static final ZoneId KOREA_ZONE_ID = ZoneId.of("Asia/Seoul");
+	private static final DateTimeFormatter LIST_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 	private static final Pattern SCRIPT_DOWNLOAD_PATTERN = Pattern.compile(
 		"goLocation\\('/_module/bbs/download.php','(\\d+)','(\\w+)'\\).*?>(.*?)<");
 	private static final Pattern NOTICE_CODE_PATTERN = Pattern.compile("[?&]code=([^&]+)");
@@ -71,6 +77,9 @@ public class CauSwNoticeCrawler implements SiteCrawler {
 				if (articleUrls.size() >= siteConfig.getMaxArticles()) {
 					break;
 				}
+				if (!isWithinScanRange(row, siteConfig)) {
+					continue;
+				}
 				Element linkElement = row.selectFirst(selectors.getArticleLink());
 				if (linkElement == null) {
 					continue;
@@ -88,6 +97,21 @@ public class CauSwNoticeCrawler implements SiteCrawler {
 		log.debug("[크롤링] 공지 목록 수집 완료. siteId={}, 추출={}, 중복 제거 후={}",
 			siteConfig.getSiteId(), articleUrls.size(), distinctArticleUrls.size());
 		return distinctArticleUrls;
+	}
+
+	private boolean isWithinScanRange(Element row, SiteConfig siteConfig) {
+		Element dateElement = row.selectFirst("td:nth-last-child(2)");
+		if (dateElement == null || dateElement.text().isBlank()) {
+			throw IntegrationErrorCode.CRAWL_PARSE_FAILED.toBaseException();
+		}
+		try {
+			LocalDate announceDate = LocalDate.parse(dateElement.text().trim(), LIST_DATE_FORMATTER);
+			LocalDate today = LocalDate.now(KOREA_ZONE_ID);
+			return !announceDate.isBefore(today.minusDays(siteConfig.getMaxScanRangeDays()))
+				&& !announceDate.isAfter(today);
+		} catch (DateTimeParseException e) {
+			throw IntegrationErrorCode.CRAWL_PARSE_FAILED.toBaseException();
+		}
 	}
 
 	private String extractNoticeId(String url) {

--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/CrawledNoticeTransferService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/CrawledNoticeTransferService.java
@@ -1,5 +1,6 @@
 package net.causw.app.main.domain.integration.crawled.service;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -58,6 +59,10 @@ public class CrawledNoticeTransferService {
 	public void transfer(String noticeId) {
 		CrawledNotice notice = crawledNoticeReader.findById(noticeId);
 		Post existingPost = findExistingPost(notice);
+		if (existingPost == null && !LocalDate.now().equals(notice.getAnnounceDate())) {
+			crawledNoticeWriter.markTransferred(notice);
+			return;
+		}
 		User systemUser = getSystemUser();
 		Board board = boardReader.getById(notice.getTargetBoardId());
 		Post post = processUpdatedNotice(notice, board, systemUser, existingPost);

--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/implementation/CrawledNoticeWriter.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/implementation/CrawledNoticeWriter.java
@@ -33,6 +33,16 @@ public class CrawledNoticeWriter {
 	}
 
 	/**
+	 * 공지를 Post로 변환하지 않고 전송 완료 상태로 저장합니다.
+	 *
+	 * @param notice 전송을 완료한 공지
+	 */
+	public void markTransferred(CrawledNotice notice) {
+		notice.setIsUpdated(false);
+		crawledNoticeRepository.save(notice);
+	}
+
+	/**
 	 * 정제 공지를 새 엔티티로 저장하고 Post 전송 대기 상태로 표시합니다.
 	 *
 	 * @param article 저장할 정제 공지

--- a/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauAiNoticeCrawlerTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauAiNoticeCrawlerTest.java
@@ -5,6 +5,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
@@ -28,6 +31,9 @@ import net.causw.app.main.domain.integration.crawled.entity.SiteConfig;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CauAiNoticeCrawler 테스트")
 class CauAiNoticeCrawlerTest {
+	private static final ZoneId KOREA_ZONE_ID = ZoneId.of("Asia/Seoul");
+	private static final DateTimeFormatter LIST_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
 	@InjectMocks
 	private CauAiNoticeCrawler crawler;
 
@@ -42,12 +48,7 @@ class CauAiNoticeCrawlerTest {
 		@DisplayName("공지 URL의 no를 외부 식별자로 사용한다")
 		void shouldUseNoAsExternalId_whenNoticeUrlIsFetched() {
 			// given
-			given(crawlHttpClient.fetch(any(), any())).willReturn("""
-				<table class='table-basic'><tbody>
-				<tr><td><span class='tag blue'>공지</span></td>
-				<td class='title'><a href='?category=1&view=detail&no=3491&keyword=&search=title'>AI 공지</a></td></tr>
-				</tbody></table>
-				""");
+			given(crawlHttpClient.fetch(any(), any())).willReturn(noticeRows(3491));
 
 			// when
 			List<ArticleUrl> result = crawler.fetchList(context);
@@ -56,6 +57,22 @@ class CauAiNoticeCrawlerTest {
 			assertThat(result).containsExactly(new ArticleUrl(
 				"https://ai.cau.ac.kr/sub07/sub0701.php?category=1&view=detail&no=3491&keyword=&search=title",
 				"3491", "공지"));
+		}
+
+		@Test
+		@DisplayName("최대 스캔 범위 밖의 공지는 목록 수집에서 제외한다")
+		void shouldExcludeNoticesOutsideMaxScanRange_whenListIsFetched() {
+			// given
+			LocalDateTime now = LocalDateTime.now(KOREA_ZONE_ID);
+			given(crawlHttpClient.fetch(any(), any())).willReturn(noticeRows(
+				noticeRow(3491, now.minusDays(3)),
+				noticeRow(3490, now.minusDays(4))));
+
+			// when
+			List<ArticleUrl> result = crawler.fetchList(context);
+
+			// then
+			assertThat(result).extracting(ArticleUrl::externalId).containsExactly("3491");
 		}
 
 		@Test
@@ -117,12 +134,20 @@ class CauAiNoticeCrawlerTest {
 	private String noticeRows(int... noticeIds) {
 		StringBuilder rows = new StringBuilder("<table class='table-basic'><tbody>");
 		for (int noticeId : noticeIds) {
-			rows.append("<tr><td>공지</td><td class='title'><a href='?no=")
-				.append(noticeId)
-				.append("'>공지 ")
-				.append(noticeId)
-				.append("</a></td></tr>");
+			rows.append(noticeRow(noticeId, LocalDateTime.now(KOREA_ZONE_ID)));
 		}
 		return rows.append("</tbody></table>").toString();
+	}
+
+	private String noticeRows(String... rows) {
+		return "<table class='table-basic'><tbody>" + String.join("", rows) + "</tbody></table>";
+	}
+
+	private String noticeRow(int noticeId, LocalDateTime announceDate) {
+		return """
+			<tr><td>공지</td><td class='title'><a href='?category=1&view=detail&no=%d&keyword=&search=title'>공지 %d</a></td>
+			<td class='pc-only'>관리자</td><td class='pc-only'>%s</td><td class='pc-only'>1</td></tr>
+			"""
+			.formatted(noticeId, noticeId, announceDate.format(LIST_DATE_FORMATTER));
 	}
 }

--- a/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauSwNoticeCrawlerTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauSwNoticeCrawlerTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +26,9 @@ import net.causw.app.main.domain.integration.crawled.dto.RawArticle;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CauSwNoticeCrawler 테스트")
 class CauSwNoticeCrawlerTest {
+	private static final ZoneId KOREA_ZONE_ID = ZoneId.of("Asia/Seoul");
+	private static final DateTimeFormatter LIST_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
 	@InjectMocks
 	private CauSwNoticeCrawler crawler;
 
@@ -50,12 +56,8 @@ class CauSwNoticeCrawlerTest {
 		@DisplayName("공지 URL의 code와 uid를 외부 식별자로 사용한다")
 		void shouldUseCodeAndUidAsExternalId_whenNoticeUrlIsFetched() {
 			// given
-			given(crawlHttpClient.fetch(any(), any())).willReturn("""
-				<table class='table-basic'><tbody>
-				<tr><td class='aleft'><a href='/sub05/sub0501.php?nmode=view&code=oktomato_bbs05&uid=3433'>공지</a></td>
-				<td><span class='tag'>학사</span></td></tr>
-				</tbody></table>
-				""");
+			given(crawlHttpClient.fetch(any(), any())).willReturn(
+				noticeRows(noticeRow(3433, LocalDate.now(KOREA_ZONE_ID))));
 
 			// when
 			List<ArticleUrl> result = crawler.fetchList(context);
@@ -64,6 +66,22 @@ class CauSwNoticeCrawlerTest {
 			assertThat(result).containsExactly(new ArticleUrl(
 				"https://cse.cau.ac.kr/sub05/sub0501.php?nmode=view&code=oktomato_bbs05&uid=3433",
 				"oktomato_bbs05:3433", "학사"));
+		}
+
+		@Test
+		@DisplayName("최대 스캔 범위 밖의 공지는 목록 수집에서 제외한다")
+		void shouldExcludeNoticesOutsideMaxScanRange_whenListIsFetched() {
+			// given
+			LocalDate today = LocalDate.now(KOREA_ZONE_ID);
+			given(crawlHttpClient.fetch(any(), any())).willReturn(noticeRows(
+				noticeRow(3433, today.minusDays(3)),
+				noticeRow(3432, today.minusDays(4))));
+
+			// when
+			List<ArticleUrl> result = crawler.fetchList(context);
+
+			// then
+			assertThat(result).extracting(ArticleUrl::externalId).containsExactly("oktomato_bbs05:3433");
 		}
 	}
 
@@ -95,5 +113,17 @@ class CauSwNoticeCrawlerTest {
 			assertThat(result.category()).isEqualTo("공지");
 			assertThat(result.attachments()).hasSize(1);
 		}
+	}
+
+	private String noticeRows(String... rows) {
+		return "<table class='table-basic'><tbody>" + String.join("", rows) + "</tbody></table>";
+	}
+
+	private String noticeRow(int uid, LocalDate announceDate) {
+		return """
+			<tr><td><span class='tag'>학사</span></td><td class='pc-only'></td>
+			<td class='aleft'><a href='/sub05/sub0501.php?nmode=view&code=oktomato_bbs05&uid=%d'>공지</a></td>
+			<td class='pc-only'>학부사무실</td><td class='pc-only'>%s</td><td class='pc-only'>1</td></tr>
+			""".formatted(uid, announceDate.format(LIST_DATE_FORMATTER));
 	}
 }

--- a/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/service/CrawledNoticeTransferServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/service/CrawledNoticeTransferServiceTest.java
@@ -119,7 +119,7 @@ class CrawledNoticeTransferServiceTest {
 	@DisplayName("크롤링 시스템 계정이 없으면 통합 오류 코드로 예외를 발생시킨다")
 	void transfer_shouldThrowIntegrationException_whenSystemUserDoesNotExist() {
 		// given
-		CrawledNotice notice = notice(LocalDate.of(2026, 8, 10));
+		CrawledNotice notice = notice(LocalDate.now());
 		given(crawledNoticeReader.findById(notice.getId())).willReturn(notice);
 		given(userReader.findByEmail(StaticValue.SYSTEM_CRAWLER_ACCOUNT)).willReturn(Optional.empty());
 

--- a/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/service/CrawledNoticeTransferServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/service/CrawledNoticeTransferServiceTest.java
@@ -2,6 +2,7 @@ package net.causw.app.main.domain.integration.crawled.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.verify;
 
 import java.time.LocalDate;
@@ -51,10 +52,10 @@ class CrawledNoticeTransferServiceTest {
 	private org.springframework.context.ApplicationEventPublisher applicationEventPublisher;
 
 	@Test
-	@DisplayName("연결된 Post가 없는 전송 대기 공지는 공지일과 관계없이 새 Post로 생성한다")
-	void transfer_shouldCreatePost_whenUnlinkedNoticeIsPending() {
+	@DisplayName("연결된 Post가 없는 오늘 공지는 새 Post로 생성한다")
+	void transfer_shouldCreatePost_whenUnlinkedNoticeIsAnnouncedToday() {
 		// given
-		CrawledNotice notice = notice(LocalDate.of(2026, 8, 10));
+		CrawledNotice notice = notice(LocalDate.now());
 		given(crawledNoticeReader.findById(notice.getId())).willReturn(notice);
 		given(userReader.findByEmail(StaticValue.SYSTEM_CRAWLER_ACCOUNT))
 			.willReturn(Optional.of(org.mockito.Mockito.mock(User.class)));
@@ -67,6 +68,23 @@ class CrawledNoticeTransferServiceTest {
 		verify(postWriter).save(org.mockito.ArgumentMatchers.any(Post.class));
 		verify(crawledNoticeWriter).markTransferred(org.mockito.ArgumentMatchers.eq(notice),
 			org.mockito.ArgumentMatchers.any(Post.class));
+	}
+
+	@Test
+	@DisplayName("연결된 Post가 없는 과거 공지는 전송 완료만 기록한다")
+	void transfer_shouldMarkTransferredWithoutCreatingPost_whenUnlinkedNoticeIsNotAnnouncedToday() {
+		// given
+		CrawledNotice notice = notice(LocalDate.now().minusDays(1));
+		given(crawledNoticeReader.findById(notice.getId())).willReturn(notice);
+
+		// when
+		transferService.transfer(notice.getId());
+
+		// then
+		verify(crawledNoticeWriter).markTransferred(notice);
+		then(postWriter).shouldHaveNoInteractions();
+		then(userReader).shouldHaveNoInteractions();
+		then(boardReader).shouldHaveNoInteractions();
 	}
 
 	@Test


### PR DESCRIPTION
### 🚩 관련사항
Closes #1486

### 📢 전달사항
CAU 소프트웨어학부와 AI학과 공지 크롤링에서 최대 스캔 범위를 지난 공지의 상세 수집과 신규 Post 생성을 방지합니다.

- 두 목록 수집 단계에서 한국 시간 기준 작성일이 `오늘 - maxScanRangeDays`부터 오늘까지인 공지만 반환합니다.
- 소프트웨어학부(`yyyy.MM.dd`)와 AI학과(`yyyy-MM-dd HH:mm:ss`)의 목록 날짜 형식을 파싱하지 못하면 크롤링 파싱 오류로 처리합니다.
- 기존 Post가 없는 과거 공지는 새 Post로 전송하지 않고 전송 완료 상태만 기록합니다.

리뷰 시 목록 행의 작성일 셀렉터(`td:nth-last-child(2)`)가 두 사이트의 공지 HTML 구조와 일치하는지 확인 부탁드립니다.

### 📸 스크린샷
N/A

### 📃 진행사항
- [x] 목록 수집 단계에 `maxScanRangeDays` 기반 작성일 필터 적용
- [x] 범위 경계일 포함 및 범위 초과 공지 제외 테스트 추가
- [x] AI학과 공지 목록에 동일한 스캔 범위 필터 적용
- [x] 기존 Post가 없는 과거 공지의 Post 전송 방지
- [x] 과거 공지 전송 완료 상태 기록 테스트 추가

### ⚙️ 기타사항

개발기간: 2026-08-24 ~ 2026-08-24
