### PR TITLE
feat: 동문수첩 '소통' 탭 개편 및 게시판 분기 처리

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/controller/BoardController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/controller/BoardController.java
@@ -12,6 +12,7 @@ import net.causw.app.main.domain.community.board.api.v2.dto.response.BoardReadab
 import net.causw.app.main.domain.community.board.api.v2.dto.response.BoardWritableListResponse;
 import net.causw.app.main.domain.community.board.api.v2.mapper.BoardReadableMapper;
 import net.causw.app.main.domain.community.board.api.v2.mapper.BoardWritableMapper;
+import net.causw.app.main.domain.community.board.entity.BoardGroup;
 import net.causw.app.main.domain.community.board.service.BoardService;
 import net.causw.app.main.domain.user.auth.userdetails.CustomUserDetails;
 import net.causw.app.main.shared.dto.ApiResponse;
@@ -33,21 +34,23 @@ public class BoardController {
 	@GetMapping("/available")
 	@ResponseStatus(HttpStatus.OK)
 	@Operation(summary = "이용 가능한 게시판 목록", description = "현재 사용자가 이용 가능한 게시판의 id, name 목록을 표시 순서대로 반환합니다.\n"
-		+ "파라미터로 isTab 전달 시 탭으로 표시할 게시판 목록을 반환합니다.")
+		+ "파라미터로 boardGroup 전달 시 해당 그룹(소식 = NOTICE, 소통 = COMMUNITY)에 맞는 게시판 목록을 반환합니다.")
 	public ApiResponse<BoardReadableListResponse> getAvailableBoards(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
-		@RequestParam(name = "isTab", defaultValue = "false", required = false) boolean isTab) {
+		@RequestParam(name = "boardGroup") BoardGroup boardGroup) {
 		return ApiResponse.success(
 			boardReadableMapper
-				.toReadableListResponse(boardService.getReadableBoards(userDetails.getUser().getId(), isTab)));
+				.toReadableListResponse(boardService.getReadableBoards(userDetails.getUser().getId(), boardGroup)));
 	}
 
 	@GetMapping("/writable")
 	@ResponseStatus(HttpStatus.OK)
-	@Operation(summary = "쓰기 가능한 게시판 목록", description = "현재 사용자가 쓰기 가능한 게시판의 id, name 목록을 표시 순서대로 반환합니다.")
+	@Operation(summary = "쓰기 가능한 게시판 목록", description = "현재 사용자가 쓰기 가능한 게시판의 id, name 목록을 표시 순서대로 반환합니다.\n"
+		+ "파라미터로 boardGroup 전달 시 해당 그룹(소식 = NOTICE, 소통 = COMMUNITY)에 맞는 게시판 목록을 반환합니다.")
 	public ApiResponse<BoardWritableListResponse> getWritableBoards(
-		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@RequestParam(name = "boardGroup") BoardGroup boardGroup) {
 		return ApiResponse.success(
-			boardWritableMapper.toWritableListResponse(boardService.getWritableBoards(userDetails.getUser().getId())));
+			boardWritableMapper.toWritableListResponse(boardService.getWritableBoards(userDetails.getUser().getId(), boardGroup)));
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/controller/BoardController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/controller/BoardController.java
@@ -51,6 +51,7 @@ public class BoardController {
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@RequestParam(name = "boardGroup") BoardGroup boardGroup) {
 		return ApiResponse.success(
-			boardWritableMapper.toWritableListResponse(boardService.getWritableBoards(userDetails.getUser().getId(), boardGroup)));
+			boardWritableMapper
+				.toWritableListResponse(boardService.getWritableBoards(userDetails.getUser().getId(), boardGroup)));
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/entity/BoardGroup.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/entity/BoardGroup.java
@@ -1,0 +1,6 @@
+package net.causw.app.main.domain.community.board.entity;
+
+public enum BoardGroup {
+	NOTICE, // 소식 탭
+	COMMUNITY // 소통 탭 (동문수첩 내부)
+}

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/service/BoardService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/service/BoardService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import net.causw.app.main.domain.community.board.entity.BoardGroup;
 import net.causw.app.main.domain.community.board.service.dto.BoardReadableItemResult;
 import net.causw.app.main.domain.community.board.service.dto.BoardWritableItemResult;
 import net.causw.app.main.domain.community.board.service.implementation.BoardAccessManager;
@@ -25,12 +26,12 @@ public class BoardService {
 	 * 특정 사용자가 읽기 가능한 게시판의 id, name 목록을 표시 순서대로 반환합니다.
 	 *
 	 * @param userId 사용자 ID
-	 * @param isTab 탭 노출용 필터링 여부
+	 * @param boardGroup 게시판 그룹 Enum (NOTICE, COMMUNITY)
 	 * @return 읽기 가능한 게시판 목록 (id, name)
 	 */
-	public List<BoardReadableItemResult> getReadableBoards(String userId, boolean isTab) {
+	public List<BoardReadableItemResult> getReadableBoards(String userId, BoardGroup boardGroup) {
 		User user = userReader.findUserById(userId);
-		return boardAccessManager.getReadableBoards(user, isTab).stream()
+		return boardAccessManager.getReadableBoards(user, boardGroup).stream()
 			.map(board -> new BoardReadableItemResult(board.getId(), board.getName()))
 			.toList();
 	}
@@ -41,11 +42,12 @@ public class BoardService {
 	 * 공개 게시판의 scope를 우회할 수 있습니다. HIDDEN 게시판에는 누구도 작성할 수 없습니다.
 	 *
 	 * @param userId 사용자 ID
+	 * @param boardGroup 게시판 그룹 Enum (NOTICE, COMMUNITY)
 	 * @return 쓰기 가능한 게시판 목록 (id, name)
 	 */
-	public List<BoardWritableItemResult> getWritableBoards(String userId) {
+	public List<BoardWritableItemResult> getWritableBoards(String userId, BoardGroup boardGroup) {
 		User user = userReader.findUserById(userId);
-		return boardAccessManager.getWritableBoards(user).stream()
+		return boardAccessManager.getWritableBoards(user, boardGroup).stream()
 			.map(b -> new BoardWritableItemResult(b.getId(), b.getName()))
 			.toList();
 	}

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/service/implementation/BoardAccessManager.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/service/implementation/BoardAccessManager.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import net.causw.app.main.domain.community.board.entity.Board;
 import net.causw.app.main.domain.community.board.entity.BoardConfig;
+import net.causw.app.main.domain.community.board.entity.BoardGroup;
 import net.causw.app.main.domain.community.common.service.CommunityPermissionPolicy;
 import net.causw.app.main.domain.user.account.entity.user.User;
 
@@ -23,18 +24,18 @@ public class BoardAccessManager {
 	private final BoardReader boardReader;
 	private final BoardConfigReader boardConfigReader;
 
-	public List<Board> getReadableBoards(User viewer, boolean isTab) {
+	public List<Board> getReadableBoards(User viewer, BoardGroup boardGroup) {
 		return getAccessibleBoards(
 			viewer,
-			config -> !isTab || config.isNotice(),
+			config -> isMatchingGroup(config.isNotice(), boardGroup),
 			(board, config, adminIds) -> CommunityPermissionPolicy.canReadBoard(
 				viewer, board, config, adminIds));
 	}
 
-	public List<Board> getWritableBoards(User writer) {
+	public List<Board> getWritableBoards(User writer, BoardGroup boardGroup) {
 		return getAccessibleBoards(
 			writer,
-			config -> true,
+			config -> isMatchingGroup(config.isNotice(), boardGroup),
 			(board, config, adminIds) -> CommunityPermissionPolicy.canWriteBoard(
 				writer, board, config, adminIds));
 	}
@@ -67,6 +68,16 @@ public class BoardAccessManager {
 				adminIdMap.getOrDefault(item.board().getId(), Set.of())))
 			.map(BoardWithConfig::board)
 			.toList();
+	}
+
+	// tb_board_config의 is_notice 값과 요청받은 boardGroup을 매핑
+	private boolean isMatchingGroup(boolean isNoticeConfig, BoardGroup requestGroup) {
+		if (requestGroup == BoardGroup.NOTICE) {
+			return isNoticeConfig;
+		} else if (requestGroup == BoardGroup.COMMUNITY) {
+			return !isNoticeConfig;
+		}
+		return false;
 	}
 
 	@FunctionalInterface

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/request/PostListCondition.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/request/PostListCondition.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "게시글 목록 조회 요청")
 public record PostListCondition(
-	@Schema(description = "게시판 ID 목록 (null 또는 빈 리스트면 전체 게시판)", example = "[\"board-uuid-1\", \"board-uuid-2\"]") List<String> boardIds,
+	@Schema(description = "게시판 ID 목록 (값이 있으면 특정 게시판 조회, null 또는 빈 리스트이고 boardGroup이 있으면 해당 그룹만 조회)", example = "[\"board-uuid-1\", \"board-uuid-2\"]") List<String> boardIds,
 	@Schema(description = "게시판 그룹 (소식 = NOTICE, 소통 = COMMUNITY)", example = "NOTICE") BoardGroup boardGroup,
 	@Schema(description = "커서 (마지막 게시글의 createdAt)", example = "2026-02-09T12:00:00") String cursor,
 	@Schema(description = "조회할 개수", example = "20") Integer size,

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/request/PostListCondition.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/api/v2/dto/request/PostListCondition.java
@@ -2,11 +2,14 @@ package net.causw.app.main.domain.community.post.api.v2.dto.request;
 
 import java.util.List;
 
+import net.causw.app.main.domain.community.board.entity.BoardGroup;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "게시글 목록 조회 요청")
 public record PostListCondition(
 	@Schema(description = "게시판 ID 목록 (null 또는 빈 리스트면 전체 게시판)", example = "[\"board-uuid-1\", \"board-uuid-2\"]") List<String> boardIds,
+	@Schema(description = "게시판 그룹 (소식 = NOTICE, 소통 = COMMUNITY)", example = "NOTICE") BoardGroup boardGroup,
 	@Schema(description = "커서 (마지막 게시글의 createdAt)", example = "2026-02-09T12:00:00") String cursor,
 	@Schema(description = "조회할 개수", example = "20") Integer size,
 	@Schema(description = "검색 키워드", example = "검색어") String keyword) {

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/PostService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/PostService.java
@@ -19,6 +19,8 @@ import net.causw.app.main.domain.asset.file.service.implementation.FileReader;
 import net.causw.app.main.domain.asset.file.service.implementation.UserProfileImageReader;
 import net.causw.app.main.domain.community.board.entity.Board;
 import net.causw.app.main.domain.community.board.entity.BoardConfig;
+import net.causw.app.main.domain.community.board.entity.BoardGroup;
+import net.causw.app.main.domain.community.board.service.implementation.BoardAccessManager;
 import net.causw.app.main.domain.community.board.service.implementation.BoardConfigReader;
 import net.causw.app.main.domain.community.board.service.implementation.BoardReader;
 import net.causw.app.main.domain.community.common.service.CommunityPermissionPolicy;
@@ -64,6 +66,7 @@ public class PostService {
 	private final PostImageManager postImageManager;
 	private final BoardReader boardReader;
 	private final BoardConfigReader boardConfigReader;
+	private final BoardAccessManager boardAccessManager;
 	private final LikePostReader likePostReader;
 	private final BlockReader userBlockReader;
 	private final ApplicationEventPublisher eventPublisher;
@@ -186,6 +189,7 @@ public class PostService {
 		User viewer = query.viewer();
 		CommunityPermissionPolicy.validateActiveUser(viewer);
 		List<String> requestedBoardIds = query.boardIds();
+		BoardGroup boardGroup = query.boardGroup();
 		String cursor = query.cursor();
 		int size = query.size() != null ? query.size() : StaticValue.DEFAULT_POST_PAGE_SIZE; // 기본값 20
 		String keyword = query.keyword();
@@ -206,6 +210,17 @@ public class PostService {
 			}
 
 			boardIds = requestedBoardIds;
+		}
+		// 게시판 ID가 없고, 그룹만 지정된 경우
+		else if (boardGroup != null) {
+			boardIds = boardAccessManager.getReadableBoards(viewer, boardGroup).stream()
+				.map(Board::getId)
+				.toList();
+
+			// 권한이 없거나 게시판이 없는 경우, 빈 목록 반환
+			if (boardIds.isEmpty()) {
+				return PostListResult.of(List.of(), null);
+			}
 		}
 
 		// 뷰어가 차단한 사용자 조회

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/dto/PostListQuery.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/dto/PostListQuery.java
@@ -2,15 +2,17 @@ package net.causw.app.main.domain.community.post.service.dto;
 
 import java.util.List;
 
+import net.causw.app.main.domain.community.board.entity.BoardGroup;
 import net.causw.app.main.domain.user.account.entity.user.User;
 
 public record PostListQuery(
 	User viewer,
 	List<String> boardIds,
+	BoardGroup boardGroup,
 	String cursor,
 	Integer size,
 	String keyword) {
-	public static PostListQuery of(User viewer, List<String> boardIds, String cursor, Integer size, String keyword) {
-		return new PostListQuery(viewer, boardIds, cursor, size, keyword);
+	public static PostListQuery of(User viewer, List<String> boardIds, BoardGroup boardGroup, String cursor, Integer size, String keyword) {
+		return new PostListQuery(viewer, boardIds, boardGroup, cursor, size, keyword);
 	}
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/service/dto/PostListQuery.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/service/dto/PostListQuery.java
@@ -12,7 +12,8 @@ public record PostListQuery(
 	String cursor,
 	Integer size,
 	String keyword) {
-	public static PostListQuery of(User viewer, List<String> boardIds, BoardGroup boardGroup, String cursor, Integer size, String keyword) {
+	public static PostListQuery of(User viewer, List<String> boardIds, BoardGroup boardGroup, String cursor,
+		Integer size, String keyword) {
 		return new PostListQuery(viewer, boardIds, boardGroup, cursor, size, keyword);
 	}
 }

--- a/app-main/src/main/resources/db/migration/V20260824171428__CreateSuccessStoryBoard.sql
+++ b/app-main/src/main/resources/db/migration/V20260824171428__CreateSuccessStoryBoard.sql
@@ -1,0 +1,33 @@
+-- Migration: CreateSuccessStoryBoard
+
+-- 자유 게시판 이름 변경
+UPDATE tb_board
+SET name = '자유',
+    updated_at = NOW()
+WHERE name = '자유 게시판';
+
+
+-- 합격수기 게시판 추가
+SET @new_board_id = UUID();
+
+INSERT INTO tb_board (
+    id, name, description, create_role_list, category,
+    is_deleted, is_default, is_alumni, is_home, is_anonymous_allowed, is_default_notice,
+    created_at, updated_at
+)
+VALUES (
+   @new_board_id, '합격수기', '합격수기 공유 게시판입니다.',
+   'ADMIN,VICE_PRESIDENT,PRESIDENT,LEADER_CIRCLE,LEADER_1,LEADER_2,LEADER_3,LEADER_4,COUNCIL,COMMON,ADMIN,PRESIDENT', 'COMMUNITY',
+   false, false, false, false, true, false,
+   NOW(), NOW()
+);
+
+-- 합격수기 게시판 설정 추가 (display_order는 기존 게시판 설정의 최대값 + 10으로 설정 (맨 마지막 위치))
+INSERT INTO tb_board_config (
+    board_id, is_anonymous, read_scope, write_scope, is_notice,
+    visibility, display_order, created_at, updated_at
+)
+SELECT
+    @new_board_id, 1, 'BOTH', 'ALL_USER', 0,
+    'VISIBLE', COALESCE(MAX(display_order), 0) + 10, NOW(), NOW()
+FROM tb_board_config;

--- a/app-main/src/test/java/net/causw/app/main/domain/community/post/service/PostServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/community/post/service/PostServiceTest.java
@@ -669,7 +669,7 @@ public class PostServiceTest {
 		void getPosts_shouldExcludeBlockedUsersPosts() {
 			// given
 			Set<String> blockedUserIds = Set.of("blocked-writer-id");
-			PostListQuery query = PostListQuery.of(viewer, List.of(boardId), null, 20, null);
+			PostListQuery query = PostListQuery.of(viewer, List.of(boardId), null, null, 20, null);
 			List<String> boardAdminIds = List.of("admin-id");
 
 			given(blockReader.findBlockeeUserIdsByBlocker(viewer)).willReturn(blockedUserIds);
@@ -692,7 +692,7 @@ public class PostServiceTest {
 		@Test
 		void getPosts_shouldSucceed_forSpecificBoard() {
 			// given
-			PostListQuery query = PostListQuery.of(viewer, List.of(boardId), null, 20, null);
+			PostListQuery query = PostListQuery.of(viewer, List.of(boardId), null, null, 20, null);
 
 			List<String> boardAdminIds = List.of("admin-id");
 
@@ -756,7 +756,7 @@ public class PostServiceTest {
 		@Test
 		void getPosts_shouldReturnFalsePermissionFlags_whenPostIsDeleted() {
 			// given
-			PostListQuery query = PostListQuery.of(viewer, List.of(boardId), null, 20, null);
+			PostListQuery query = PostListQuery.of(viewer, List.of(boardId), null, null, 20, null);
 			PostCursorResult deletedPostResult = new PostCursorResult(
 				"deleted-post-id",
 				"테스트 제목",
@@ -806,7 +806,7 @@ public class PostServiceTest {
 		void getPosts_shouldSucceed_forMultipleBoards() {
 			// given
 			String boardId2 = "board-id-2";
-			PostListQuery query = PostListQuery.of(viewer, List.of(boardId, boardId2), null, 20, null);
+			PostListQuery query = PostListQuery.of(viewer, List.of(boardId, boardId2), null, null, 20, null);
 
 			List<String> firstBoardAdminIds = List.of("viewer-id");
 			List<String> secondBoardAdminIds = List.of("admin-id");
@@ -918,7 +918,7 @@ public class PostServiceTest {
 		void getPosts_shouldSucceed_withCursor() {
 			// given
 			String cursor = "2024-01-01T12:00:00|post-id-1";
-			PostListQuery query = PostListQuery.of(viewer, List.of(boardId), cursor, 20, null);
+			PostListQuery query = PostListQuery.of(viewer, List.of(boardId), null, cursor, 20, null);
 
 			List<String> boardAdminIds = List.of("admin-id");
 
@@ -988,7 +988,7 @@ public class PostServiceTest {
 		void getPosts_shouldSucceed_withKeyword() {
 			// given
 			String keyword = "검색어";
-			PostListQuery query = PostListQuery.of(viewer, List.of(boardId), null, 20, keyword);
+			PostListQuery query = PostListQuery.of(viewer, List.of(boardId), null, null, 20, keyword);
 
 			List<String> boardAdminIds = List.of("admin-id");
 
@@ -1047,7 +1047,7 @@ public class PostServiceTest {
 		@Test
 		void getPosts_shouldSucceed_withoutBoardId() {
 			// given
-			PostListQuery query = PostListQuery.of(viewer, null, null, 20, null);
+			PostListQuery query = PostListQuery.of(viewer, null, null, null, 20, null);
 
 			PostCursorResult postCursorResult = new PostCursorResult(
 				"post-id",
@@ -1101,7 +1101,7 @@ public class PostServiceTest {
 		@Test
 		void getPosts_shouldReturnEmpty_whenNoAccessibleBoards() {
 			// given
-			PostListQuery query = PostListQuery.of(viewer, null, null, 20, null);
+			PostListQuery query = PostListQuery.of(viewer, null, null, null, 20, null);
 			Slice<PostCursorResult> emptySlice = new SliceImpl<>(
 				List.of(),
 				PageRequest.of(0, 20),
@@ -1138,7 +1138,7 @@ public class PostServiceTest {
 				null,
 				null);
 
-			PostListQuery query = PostListQuery.of(viewer, List.of(boardId), null, 20, null);
+			PostListQuery query = PostListQuery.of(viewer, List.of(boardId), null, null, 20, null);
 			List<String> boardAdminIds = List.of("admin-id");
 
 			given(boardConfigReader.getByBoardId(boardId)).willReturn(hiddenBoardConfig);
@@ -1154,7 +1154,7 @@ public class PostServiceTest {
 		@Test
 		void getPosts_shouldSucceed_withEmptyResult() {
 			// given
-			PostListQuery query = PostListQuery.of(viewer, List.of(boardId), null, 20, null);
+			PostListQuery query = PostListQuery.of(viewer, List.of(boardId), null, null, 20, null);
 			List<String> boardAdminIds = List.of("admin-id");
 
 			Slice<PostCursorResult> emptySlice = new SliceImpl<>(
@@ -1182,7 +1182,7 @@ public class PostServiceTest {
 		@Test
 		void getPosts_shouldSucceed_withAnonymousPost() {
 			// given
-			PostListQuery query = PostListQuery.of(viewer, List.of(boardId), null, 20, null);
+			PostListQuery query = PostListQuery.of(viewer, List.of(boardId), null, null, 20, null);
 			List<String> boardAdminIds = List.of("admin-id");
 
 			PostCursorResult anonymousPostResult = new PostCursorResult(
@@ -1243,7 +1243,7 @@ public class PostServiceTest {
 		@Test
 		void getPosts_shouldSucceed_withMixedAnonymousPosts() {
 			// given
-			PostListQuery query = PostListQuery.of(viewer, List.of(boardId), null, 20, null);
+			PostListQuery query = PostListQuery.of(viewer, List.of(boardId), null, null, 20, null);
 			List<String> boardAdminIds = List.of("admin-id");
 
 			PostCursorResult normalPostResult = new PostCursorResult(

--- a/app-main/src/test/java/net/causw/app/main/domain/community/post/service/PostServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/community/post/service/PostServiceTest.java
@@ -44,9 +44,11 @@ import net.causw.app.main.domain.asset.file.enums.FilePath;
 import net.causw.app.main.domain.asset.file.service.implementation.UserProfileImageReader;
 import net.causw.app.main.domain.community.board.entity.Board;
 import net.causw.app.main.domain.community.board.entity.BoardConfig;
+import net.causw.app.main.domain.community.board.entity.BoardGroup;
 import net.causw.app.main.domain.community.board.entity.BoardReadScope;
 import net.causw.app.main.domain.community.board.entity.BoardVisibility;
 import net.causw.app.main.domain.community.board.entity.BoardWriteScope;
+import net.causw.app.main.domain.community.board.service.implementation.BoardAccessManager;
 import net.causw.app.main.domain.community.board.service.implementation.BoardConfigReader;
 import net.causw.app.main.domain.community.board.service.implementation.BoardReader;
 import net.causw.app.main.domain.community.post.entity.Post;
@@ -102,6 +104,9 @@ public class PostServiceTest {
 
 	@Mock
 	BoardConfigReader boardConfigReader;
+
+	@Mock
+	BoardAccessManager boardAccessManager;
 
 	@Mock
 	LikePostReader likePostReader;
@@ -1327,6 +1332,56 @@ public class PostServiceTest {
 				() -> assertThat(result.posts().get(1).writerProfileImage().profileImageUrl()).isNull());
 			verify(postReader, times(1)).findPostsWithCursor(anyList(), any(PostReadQueryContext.class), eq(null),
 				eq(null), eq(20), eq(null));
+		}
+
+		@DisplayName("게시판 ID 없이 boardGroup(COMMUNITY)만 넘기면, 해당 탭의 접근 가능한 게시판들의 글을 통합 조회한다")
+		@Test
+		void getPosts_by_boardGroup_success() {
+			// given
+			User viewer = ObjectFixtures.getCertifiedUserWithId("viewer-id");
+			viewer.setAcademicStatus(AcademicStatus.ENROLLED);
+
+			PostListQuery query = PostListQuery.of(viewer, null, BoardGroup.COMMUNITY, null, 20, null);
+
+			String freeBoardId = "free-board-id";
+			String successBoardId = "success-board-id";
+			Board freeBoard = ObjectFixtures.getBoardV2WithId(freeBoardId);
+			Board successBoard = ObjectFixtures.getBoardV2WithId(successBoardId);
+
+			// Mocking
+			given(boardAccessManager.getReadableBoards(viewer, BoardGroup.COMMUNITY))
+				.willReturn(List.of(freeBoard, successBoard));
+
+			PostCursorResult postCursorResult = new PostCursorResult(
+				"post-id", "테스트 제목", "게시글 내용", 5L, 10L, 0L, false, null, false, false, true,
+				"writer-id", "작성자", "닉네임", 2020, UserState.ACTIVE, ProfileImageType.CUSTOM, "profile-url",
+				LocalDateTime.now(), LocalDateTime.now(), freeBoardId, "자유 게시판"
+			);
+			Slice<PostCursorResult> slice = new SliceImpl<>(List.of(postCursorResult), PageRequest.of(0, 20), false);
+
+			// Mocking
+			given(postReader.findPostsWithCursor(
+				eq(List.of(freeBoardId, successBoardId)),
+				any(PostReadQueryContext.class), eq(null), eq(null), eq(20), eq(null)))
+				.willReturn(slice);
+
+			given(postReader.findPostImagesByPostIds(anyList())).willReturn(Map.of());
+			given(likePostReader.getLikedPostIds(anyString(), anyList())).willReturn(Set.of());
+
+			// when
+			PostListResult result = postService.getPosts(query);
+
+			// then
+			assertAll(
+				() -> assertThat(result).isNotNull(),
+				() -> assertThat(result.posts()).hasSize(1),
+				() -> assertThat(result.posts().get(0).boardId()).isEqualTo(freeBoardId)
+			);
+
+			// Verify
+			verify(boardAccessManager, times(1)).getReadableBoards(viewer, BoardGroup.COMMUNITY);
+			verify(postReader, times(1)).findPostsWithCursor(
+				eq(List.of(freeBoardId, successBoardId)), any(PostReadQueryContext.class), eq(null), eq(null), eq(20), eq(null));
 		}
 	}
 

--- a/app-main/src/test/java/net/causw/app/main/domain/community/post/service/PostServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/community/post/service/PostServiceTest.java
@@ -1355,8 +1355,7 @@ public class PostServiceTest {
 			PostCursorResult postCursorResult = new PostCursorResult(
 				"post-id", "테스트 제목", "게시글 내용", 5L, 10L, 0L, false, null, false, false, true,
 				"writer-id", "작성자", "닉네임", 2020, UserState.ACTIVE, ProfileImageType.CUSTOM, "profile-url",
-				LocalDateTime.now(), LocalDateTime.now(), freeBoardId, "자유 게시판"
-			);
+				LocalDateTime.now(), LocalDateTime.now(), freeBoardId, "자유 게시판");
 			Slice<PostCursorResult> slice = new SliceImpl<>(List.of(postCursorResult), PageRequest.of(0, 20), false);
 
 			// Mocking
@@ -1375,13 +1374,13 @@ public class PostServiceTest {
 			assertAll(
 				() -> assertThat(result).isNotNull(),
 				() -> assertThat(result.posts()).hasSize(1),
-				() -> assertThat(result.posts().get(0).boardId()).isEqualTo(freeBoardId)
-			);
+				() -> assertThat(result.posts().get(0).boardId()).isEqualTo(freeBoardId));
 
 			// Verify
 			verify(boardAccessManager, times(1)).getReadableBoards(viewer, BoardGroup.COMMUNITY);
 			verify(postReader, times(1)).findPostsWithCursor(
-				eq(List.of(freeBoardId, successBoardId)), any(PostReadQueryContext.class), eq(null), eq(null), eq(20), eq(null));
+				eq(List.of(freeBoardId, successBoardId)), any(PostReadQueryContext.class), eq(null), eq(null), eq(20),
+				eq(null));
 		}
 	}
 


### PR DESCRIPTION
### 🚩 관련사항
#1477 


### 📢 전달사항
**[작업 배경]**
기존 커뮤니티의 '자유 게시판'을 동문수첩 하위의 '소통' 탭으로 이전하고, 게시판을 [자유 / 합격수기] 2가지로 분기합니다.

**[핵심 변경 사항]**
기존 `tb_board_config` 테이블의 `is_notice` 필드를 활용해 탭을 구분하도록 설계했습니다.
- `NOTICE` (소식 탭): `is_notice = true`
- `COMMUNITY` (소통 탭): `is_notice = false`

1. **BoardGroup Enum 도입**
   - Boolean 파라미터 대신 확장성을 고려해 `BoardGroup` Enum(`NOTICE`, `COMMUNITY`)을 도입하여 명시적으로 탭을 구분했습니다.
2. **게시판 목록 조회 필터링 적용**
   - `BoardController`의 조회 API(`/available`, `/writable`)에 `boardGroup` 파라미터를 추가하여, 각 탭에 속한 게시판만 안전하게 필터링하여 응답합니다.
3. **'전체' 탭 클릭 시 게시글 통합 조회 로직 구현**
   - `PostController`에서 특정 게시판 ID 없이 `boardGroup`만 요청될 경우, `BoardAccessManager`를 통해 현재 유저가 읽을 수 있는 해당 그룹의 게시판 ID 리스트를 동적으로 추출합니다.
   - 이를 기존 QueryDSL 로직에 넘겨주어, 쿼리 수정이나 성능 저하 없이 탭별 전체 게시글 통합 조회가 가능하도록 구현했습니다.
4. **DB 마이그레이션 스크립트 작성**
   - 기존 '자유 게시판'은 명칭만 '자유'로 업데이트하여 기존 게시글을 그대로 유지합니다.
   - 신규 '합격수기' 게시판 및 설정 데이터를 생성하는 Flyway(또는 셋업) 스크립트를 추가했습니다.


### 📸 스크린샷
<img width="547" height="859" alt="image" src="https://github.com/user-attachments/assets/3c3d1beb-c070-41a2-92b3-259ef96528e7" />

파라미터로 boardGroup값을 같이 넘기면, 해당 탭의 조건에 맞는 게시판 정보 반환 (NOTICE)

<img width="564" height="803" alt="image" src="https://github.com/user-attachments/assets/4e256943-19c7-42a9-82ef-d5203bcf788a" />

COMMUNITY도 동일


### 📃 진행사항
- [x] 신규 합격 수기 게시판 및 게시판 설정(tb_board_config) 추가 SQL 작성
- [x] 기존 자유 게시판 명칭 업데이트 SQL 작성
- [x] 게시판 목록 조회 API(`/boards/available`, `/writable`) `boardGroup` 필터링 로직 추가
- [x] 게시글 목록 조회 API(`/posts`) 탭(그룹)별 전체 게시글 통합 조회 로직 추가


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 2d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 게시판을 공지와 커뮤니티 그룹으로 구분해 조회할 수 있습니다.
  * 게시글 목록에서 게시판 그룹을 기준으로 검색 범위를 지정할 수 있습니다.
  * 새로운 ‘합격수기’ 게시판이 추가되었습니다.
  * ‘자유 게시판’ 이름이 ‘자유’로 변경되었습니다.

* **변경 사항**
  * 게시판 조회 시 게시판 그룹 선택이 필수로 변경되었습니다.
  * 사용자가 접근 가능한 게시판만 그룹별로 표시됩니다.
  * ‘합격수기’ 게시판에서는 익명 게시글을 작성할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->