### PR TITLE
refactor: hasAnyRole 시큐리티 메서드 추가 및 admin 컨트롤러 적용

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/admin/audit/api/v2/controller/AdminAuditLogController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/admin/audit/api/v2/controller/AdminAuditLogController.java
@@ -24,7 +24,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/admin/audit-logs")
-@PreAuthorize("@security.hasRole(@Role.ADMIN) or @security.hasRole(@Role.SYSTEM_ADMIN)")
+@PreAuthorize("@security.hasAnyRole(@Role.ADMIN, @Role.SYSTEM_ADMIN)")
 @RequireAdminRole(target = AdminTarget.ALL_ADMIN)
 @Tag(name = "Admin Audit Log v2", description = "관리자 감사 로그 API")
 public class AdminAuditLogController {

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/file/api/v2/controller/FileController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/file/api/v2/controller/FileController.java
@@ -74,7 +74,7 @@ public class FileController {
 
 	@Operation(summary = "파일 업로드 (ADMIN)", description = "단일 파일을 업로드합니다.")
 	@PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	@PreAuthorize("@security.hasRole(@Role.ADMIN) or @security.hasRole(@Role.SYSTEM_ADMIN)")
+	@PreAuthorize("@security.hasAnyRole(@Role.ADMIN, @Role.SYSTEM_ADMIN)")
 	@RequireAdminRole(target = AdminTarget.ALL_ADMIN)
 	public ApiResponse<FileUploadResponse> uploadFile(
 		@RequestParam("file") MultipartFile file,
@@ -88,7 +88,7 @@ public class FileController {
 
 	@Operation(summary = "다중 파일 업로드", description = "여러 파일을 한 번에 업로드합니다.")
 	@PostMapping(value = "/upload/multiple", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	@PreAuthorize("@security.hasRole(@Role.ADMIN) or @security.hasRole(@Role.SYSTEM_ADMIN)")
+	@PreAuthorize("@security.hasAnyRole(@Role.ADMIN, @Role.SYSTEM_ADMIN)")
 	@RequireAdminRole(target = AdminTarget.ALL_ADMIN)
 	public ApiResponse<MultipleFilesUploadResponse> uploadMultipleFiles(
 		@RequestParam("files") List<MultipartFile> files,
@@ -102,7 +102,7 @@ public class FileController {
 
 	@Operation(summary = "파일 조회", description = "파일 ID로 파일 정보를 조회합니다.")
 	@GetMapping("/{fileId}")
-	@PreAuthorize("@security.hasRole(@Role.ADMIN) or @security.hasRole(@Role.SYSTEM_ADMIN)")
+	@PreAuthorize("@security.hasAnyRole(@Role.ADMIN, @Role.SYSTEM_ADMIN)")
 	@RequireAdminRole(target = AdminTarget.ALL_ADMIN)
 	public ApiResponse<FileInfoResponse> getFile(@PathVariable String fileId) {
 		log.info("File info requested. FileId: {}", fileId);
@@ -114,7 +114,7 @@ public class FileController {
 
 	@Operation(summary = "파일 수정", description = "기존 파일을 삭제하고 새 파일로 교체합니다.")
 	@PutMapping(value = "/{fileId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	@PreAuthorize("@security.hasRole(@Role.ADMIN) or @security.hasRole(@Role.SYSTEM_ADMIN)")
+	@PreAuthorize("@security.hasAnyRole(@Role.ADMIN, @Role.SYSTEM_ADMIN)")
 	@RequireAdminRole(target = AdminTarget.ALL_ADMIN)
 	public ApiResponse<FileUploadResponse> updateFile(
 		@PathVariable String fileId,
@@ -129,7 +129,7 @@ public class FileController {
 
 	@Operation(summary = "파일 삭제", description = "파일을 삭제합니다.")
 	@DeleteMapping("/{fileId}")
-	@PreAuthorize("@security.hasRole(@Role.ADMIN) or @security.hasRole(@Role.SYSTEM_ADMIN)")
+	@PreAuthorize("@security.hasAnyRole(@Role.ADMIN, @Role.SYSTEM_ADMIN)")
 	@RequireAdminRole(target = AdminTarget.ALL_ADMIN)
 	public ApiResponse<Void> deleteFile(@PathVariable String fileId) {
 		log.info("File delete requested. FileId: {}", fileId);

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/api/v2/controller/admin/LockerAdminController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/api/v2/controller/admin/LockerAdminController.java
@@ -35,7 +35,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/admin/lockers")
-@PreAuthorize("@security.hasRole(@Role.ADMIN) or @security.hasRole(@Role.SYSTEM_ADMIN)")
+@PreAuthorize("@security.hasAnyRole(@Role.ADMIN, @Role.SYSTEM_ADMIN)")
 @RequireAdminRole(target = AdminTarget.ENROLLED_ADMIN)
 @Tag(name = "Locker Admin v2", description = "관리자 사물함 관리 API V2")
 public class LockerAdminController {

--- a/app-main/src/main/java/net/causw/app/main/domain/asset/locker/api/v2/controller/admin/LockerPolicyAdminController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/asset/locker/api/v2/controller/admin/LockerPolicyAdminController.java
@@ -26,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/admin/lockers/policy")
-@PreAuthorize("@security.hasRole(@Role.ADMIN) or @security.hasRole(@Role.SYSTEM_ADMIN)")
+@PreAuthorize("@security.hasAnyRole(@Role.ADMIN, @Role.SYSTEM_ADMIN)")
 @RequireAdminRole(target = AdminTarget.ENROLLED_ADMIN)
 @Tag(name = "LockerPolicy Admin v2", description = "관리자 사물함 정책 관리 API V2")
 public class LockerPolicyAdminController {

--- a/app-main/src/main/java/net/causw/app/main/domain/campus/schedule/api/v2/controller/ScheduleAdminController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/campus/schedule/api/v2/controller/ScheduleAdminController.java
@@ -31,7 +31,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/admin/schedules")
-@PreAuthorize("@security.hasRole(@Role.ADMIN) or @security.hasRole(@Role.SYSTEM_ADMIN)")
+@PreAuthorize("@security.hasAnyRole(@Role.ADMIN, @Role.SYSTEM_ADMIN)")
 @RequireAdminRole(target = AdminTarget.ENROLLED_ADMIN)
 public class ScheduleAdminController {
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/controller/BoardAdminController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/controller/BoardAdminController.java
@@ -37,7 +37,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/admin/boards")
-@PreAuthorize("@security.hasRole(@Role.ADMIN) or @security.hasRole(@Role.SYSTEM_ADMIN)")
+@PreAuthorize("@security.hasAnyRole(@Role.ADMIN, @Role.SYSTEM_ADMIN)")
 @RequireAdminRole(target = AdminTarget.SYSTEM_ONLY)
 @Tag(name = "Board Admin v2", description = "관리자 게시판 관리 API")
 public class BoardAdminController {

--- a/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/api/v2/controller/CeremonyAdminController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/ceremony/api/v2/controller/CeremonyAdminController.java
@@ -40,7 +40,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/admin/ceremonies")
-@PreAuthorize("@security.hasRole(@Role.ADMIN) or @security.hasRole(@Role.SYSTEM_ADMIN)")
+@PreAuthorize("@security.hasAnyRole(@Role.ADMIN, @Role.SYSTEM_ADMIN)")
 @RequireAdminRole(target = AdminTarget.ALL_ADMIN)
 public class CeremonyAdminController {
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/report/api/v2/controller/ReportAdminController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/report/api/v2/controller/ReportAdminController.java
@@ -28,7 +28,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/admin/reports")
-@PreAuthorize("@security.hasRole(@Role.ADMIN) or @security.hasRole(@Role.SYSTEM_ADMIN)")
+@PreAuthorize("@security.hasAnyRole(@Role.ADMIN, @Role.SYSTEM_ADMIN)")
 @RequireAdminRole(target = AdminTarget.ALL_ADMIN)
 @Tag(name = "Report Admin v2", description = "관리자 신고 관리 API")
 public class ReportAdminController {

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/api/v2/controller/NotificationAdminController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/api/v2/controller/NotificationAdminController.java
@@ -22,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/admin/notifications")
-@PreAuthorize("@security.hasRole(@Role.ADMIN) or @security.hasRole(@Role.SYSTEM_ADMIN)")
+@PreAuthorize("@security.hasAnyRole(@Role.ADMIN, @Role.SYSTEM_ADMIN)")
 @RequireAdminRole(target = AdminTarget.ALL_ADMIN)
 @Tag(name = "Notification Admin v2", description = "관리자 알림 관리 API")
 public class NotificationAdminController {

--- a/app-main/src/main/java/net/causw/app/main/domain/user/academic/api/v2/controller/AcademicRecordAdminController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/academic/api/v2/controller/AcademicRecordAdminController.java
@@ -30,7 +30,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/admin/academic-records")
-@PreAuthorize("@security.hasRole(@Role.ADMIN) or @security.hasRole(@Role.SYSTEM_ADMIN)")
+@PreAuthorize("@security.hasAnyRole(@Role.ADMIN, @Role.SYSTEM_ADMIN)")
 @RequireAdminRole(target = AdminTarget.ALL_ADMIN)
 @Tag(name = "AcademicRecord Admin v2", description = "관리자 학적상태 변경신청 관리 API")
 public class AcademicRecordAdminController {

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/controller/UserAdminController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/controller/UserAdminController.java
@@ -42,7 +42,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/admin/users")
-@PreAuthorize("@security.hasRole(@Role.ADMIN) or @security.hasRole(@Role.SYSTEM_ADMIN)")
+@PreAuthorize("@security.hasAnyRole(@Role.ADMIN, @Role.SYSTEM_ADMIN)")
 @RequireAdminRole(target = AdminTarget.ALL_ADMIN)
 @Tag(name = "User Admin v2", description = "관리자 권한으로 사용자 계정을 관리하는 API")
 public class UserAdminController {

--- a/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/controller/UserQueryAdminController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/account/api/v2/controller/UserQueryAdminController.java
@@ -29,7 +29,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/admin/users")
-@PreAuthorize("@security.hasRole(@Role.ADMIN) or @security.hasRole(@Role.SYSTEM_ADMIN)")
+@PreAuthorize("@security.hasAnyRole(@Role.ADMIN, @Role.SYSTEM_ADMIN)")
 @RequireAdminRole(target = AdminTarget.ALL_ADMIN)
 @Tag(name = "User Admin Query v2", description = "게시판 관리 등 관리자 기능에서 공통으로 사용되는 사용자 검색용 API")
 public class UserQueryAdminController {

--- a/app-main/src/main/java/net/causw/app/main/domain/user/auth/service/SecurityService.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/user/auth/service/SecurityService.java
@@ -54,6 +54,19 @@ public class SecurityService {
 	}
 
 	/**
+	 * 현재 인증된 사용자가 주어진 Role 중 하나라도 보유하고 있는지 확인
+	 * @param roles Role enum 배열 (예: Role.ADMIN, Role.SYSTEM_ADMIN)
+	 */
+	public boolean hasAnyRole(Role... roles) {
+		for (Role role : roles) {
+			if (hasRole(role)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * 현재 인증된 사용자가 활성 상태인지 확인
 	 * <p>
 	 * 사용자 상태(UserState)가 ACTIVE고


### PR DESCRIPTION
### 🚩 관련사항
x

### 📢 전달사항
**[버그 현상 및 원인]**

* **현상:** 직전 PR(학적 기반 권한 분리) 반영 후, **`SYSTEM_ADMIN` 계정으로 관리자 API 호출 시 403 Forbidden 에러가 발생하는 이슈**가 있었습니다.
* **원인:** 컨트롤러 상단에 적용했던 `@PreAuthorize("@security.hasRole(@Role.ADMIN) or @security.hasRole(@Role.SYSTEM_ADMIN)")` 구문에서, 커스텀 빈(`@security`)과 AOP(`@MeasureTime` 등)가 겹치며 SpEL의 `or` 단락 평가(Short-circuit evaluation)가 의도대로 작동하지 않는 프록시 충돌 이슈가 발생했습니다.

**[해결 방안 및 주요 변경 포인트]**

* **`SecurityService.hasAnyRole` 메서드 추가:** SpEL 상에서 `or` 연산을 수행하는 대신, 백엔드 로직 내부에서 가변 인자(`Role... roles`)를 받아 한 번에 권한을 검사하는 `hasAnyRole` 메서드를 신규 구현했습니다.
* **Admin 컨트롤러 일괄 적용:** 기존의 `or` 구문들을 모두 `@PreAuthorize("@security.hasAnyRole(@Role.ADMIN, @Role.SYSTEM_ADMIN)")` 형태로 변경했습니다.
* *(참고)* 스프링 내장 기능(`hasAnyRole('ADMIN')`) 대신 기존 커스텀 빈 방식을 유지한 이유는, 문자열 하드코딩으로 인한 휴먼 에러를 방지(Enum 타입 안정성 확보)하고 기존 도메인 특화 인가 로직(`isCertifiedUser` 등)과의 **설계 일관성을 유지**하기 위함입니다.



### 📸 스크린샷
x


### 📃 진행사항
* [x] `SecurityService`에 `hasAnyRole(Role... roles)` 메서드 신규 구현
* [x] 모든 관리자 전용 Controller의 `@PreAuthorize` 어노테이션 수정 (`hasRole or hasRole` -> `hasAnyRole`)
* [x] 로컬 환경에서 `SYSTEM_ADMIN` 계정으로 403 에러 발생 여부 테스트 및 해결 확인


### ⚙️ 기타사항
x

개발기간: 1d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **권한 관리 개선**
  * 관리자 기능 전반에서 `ADMIN` 또는 `SYSTEM_ADMIN` 역할을 보유한 경우 접근할 수 있도록 권한 검사를 일관되게 정리했습니다.
  * 감사 로그, 파일, 사물함, 일정, 게시판, 신고, 알림 및 사용자 관리 기능에 동일한 접근 기준이 적용됩니다.
  * 관리자 권한 확인 방식이 단순화되어 접근 제어의 일관성과 유지보수성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->