### PR TITLE
fix: 시스템관리자 조회 N+1 쿼리 최적화

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/repository/query/PostQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/repository/query/PostQueryRepository.java
@@ -526,8 +526,7 @@ public class PostQueryRepository {
 			.from(user)
 			.where(
 				user.id.in(userIds),
-				user.roles.contains(Role.SYSTEM_ADMIN)
-			)
+				user.roles.contains(Role.SYSTEM_ADMIN))
 			.fetch();
 
 		return new HashSet<>(systemAdminIds);

--- a/app-main/src/main/java/net/causw/app/main/domain/community/post/repository/query/PostQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/post/repository/query/PostQueryRepository.java
@@ -526,7 +526,8 @@ public class PostQueryRepository {
 			.from(user)
 			.where(
 				user.id.in(userIds),
-				user.roles.any().eq(Role.SYSTEM_ADMIN))
+				user.roles.contains(Role.SYSTEM_ADMIN)
+			)
 			.fetch();
 
 		return new HashSet<>(systemAdminIds);


### PR DESCRIPTION
### 🚩 관련사항
x


### 📢 전달사항
**[장애 발생 배경 및 원인]**
- 최근 관리자 권한 개편 PR(#1476) 배포 이후, 게시글 목록 조회 API 호출 시 쿼리 폭주로 인해 EC2 서버(t2.micro)의 메모리가 급증하며 서버가 프리징되는 장애가 발생했습니다.
- 원인 분석 결과, `PostQueryRepository.findSystemAdminUserIds()` 메서드 내부에서 QueryDSL의 `.any().eq(Role.SYSTEM_ADMIN)` 문법을 사용한 것이 문제였습니다.
- `@ElementCollection`인 `roles`에 해당 문법을 사용 시, DB 단에서 한 번에 쿼리가 나가지 않고 **가져온 유저의 수만큼 `user_roles` 테이블을 단건으로 반복 조회하는 치명적인 N+1 쿼리가 발생**했습니다.

**[해결 로직]**
- `.any().eq()` 대신 JPA 표준 문법인 `MEMBER OF`로 정확히 번역되는 **`.contains()`**로 수정했습니다.
- 이를 통해 하이버네이트가 최적화된 단일 `EXISTS` 서브쿼리를 생성하도록 유도하여, 유저 수와 관계없이 단 1번의 쿼리로 조회되도록 최적화했습니다.


### 📸 스크린샷
<img width="1904" height="69" alt="image" src="https://github.com/user-attachments/assets/31227f4a-2762-4663-9099-d0df89da4bfb" />

<img width="620" height="323" alt="image" src="https://github.com/user-attachments/assets/7c453ad0-6d61-4080-afb5-04bf10f853d9" />

분명 머지할때는 아무 이슈가 없었지만 머지 후 테스트 과정에서 서버가 unhealthy로 바뀌며 응답하지 않는 현상 발생

### 📃 진행사항
- [x] `PostQueryRepository.findSystemAdminUserIds` 내 QueryDSL 문법 수정 (`.any().eq()` -> `.contains()`)


### ⚙️ 기타사항
기타 참고사항을 적어주세요.

개발기간: 