### PR TITLE
feat: 동문 수첩 학과 복수 필터 추가

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/dto/request/UserInfoListRequest.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/dto/request/UserInfoListRequest.java
@@ -2,6 +2,8 @@ package net.causw.app.main.domain.user.account.api.v2.dto.request;
 
 import java.util.List;
 
+import net.causw.app.main.domain.user.account.enums.user.Department;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 
@@ -14,6 +16,8 @@ public record UserInfoListRequest(
 	@Schema(description = "학번 범위 끝", example = "2025") Integer admissionYearEnd,
 
 	@Schema(description = "학적 상태", example = "[\"ENROLLED\", \"GRADUATED\"]") List<String> academicStatus,
+
+	@Schema(description = "학과 필터링 (복수 선택 가능, 미선택 시 전체)", example = "[\"SCHOOL_OF_SW\", \"SCHOOL_OF_CSE\"]") List<Department> department,
 
 	@Schema(description = "정렬 기준", example = "UPDATED_AT_DESC") String sortType,
 

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/userInfo/UserInfoQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/repository/userInfo/UserInfoQueryRepository.java
@@ -16,6 +16,7 @@ import net.causw.app.main.domain.user.account.entity.user.QUser;
 import net.causw.app.main.domain.user.account.entity.userInfo.QUserCareer;
 import net.causw.app.main.domain.user.account.entity.userInfo.QUserInfo;
 import net.causw.app.main.domain.user.account.entity.userInfo.UserInfo;
+import net.causw.app.main.domain.user.account.enums.user.Department;
 import net.causw.app.main.domain.user.account.enums.userinfo.SortType;
 import net.causw.app.main.domain.user.account.enums.userinfo.UserInfoSectionType;
 import net.causw.app.main.domain.user.account.service.dto.request.UserInfoListCondition;
@@ -248,6 +249,7 @@ public class UserInfoQueryRepository {
 			condition = condition.and(userInfo.user.id.ne(excludeUserId));
 		}
 		List<String> academicStatusList = filter.academicStatus();
+		List<Department> departmentList = filter.department();
 		Integer admissionYearStart = filter.admissionYearStart();
 		Integer admissionYearEnd = filter.admissionYearEnd();
 		String keyword = filter.keyword();
@@ -261,6 +263,11 @@ public class UserInfoQueryRepository {
 				.map(AcademicStatus::fromString)
 				.toList();
 			condition = condition.and(userInfo.user.academicStatus.in(academicStatuses));
+		}
+
+		// 학과 필터
+		if (departmentList != null && !departmentList.isEmpty()) {
+			condition = condition.and(userInfo.user.department.in(departmentList));
 		}
 
 		// 학번 필터

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/service/dto/request/UserInfoListCondition.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/service/dto/request/UserInfoListCondition.java
@@ -2,10 +2,13 @@ package net.causw.app.main.domain.user.account.service.dto.request;
 
 import java.util.List;
 
+import net.causw.app.main.domain.user.account.enums.user.Department;
+
 public record UserInfoListCondition(
 	String keyword,
 	Integer admissionYearStart,
 	Integer admissionYearEnd,
 	List<String> academicStatus,
+	List<Department> department,
 	String sortType) {
 }


### PR DESCRIPTION
### 🚩 관련사항
Closes #1501

### 📢 전달사항
동문 수첩 목록에서 사용자가 여러 학과를 선택해 조회 범위를 좁힐 수 있도록 `department` 필터를 추가했습니다.

`GET /api/v2/users-info`와 커서 기반인 `GET /api/v2/users-info/list`가 동일한 목록 조건을 사용하므로 두 API에 함께 적용됩니다. `department` 값을 반복 전달하면 QueryDSL `IN` 조건으로 선택한 학과만 조회하며, 파라미터가 없거나 빈 목록이면 조건을 생략해 기존과 같이 전체 학과를 조회합니다.

요청 예시: `?department=SCHOOL_OF_SW&department=SCHOOL_OF_CSE`

### 📸 스크린샷
N/A

### 📃 진행사항
- [x] user-info 목록 요청과 서비스 조건에 복수 학과 필터를 추가했습니다.
- [x] 선택한 학과 목록을 QueryDSL `IN` 조건으로 적용했습니다.
- [x] 미선택 시 기존 전체 조회 동작을 유지했습니다.
- [x] `UserInfoServiceTest` 및 Spotless 검증을 완료했습니다.

### ⚙️ 기타사항
DB 스키마 변경은 없습니다.

개발기간: 2026-08-25 ~ 2026-08-25


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 목록 조회 시 여러 학과를 선택해 필터링할 수 있습니다.
  * 학과 필터를 선택하지 않으면 기존과 동일하게 전체 학과를 조회합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->