### PR TITLE
infra: 분산 트레이스 수집을 위한 OTel Collector, Tempo 및 Grafana 연동 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ monitoring/prometheus-data/
 monitoring/grafana-data/
 monitoring/loki-data/
 monitoring/mysqld-exporter/.my.cnf
+monitoring/tempo-data/
 
 /.claude
 docs/superpowers/

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -8,3 +8,9 @@ datasources:
     isDefault: true
     uid: prometheus-local
     editable: true
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    uid: tempo-local
+    editable: true

--- a/monitoring/local/docker-compose.yml
+++ b/monitoring/local/docker-compose.yml
@@ -67,3 +67,34 @@ services:
     ports:
       - "9100:9100"
     restart: unless-stopped
+
+  tempo:
+    image: grafana/tempo:latest
+    container_name: causw-tempo
+    env_file:
+      - ../../.env.local
+    user: "${MY_UID}:${MY_GID}"
+    command: [ "-config.file=/etc/tempo/tempo.yml" ]
+    volumes:
+      - ../tempo/tempo.yml:/etc/tempo/tempo.yml
+      - ../tempo-data:/tmp/tempo
+    ports:
+      - "3200:3200"
+    restart: unless-stopped
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: causw-otel-collector
+    env_file:
+      - ../../.env.local
+    user: "${MY_UID}:${MY_GID}"
+    command: [ "--config=/etc/otelcol-contrib/otel-collector.yml" ]
+    volumes:
+      - ../otel-collector/otel-collector.yml:/etc/otelcol-contrib/otel-collector.yml
+    ports:
+      - "4317:4317" # OTLP gRPC
+      - "4318:4318" # OTLP HTTP
+      - "8888:8888"
+    depends_on:
+      - tempo
+    restart: unless-stopped

--- a/monitoring/otel-collector/otel-collector.yml
+++ b/monitoring/otel-collector/otel-collector.yml
@@ -1,0 +1,21 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+
+exporters:
+  otlphttp/tempo:
+    endpoint: http://tempo:4318
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/tempo]

--- a/monitoring/tempo/tempo.yml
+++ b/monitoring/tempo/tempo.yml
@@ -1,0 +1,20 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+        http:
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /tmp/tempo/traces
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo

--- a/monitoring/tempo/tempo.yml
+++ b/monitoring/tempo/tempo.yml
@@ -6,11 +6,15 @@ distributor:
     otlp:
       protocols:
         grpc:
+          endpoint: 0.0.0.0:4317
         http:
+          endpoint: 0.0.0.0:4318
 
 storage:
   trace:
     backend: local
+    wal:
+      path: /tmp/tempo/wal
     local:
       path: /tmp/tempo/traces
 


### PR DESCRIPTION
### 🚩 관련사항
Closes #1494


### 📢 전달사항
- **개발 배경**: 분산 트레이스(Distributed Tracing) 수집 및 모니터링 환경을 구축하기 위해 로컬 개발 환경에 OTel Collector와 Grafana Tempo를 도입했습니다.
- **주요 변경 사항**:
  - `docker-compose.yml`: 기존 Prometheus, Grafana 스택에 `causw-tempo`, `causw-otel-collector` 서비스 추가
  - `otel-collector.yml`: Spring Boot 앱으로부터 OTLP/HTTP(4318), gRPC(4317) 데이터를 수신하여 Tempo로 전달하도록 수집 파이프라인 구성
  - `tempo.yml`: 트레이스 데이터 저장을 위한 로컬 스토리지 경로 설정
  - `datasource.yml`: Grafana에 Tempo 데이터소스 자동 연동 설정 추가
  - `.gitignore`: Tempo 런타임 데이터 디렉토리(`monitoring/tempo-data/`) 예외 처리 추가
- **집중적으로 봐주셨으면 하는 부분**:
  - 도커 컴포즈 포트 매핑(`4317`, `4318`, `3200`) 및 기존 Prometheus/Grafana와의 연동 구조가 자연스럽게 병합되었는지 확인 부탁드립니다.


### 📸 스크린샷
관련한 스크린샷을 첨부해주세요.


### 📃 진행사항
- [x] OTel Collector 설정 파일(`otel-collector.yml`) 작성
- [x] Grafana Tempo 설정 파일(`tempo.yml`) 작성
- [x] 기존 `docker-compose.yml`에 Tempo 및 OTel Collector 컨테이너 추가
- [x] Grafana Datasource(`datasource.yml`)에 Tempo 연동 설정 추가
- [x] 로컬 환경에서 도커 컨테이너 구동 테스트 및 정상 작동 확인 (`docker ps`)
- [ ] Spring Boot OpenTelemetry 의존성 및 설정 연동 완료 후 통합 테스트 진행


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 2026.08.24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * Grafana에서 Tempo 기반의 분산 추적 데이터를 조회할 수 있습니다.
  * OpenTelemetry를 통해 수집한 트레이스를 Tempo로 전송하고 로컬에 저장합니다.
  * OTLP gRPC 및 HTTP 방식의 트레이스 수집을 지원합니다.

* **개선**
  * 로컬 모니터링 서비스가 중단 후 자동으로 재시작되도록 개선했습니다.
  * Tempo 모니터링 데이터가 불필요하게 버전 관리되지 않도록 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->