### PR TITLE
fix: Docker dangling 이미지 정리 오류 방지

### DIFF
--- a/.github/scripts/restart-container.sh
+++ b/.github/scripts/restart-container.sh
@@ -45,6 +45,7 @@ IMAGE_LIST="$(
 printf '%s\n' "$IMAGE_LIST" |
   while read -r image_ref image_id; do
     [ -n "$image_ref" ] || continue
+    [ "$image_ref" = "<none>:<none>" ] && continue
     if [ "$image_ref" = "$MIGRATION_IMAGE" ] || \
       [ "$image_id" = "$CURRENT_IMAGE_ID" ] || \
       [ "$image_id" = "$PREVIOUS_IMAGE_ID" ]; then


### PR DESCRIPTION
### 🚩 관련사항
Closes #1490

### 📢 전달사항
prod CD에서 새 컨테이너가 실행된 뒤 Docker 이미지 정리 단계가 `invalid reference format`으로 실패하던 문제를 수정합니다.

Docker가 dangling 이미지를 `<none>:<none>`으로 표시할 때 이를 `docker image rm`의 이미지 참조로 전달하지 않도록 제외했습니다. 현재 이미지, 직전 이미지, 마이그레이션 이미지를 보존하는 기존 정리 규칙과 컨테이너 재기동 흐름은 변경하지 않습니다.

### 📸 스크린샷
N/A

### 📃 진행사항
- [x] `<none>:<none>` dangling 이미지를 삭제 대상에서 제외
- [x] 배포 스크립트 셸 문법 및 포맷 검증

### ⚙️ 기타사항

- DB 스키마 및 마이그레이션 변경 없음 (`db-change` 라벨 불필요)

개발기간: 2026-08-24 ~ 2026-08-24
