### PR TITLE
fix: WebSecurityConfig admin관련 권한 추가

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/core/security/WebSecurityConfig.java
+++ b/app-main/src/main/java/net/causw/app/main/core/security/WebSecurityConfig.java
@@ -83,7 +83,7 @@ public class WebSecurityConfig {
 				.permitAll()
 				.requestMatchers(HttpMethod.GET, "/api/v2/terms")
 				.permitAll()
-				.requestMatchers("/api/v2/admin/**").hasRole("ADMIN")
+				.requestMatchers("/api/v2/admin/**").hasAnyRole("ADMIN", "SYSTEM_ADMIN")
 				.anyRequest().authenticated())
 			.oauth2Login(oauth2 -> oauth2
 				.authorizationEndpoint(authorizationEndpoint -> authorizationEndpoint

--- a/app-main/src/main/java/net/causw/app/main/domain/admin/monitoring/api/v2/controller/ServerErrorAlertTestController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/admin/monitoring/api/v2/controller/ServerErrorAlertTestController.java
@@ -5,6 +5,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import net.causw.app.main.core.aop.annotation.RequireAdminRole;
+import net.causw.app.main.core.aop.enums.AdminTarget;
 import net.causw.app.main.shared.dto.ApiResponse;
 import net.causw.global.exception.ErrorCode;
 import net.causw.global.exception.ServiceUnavailableException;
@@ -14,7 +16,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequestMapping("/api/v2/admin/system-error-tests")
-@PreAuthorize("@security.hasRole(@Role.ADMIN)")
+@PreAuthorize("@security.hasAnyRole(@Role.ADMIN, @Role.SYSTEM_ADMIN)")
+@RequireAdminRole(target = AdminTarget.SYSTEM_ONLY)
 @Tag(name = "System Error Alert Test v2", description = "서버 오류 알림 검증 API")
 public class ServerErrorAlertTestController {
 

--- a/app-main/src/main/java/net/causw/app/main/domain/community/systemnotice/api/v2/controller/AdminSystemNoticeController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/systemnotice/api/v2/controller/AdminSystemNoticeController.java
@@ -15,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import net.causw.app.main.core.aop.annotation.RequireAdminRole;
+import net.causw.app.main.core.aop.enums.AdminTarget;
 import net.causw.app.main.domain.community.systemnotice.api.v2.dto.request.SystemNoticeCreateRequest;
 import net.causw.app.main.domain.community.systemnotice.api.v2.dto.request.SystemNoticeUpdateRequest;
 import net.causw.app.main.domain.community.systemnotice.api.v2.dto.response.SystemNoticeCreateResponse;
@@ -32,7 +34,8 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/admin/system-notices")
-@PreAuthorize("@security.hasRole(@Role.ADMIN)")
+@PreAuthorize("@security.hasAnyRole(@Role.ADMIN, @Role.SYSTEM_ADMIN)")
+@RequireAdminRole(target = AdminTarget.SYSTEM_ONLY)
 @Tag(name = "System Notice Admin v2", description = "관리자 시스템 공지 관리 API")
 public class AdminSystemNoticeController {
 


### PR DESCRIPTION
### 🚩 관련사항
x

### 📢 전달사항
**[버그 및 발생 원인]**

* 시스템 관리자(`SYSTEM_ADMIN`) 계정으로 관리자 전용 API(`/api/v2/admin/**`) 호출 시 `403 Forbidden` 에러가 발생하는 문제가 있었습니다.
* 원인 분석 결과, 컨트롤러 단의 AOP 인가 로직 이전에 Spring Security의 1차 방어막인 `WebSecurityConfig`의 `FilterChain`에서 `.hasRole("ADMIN")`으로만 하드코딩되어 있어 `SYSTEM_ADMIN` 계정이 입구 컷(Filter 차단)을 당하고 있었습니다.

**[해결 및 변경 사항]**

**`WebSecurityConfig` 권한 허용 추가**
* `/api/v2/admin/**` 경로에 대해 `.hasAnyRole("ADMIN", "SYSTEM_ADMIN")`으로 수정하여 시스템 관리자도 Security Filter를 무사히 통과할 수 있도록 조치했습니다.


### 📸 스크린샷
x


### 📃 진행사항
* [x] `WebSecurityConfig`의 관리자 API 경로에 `SYSTEM_ADMIN` 권한 접근 허용 (`hasAnyRole` 적용)


### ⚙️ 기타사항

개발기간: 1d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 관리자 API에 `SYSTEM_ADMIN` 역할도 접근할 수 있도록 권한이 확대되었습니다.
  * 기존 `ADMIN` 역할의 접근 권한은 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->