### PR TITLE
feat: 시스템 공지 관리자 목록 API 추가

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/repository/PostRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/repository/PostRepository.java
@@ -25,6 +25,9 @@ public interface PostRepository extends JpaRepository<Post, String> {
 
 	Optional<Post> findTop1ByBoard_IdAndIsDeletedIsFalseOrderByCreatedAtDesc(String boardId);
 
+	@EntityGraph(attributePaths = {"writer"})
+	List<Post> findAllByBoard_IdAndIsDeletedIsFalseOrderByCreatedAtDesc(String boardId);
+
 	// Repository
 	@Query("""
 		    SELECT p FROM Post p

--- a/app-main/src/main/java/net/causw/app/main/domain/community/systemnotice/api/v2/controller/AdminSystemNoticeController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/systemnotice/api/v2/controller/AdminSystemNoticeController.java
@@ -1,9 +1,12 @@
 package net.causw.app.main.domain.community.systemnotice.api.v2.controller;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -35,6 +38,13 @@ public class AdminSystemNoticeController {
 
 	private final SystemNoticeService systemNoticeService;
 	private final SystemNoticeDtoMapper systemNoticeDtoMapper;
+
+	@GetMapping
+	@Operation(summary = "시스템 공지 목록 조회", description = "시스템 공지를 최신순으로 조회합니다.")
+	public ApiResponse<List<SystemNoticeCreateResponse>> getAll(
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		return ApiResponse.success(systemNoticeDtoMapper.toCreateResponseList(systemNoticeService.getAll()));
+	}
 
 	@PostMapping
 	@ResponseStatus(HttpStatus.CREATED)

--- a/app-main/src/main/java/net/causw/app/main/domain/community/systemnotice/api/v2/mapper/SystemNoticeDtoMapper.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/systemnotice/api/v2/mapper/SystemNoticeDtoMapper.java
@@ -1,5 +1,7 @@
 package net.causw.app.main.domain.community.systemnotice.api.v2.mapper;
 
+import java.util.List;
+
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -21,4 +23,6 @@ public interface SystemNoticeDtoMapper {
 	SystemNoticeUpdateCommand toUpdateCommand(SystemNoticeUpdateRequest request, User user);
 
 	SystemNoticeCreateResponse toCreateResponse(SystemNoticeCreateResult result);
+
+	List<SystemNoticeCreateResponse> toCreateResponseList(List<SystemNoticeCreateResult> results);
 }

--- a/app-main/src/main/java/net/causw/app/main/domain/community/systemnotice/service/SystemNoticeService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/systemnotice/service/SystemNoticeService.java
@@ -75,6 +75,17 @@ public class SystemNoticeService {
 			});
 	}
 
+	public List<SystemNoticeCreateResult> getAll() {
+		return systemNoticeReader.findAllPosts().stream()
+			.map(post -> new SystemNoticeCreateResult(
+				post.getId(),
+				post.getTitle(),
+				post.getContent(),
+				post.getWriter().getNickname(),
+				post.getCreatedAt()))
+			.toList();
+	}
+
 	@Transactional
 	public void markAsRead(User viewer, String postId) {
 		CommunityPermissionPolicy.validateActiveUser(viewer);

--- a/app-main/src/main/java/net/causw/app/main/domain/community/systemnotice/service/implementation/SystemNoticeReader.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/systemnotice/service/implementation/SystemNoticeReader.java
@@ -32,6 +32,13 @@ public class SystemNoticeReader {
 				.findTop1ByBoard_IdAndIsDeletedIsFalseOrderByCreatedAtDesc(config.getBoardId()));
 	}
 
+	public List<Post> findAllPosts() {
+		return findSystemNoticeConfig()
+			.map(config -> postRepository
+				.findAllByBoard_IdAndIsDeletedIsFalseOrderByCreatedAtDesc(config.getBoardId()))
+			.orElseGet(List::of);
+	}
+
 	public Optional<UserSystemNoticeRead> findReadByUserId(String userId) {
 		return userSystemNoticeReadRepository.findByUserId(userId);
 	}

--- a/app-main/src/test/java/net/causw/app/main/domain/community/systemnotice/api/v2/controller/AdminSystemNoticeControllerTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/community/systemnotice/api/v2/controller/AdminSystemNoticeControllerTest.java
@@ -1,0 +1,48 @@
+package net.causw.app.main.domain.community.systemnotice.api.v2.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import net.causw.app.main.domain.community.systemnotice.api.v2.dto.response.SystemNoticeCreateResponse;
+import net.causw.app.main.domain.community.systemnotice.api.v2.mapper.SystemNoticeDtoMapper;
+import net.causw.app.main.domain.community.systemnotice.service.SystemNoticeService;
+import net.causw.app.main.domain.community.systemnotice.service.dto.SystemNoticeCreateResult;
+import net.causw.app.main.domain.user.auth.userdetails.CustomUserDetails;
+import net.causw.app.main.shared.dto.ApiResponse;
+
+@ExtendWith(MockitoExtension.class)
+class AdminSystemNoticeControllerTest {
+
+	@InjectMocks
+	private AdminSystemNoticeController adminSystemNoticeController;
+
+	@Mock
+	private SystemNoticeService systemNoticeService;
+	@Mock
+	private SystemNoticeDtoMapper systemNoticeDtoMapper;
+	@Mock
+	private CustomUserDetails userDetails;
+
+	@Test
+	void getAllReturnsMappedSystemNotices() {
+		SystemNoticeCreateResult result = new SystemNoticeCreateResult(
+			"post-id", "공지", "내용", "관리자", LocalDateTime.of(2026, 8, 25, 12, 0));
+		SystemNoticeCreateResponse response = new SystemNoticeCreateResponse(
+			"post-id", "공지", "내용", "관리자", LocalDateTime.of(2026, 8, 25, 12, 0));
+		given(systemNoticeService.getAll()).willReturn(List.of(result));
+		given(systemNoticeDtoMapper.toCreateResponseList(List.of(result))).willReturn(List.of(response));
+
+		ApiResponse<List<SystemNoticeCreateResponse>> apiResponse = adminSystemNoticeController.getAll(userDetails);
+
+		assertThat(apiResponse.getData()).containsExactly(response);
+	}
+}

--- a/app-main/src/test/java/net/causw/app/main/domain/community/systemnotice/service/SystemNoticeServiceTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/community/systemnotice/service/SystemNoticeServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.verify;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -186,6 +187,30 @@ class SystemNoticeServiceTest {
 
 		assertThat(result.title()).isEqualTo("테스트 제목");
 		assertThat(result.content()).isEqualTo("content");
+	}
+
+	@Test
+	void getAllReturnsSystemNoticesInReaderOrder() {
+		User writer = org.mockito.Mockito.mock(User.class);
+		Post olderPost = org.mockito.Mockito.mock(Post.class);
+		given(systemNoticeReader.findAllPosts()).willReturn(List.of(latestPost, olderPost));
+		given(latestPost.getId()).willReturn("latest-post-id");
+		given(latestPost.getTitle()).willReturn("최신 공지");
+		given(latestPost.getContent()).willReturn("latest content");
+		given(latestPost.getWriter()).willReturn(writer);
+		given(latestPost.getCreatedAt()).willReturn(LocalDateTime.of(2026, 8, 25, 12, 0));
+		given(olderPost.getId()).willReturn("older-post-id");
+		given(olderPost.getTitle()).willReturn("이전 공지");
+		given(olderPost.getContent()).willReturn("older content");
+		given(olderPost.getWriter()).willReturn(writer);
+		given(olderPost.getCreatedAt()).willReturn(LocalDateTime.of(2026, 8, 24, 12, 0));
+		given(writer.getNickname()).willReturn("관리자");
+
+		List<SystemNoticeCreateResult> results = systemNoticeService.getAll();
+
+		assertThat(results).extracting(SystemNoticeCreateResult::id)
+			.containsExactly("latest-post-id", "older-post-id");
+		assertThat(results.get(0).authorName()).isEqualTo("관리자");
 	}
 
 	@Test


### PR DESCRIPTION
### 🚩 관련사항
Closes #1504

### 📢 전달사항

시스템 공지 관리자 화면에서 기존 공지 전체를 확인할 수 있도록 최신순 목록 조회 API를 추가했습니다.

관리자 권한이 필요한 `GET /api/v2/admin/system-notices`는 삭제되지 않은 시스템 공지를 페이지네이션 없이 최신순으로 반환합니다. 기존 생성 응답과 동일한 `id`, `title`, `content`, `authorName`, `createdAt` 계약을 재사용했으며, 게시글 조회 시 작성자 정보를 함께 조회하도록 구성했습니다.

리뷰 시 시스템 공지 게시판 설정이 없을 때 빈 목록을 반환하는 동작과 목록 정렬 기준을 확인 부탁드립니다.

### 📸 스크린샷
N/A

### 📃 진행사항

- [x] 시스템 공지 전체 목록을 최신순으로 조회하는 리더·서비스 로직 추가
- [x] 관리자 전용 시스템 공지 목록 조회 API 및 응답 매핑 추가
- [x] 관리자 컨트롤러와 서비스 목록 조회 테스트 추가

### ⚙️ 기타사항

- `:app-main:test` 대상 테스트 및 `:app-main:spotlessCheck`를 실행했으나, 로컬에 Java 25 toolchain이 없어 `:global:compileJava` 단계에서 실행되지 않았습니다.
- 데이터베이스 마이그레이션 또는 스키마 변경 없음

개발기간: 2026-08-25 ~ 2026-08-25


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 관리자 시스템 공지 목록을 최신순으로 조회할 수 있는 API가 추가되었습니다.
  * 시스템 공지에 게시글 작성자와 생성 시각이 함께 표시됩니다.
  * 삭제되지 않은 시스템 공지만 목록에 포함됩니다.

* **테스트**
  * 시스템 공지 목록 조회 및 응답 변환에 대한 검증이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->