### PR TITLE
릴리즈: dev → main (2026-08-24)

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauAiNoticeCrawler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauAiNoticeCrawler.java
@@ -1,5 +1,10 @@
 package net.causw.app.main.domain.integration.crawled.crawler.implementation;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +35,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class CauAiNoticeCrawler implements SiteCrawler {
+	private static final ZoneId KOREA_ZONE_ID = ZoneId.of("Asia/Seoul");
+	private static final DateTimeFormatter LIST_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 	private static final Pattern NOTICE_NO_PATTERN = Pattern.compile("[?&]no=(\\d+)");
 
 	private final CrawlHttpClient crawlHttpClient;
@@ -60,6 +67,9 @@ public class CauAiNoticeCrawler implements SiteCrawler {
 				if (articleUrlsByExternalId.size() >= siteConfig.getMaxArticles()) {
 					break;
 				}
+				if (!isWithinScanRange(row, siteConfig)) {
+					continue;
+				}
 				Element linkElement = row.selectFirst(selectors.getArticleLink());
 				if (linkElement == null) {
 					continue;
@@ -75,6 +85,22 @@ public class CauAiNoticeCrawler implements SiteCrawler {
 		}
 
 		return List.copyOf(articleUrlsByExternalId.values());
+	}
+
+	private boolean isWithinScanRange(Element row, SiteConfig siteConfig) {
+		Element dateElement = row.selectFirst("td:nth-last-child(2)");
+		if (dateElement == null || dateElement.text().isBlank()) {
+			throw IntegrationErrorCode.CRAWL_PARSE_FAILED.toBaseException();
+		}
+		try {
+			LocalDate announceDate = LocalDateTime.parse(dateElement.text().trim(), LIST_DATE_FORMATTER)
+				.toLocalDate();
+			LocalDate today = LocalDate.now(KOREA_ZONE_ID);
+			return !announceDate.isBefore(today.minusDays(siteConfig.getMaxScanRangeDays()))
+				&& !announceDate.isAfter(today);
+		} catch (DateTimeParseException e) {
+			throw IntegrationErrorCode.CRAWL_PARSE_FAILED.toBaseException();
+		}
 	}
 
 	private String extractNoticeId(String url) {

--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauSwNoticeCrawler.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauSwNoticeCrawler.java
@@ -1,5 +1,9 @@
 package net.causw.app.main.domain.integration.crawled.crawler.implementation;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -32,6 +36,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class CauSwNoticeCrawler implements SiteCrawler {
+	private static final ZoneId KOREA_ZONE_ID = ZoneId.of("Asia/Seoul");
+	private static final DateTimeFormatter LIST_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 	private static final Pattern SCRIPT_DOWNLOAD_PATTERN = Pattern.compile(
 		"goLocation\\('/_module/bbs/download.php','(\\d+)','(\\w+)'\\).*?>(.*?)<");
 	private static final Pattern NOTICE_CODE_PATTERN = Pattern.compile("[?&]code=([^&]+)");
@@ -71,6 +77,9 @@ public class CauSwNoticeCrawler implements SiteCrawler {
 				if (articleUrls.size() >= siteConfig.getMaxArticles()) {
 					break;
 				}
+				if (!isWithinScanRange(row, siteConfig)) {
+					continue;
+				}
 				Element linkElement = row.selectFirst(selectors.getArticleLink());
 				if (linkElement == null) {
 					continue;
@@ -88,6 +97,21 @@ public class CauSwNoticeCrawler implements SiteCrawler {
 		log.debug("[크롤링] 공지 목록 수집 완료. siteId={}, 추출={}, 중복 제거 후={}",
 			siteConfig.getSiteId(), articleUrls.size(), distinctArticleUrls.size());
 		return distinctArticleUrls;
+	}
+
+	private boolean isWithinScanRange(Element row, SiteConfig siteConfig) {
+		Element dateElement = row.selectFirst("td:nth-last-child(2)");
+		if (dateElement == null || dateElement.text().isBlank()) {
+			throw IntegrationErrorCode.CRAWL_PARSE_FAILED.toBaseException();
+		}
+		try {
+			LocalDate announceDate = LocalDate.parse(dateElement.text().trim(), LIST_DATE_FORMATTER);
+			LocalDate today = LocalDate.now(KOREA_ZONE_ID);
+			return !announceDate.isBefore(today.minusDays(siteConfig.getMaxScanRangeDays()))
+				&& !announceDate.isAfter(today);
+		} catch (DateTimeParseException e) {
+			throw IntegrationErrorCode.CRAWL_PARSE_FAILED.toBaseException();
+		}
 	}
 
 	private String extractNoticeId(String url) {

--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/CrawledNoticeTransferService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/CrawledNoticeTransferService.java
@@ -1,5 +1,6 @@
 package net.causw.app.main.domain.integration.crawled.service;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -58,6 +59,10 @@ public class CrawledNoticeTransferService {
 	public void transfer(String noticeId) {
 		CrawledNotice notice = crawledNoticeReader.findById(noticeId);
 		Post existingPost = findExistingPost(notice);
+		if (existingPost == null && !LocalDate.now().equals(notice.getAnnounceDate())) {
+			crawledNoticeWriter.markTransferred(notice);
+			return;
+		}
 		User systemUser = getSystemUser();
 		Board board = boardReader.getById(notice.getTargetBoardId());
 		Post post = processUpdatedNotice(notice, board, systemUser, existingPost);

--- a/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/implementation/CrawledNoticeWriter.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/integration/crawled/service/implementation/CrawledNoticeWriter.java
@@ -33,6 +33,16 @@ public class CrawledNoticeWriter {
 	}
 
 	/**
+	 * 공지를 Post로 변환하지 않고 전송 완료 상태로 저장합니다.
+	 *
+	 * @param notice 전송을 완료한 공지
+	 */
+	public void markTransferred(CrawledNotice notice) {
+		notice.setIsUpdated(false);
+		crawledNoticeRepository.save(notice);
+	}
+
+	/**
 	 * 정제 공지를 새 엔티티로 저장하고 Post 전송 대기 상태로 표시합니다.
 	 *
 	 * @param article 저장할 정제 공지

--- a/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauAiNoticeCrawlerTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauAiNoticeCrawlerTest.java
@@ -5,6 +5,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
@@ -28,6 +31,9 @@ import net.causw.app.main.domain.integration.crawled.entity.SiteConfig;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CauAiNoticeCrawler 테스트")
 class CauAiNoticeCrawlerTest {
+	private static final ZoneId KOREA_ZONE_ID = ZoneId.of("Asia/Seoul");
+	private static final DateTimeFormatter LIST_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
 	@InjectMocks
 	private CauAiNoticeCrawler crawler;
 
@@ -42,12 +48,7 @@ class CauAiNoticeCrawlerTest {
 		@DisplayName("공지 URL의 no를 외부 식별자로 사용한다")
 		void shouldUseNoAsExternalId_whenNoticeUrlIsFetched() {
 			// given
-			given(crawlHttpClient.fetch(any(), any())).willReturn("""
-				<table class='table-basic'><tbody>
-				<tr><td><span class='tag blue'>공지</span></td>
-				<td class='title'><a href='?category=1&view=detail&no=3491&keyword=&search=title'>AI 공지</a></td></tr>
-				</tbody></table>
-				""");
+			given(crawlHttpClient.fetch(any(), any())).willReturn(noticeRows(3491));
 
 			// when
 			List<ArticleUrl> result = crawler.fetchList(context);
@@ -56,6 +57,22 @@ class CauAiNoticeCrawlerTest {
 			assertThat(result).containsExactly(new ArticleUrl(
 				"https://ai.cau.ac.kr/sub07/sub0701.php?category=1&view=detail&no=3491&keyword=&search=title",
 				"3491", "공지"));
+		}
+
+		@Test
+		@DisplayName("최대 스캔 범위 밖의 공지는 목록 수집에서 제외한다")
+		void shouldExcludeNoticesOutsideMaxScanRange_whenListIsFetched() {
+			// given
+			LocalDateTime now = LocalDateTime.now(KOREA_ZONE_ID);
+			given(crawlHttpClient.fetch(any(), any())).willReturn(noticeRows(
+				noticeRow(3491, now.minusDays(3)),
+				noticeRow(3490, now.minusDays(4))));
+
+			// when
+			List<ArticleUrl> result = crawler.fetchList(context);
+
+			// then
+			assertThat(result).extracting(ArticleUrl::externalId).containsExactly("3491");
 		}
 
 		@Test
@@ -117,12 +134,20 @@ class CauAiNoticeCrawlerTest {
 	private String noticeRows(int... noticeIds) {
 		StringBuilder rows = new StringBuilder("<table class='table-basic'><tbody>");
 		for (int noticeId : noticeIds) {
-			rows.append("<tr><td>공지</td><td class='title'><a href='?no=")
-				.append(noticeId)
-				.append("'>공지 ")
-				.append(noticeId)
-				.append("</a></td></tr>");
+			rows.append(noticeRow(noticeId, LocalDateTime.now(KOREA_ZONE_ID)));
 		}
 		return rows.append("</tbody></table>").toString();
+	}
+
+	private String noticeRows(String... rows) {
+		return "<table class='table-basic'><tbody>" + String.join("", rows) + "</tbody></table>";
+	}
+
+	private String noticeRow(int noticeId, LocalDateTime announceDate) {
+		return """
+			<tr><td>공지</td><td class='title'><a href='?category=1&view=detail&no=%d&keyword=&search=title'>공지 %d</a></td>
+			<td class='pc-only'>관리자</td><td class='pc-only'>%s</td><td class='pc-only'>1</td></tr>
+			"""
+			.formatted(noticeId, noticeId, announceDate.format(LIST_DATE_FORMATTER));
 	}
 }

--- a/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauSwNoticeCrawlerTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/crawler/implementation/CauSwNoticeCrawlerTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +26,9 @@ import net.causw.app.main.domain.integration.crawled.dto.RawArticle;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CauSwNoticeCrawler 테스트")
 class CauSwNoticeCrawlerTest {
+	private static final ZoneId KOREA_ZONE_ID = ZoneId.of("Asia/Seoul");
+	private static final DateTimeFormatter LIST_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
 	@InjectMocks
 	private CauSwNoticeCrawler crawler;
 
@@ -50,12 +56,8 @@ class CauSwNoticeCrawlerTest {
 		@DisplayName("공지 URL의 code와 uid를 외부 식별자로 사용한다")
 		void shouldUseCodeAndUidAsExternalId_whenNoticeUrlIsFetched() {
 			// given
-			given(crawlHttpClient.fetch(any(), any())).willReturn("""
-				<table class='table-basic'><tbody>
-				<tr><td class='aleft'><a href='/sub05/sub0501.php?nmode=view&code=oktomato_bbs05&uid=3433'>공지</a></td>
-				<td><span class='tag'>학사</span></td></tr>
-				</tbody></table>
-				""");
+			given(crawlHttpClient.fetch(any(), any())).willReturn(
+				noticeRows(noticeRow(3433, LocalDate.now(KOREA_ZONE_ID))));
 
 			// when
 			List<ArticleUrl> result = crawler.fetchList(context);
@@ -64,6 +66,22 @@ class CauSwNoticeCrawlerTest {
 			assertThat(result).containsExactly(new ArticleUrl(
 				"https://cse.cau.ac.kr/sub05/sub0501.php?nmode=view&code=oktomato_bbs05&uid=3433",
 				"oktomato_bbs05:3433", "학사"));
+		}
+
+		@Test
+		@DisplayName("최대 스캔 범위 밖의 공지는 목록 수집에서 제외한다")
+		void shouldExcludeNoticesOutsideMaxScanRange_whenListIsFetched() {
+			// given
+			LocalDate today = LocalDate.now(KOREA_ZONE_ID);
+			given(crawlHttpClient.fetch(any(), any())).willReturn(noticeRows(
+				noticeRow(3433, today.minusDays(3)),
+				noticeRow(3432, today.minusDays(4))));
+
+			// when
+			List<ArticleUrl> result = crawler.fetchList(context);
+
+			// then
+			assertThat(result).extracting(ArticleUrl::externalId).containsExactly("oktomato_bbs05:3433");
 		}
 	}
 
@@ -95,5 +113,17 @@ class CauSwNoticeCrawlerTest {
 			assertThat(result.category()).isEqualTo("공지");
 			assertThat(result.attachments()).hasSize(1);
 		}
+	}
+
+	private String noticeRows(String... rows) {
+		return "<table class='table-basic'><tbody>" + String.join("", rows) + "</tbody></table>";
+	}
+
+	private String noticeRow(int uid, LocalDate announceDate) {
+		return """
+			<tr><td><span class='tag'>학사</span></td><td class='pc-only'></td>
+			<td class='aleft'><a href='/sub05/sub0501.php?nmode=view&code=oktomato_bbs05&uid=%d'>공지</a></td>
+			<td class='pc-only'>학부사무실</td><td class='pc-only'>%s</td><td class='pc-only'>1</td></tr>
+			""".formatted(uid, announceDate.format(LIST_DATE_FORMATTER));
 	}
 }

--- a/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/service/CrawledNoticeTransferServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/integration/crawled/service/CrawledNoticeTransferServiceTest.java
@@ -2,6 +2,7 @@ package net.causw.app.main.domain.integration.crawled.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.verify;
 
 import java.time.LocalDate;
@@ -51,10 +52,10 @@ class CrawledNoticeTransferServiceTest {
 	private org.springframework.context.ApplicationEventPublisher applicationEventPublisher;
 
 	@Test
-	@DisplayName("연결된 Post가 없는 전송 대기 공지는 공지일과 관계없이 새 Post로 생성한다")
-	void transfer_shouldCreatePost_whenUnlinkedNoticeIsPending() {
+	@DisplayName("연결된 Post가 없는 오늘 공지는 새 Post로 생성한다")
+	void transfer_shouldCreatePost_whenUnlinkedNoticeIsAnnouncedToday() {
 		// given
-		CrawledNotice notice = notice(LocalDate.of(2026, 8, 10));
+		CrawledNotice notice = notice(LocalDate.now());
 		given(crawledNoticeReader.findById(notice.getId())).willReturn(notice);
 		given(userReader.findByEmail(StaticValue.SYSTEM_CRAWLER_ACCOUNT))
 			.willReturn(Optional.of(org.mockito.Mockito.mock(User.class)));
@@ -67,6 +68,23 @@ class CrawledNoticeTransferServiceTest {
 		verify(postWriter).save(org.mockito.ArgumentMatchers.any(Post.class));
 		verify(crawledNoticeWriter).markTransferred(org.mockito.ArgumentMatchers.eq(notice),
 			org.mockito.ArgumentMatchers.any(Post.class));
+	}
+
+	@Test
+	@DisplayName("연결된 Post가 없는 과거 공지는 전송 완료만 기록한다")
+	void transfer_shouldMarkTransferredWithoutCreatingPost_whenUnlinkedNoticeIsNotAnnouncedToday() {
+		// given
+		CrawledNotice notice = notice(LocalDate.now().minusDays(1));
+		given(crawledNoticeReader.findById(notice.getId())).willReturn(notice);
+
+		// when
+		transferService.transfer(notice.getId());
+
+		// then
+		verify(crawledNoticeWriter).markTransferred(notice);
+		then(postWriter).shouldHaveNoInteractions();
+		then(userReader).shouldHaveNoInteractions();
+		then(boardReader).shouldHaveNoInteractions();
 	}
 
 	@Test
@@ -101,7 +119,7 @@ class CrawledNoticeTransferServiceTest {
 	@DisplayName("크롤링 시스템 계정이 없으면 통합 오류 코드로 예외를 발생시킨다")
 	void transfer_shouldThrowIntegrationException_whenSystemUserDoesNotExist() {
 		// given
-		CrawledNotice notice = notice(LocalDate.of(2026, 8, 10));
+		CrawledNotice notice = notice(LocalDate.now());
 		given(crawledNoticeReader.findById(notice.getId())).willReturn(notice);
 		given(userReader.findByEmail(StaticValue.SYSTEM_CRAWLER_ACCOUNT)).willReturn(Optional.empty());
 


### PR DESCRIPTION
## 요약

- 비교: `94693013b60e050bfc112c0173315550a4ecc1b6..origin/dev` → `main`
- 호환성 결론: 호환 / 릴리즈 노트 필요

## 호환성 평가

| 영역 | 결론 | 근거 및 소비자 영향 |
| --- | --- | --- |
| API 계약 | 이슈 없음 | Controller, API DTO, 응답 envelope, 오류 코드 변경이 없습니다. |
| 데이터베이스 및 마이그레이션 | 이슈 없음 | Flyway migration, entity, repository/query, 스키마 설정 변경이 없습니다. `db-change` 라벨은 불필요합니다. |
| 보안 및 연동 | 이슈 없음 | Spring Security, 인증/환경 설정, 외부 연동 설정 변경이 없습니다. |
| 동작 및 운영 | 릴리즈 노트 필요 | CAU AI·SW 공지 크롤러가 `maxScanRangeDays` 밖의 목록 항목을 제외합니다. 기존 Post가 없는 과거 공지는 전송 완료 처리만 하며 신규 Post/공식 게시글 알림을 만들지 않습니다. 기존 Post에 연결된 공지 갱신은 계속 반영됩니다. |

## 포함된 변경사항

- 오래된 CAU AI학과·소프트웨어학부 공지의 수집 및 전송을 방지합니다.
- 목록 날짜 파싱 실패 시 기존 크롤링 파싱 오류 흐름으로 처리합니다.
- 관련 크롤러와 전송 서비스 테스트를 보강했습니다.

## 검증

- [x] `./gradlew :app-main:spotlessCheck`
- [x] 관련 테스트: `CauAiNoticeCrawlerTest`, `CauSwNoticeCrawlerTest`, `CrawledNoticeTransferServiceTest` 실행 시도
  - 로컬 Java 25 toolchain 부재로 `:global:compileJava` 단계에서 실행되지 못했습니다.
- [x] `git diff --check 94693013b60e050bfc112c0173315550a4ecc1b6..origin/dev`
- [x] `./gradlew flywayValidate` — 마이그레이션·스키마 변경이 없어 생략

## 배포 및 롤백 유의사항

- 필요한 환경/인프라 변경: 없음
- 마이그레이션 절차: 없음
- 롤백 또는 완화 방안: 문제 발생 시 이 변경을 되돌리면 기존의 과거 공지 수집·전송 동작으로 복구됩니다.

## 리뷰어 체크리스트

- [ ] 이 PR에 스키마 변경이 있으면 `db-change` 라벨을 추가합니다. (해당 없음)
- [ ] Java 25 toolchain이 구성된 CI에서 관련 테스트 결과를 확인합니다.