### PR TITLE
fix: 게시판 목록 API 하위호환성 보장

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/controller/BoardController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/controller/BoardController.java
@@ -34,22 +34,24 @@ public class BoardController {
 	@GetMapping("/available")
 	@ResponseStatus(HttpStatus.OK)
 	@Operation(summary = "이용 가능한 게시판 목록", description = "현재 사용자가 이용 가능한 게시판의 id, name 목록을 표시 순서대로 반환합니다.\n"
-		+ "파라미터로 boardGroup 전달 시 해당 그룹(소식 = NOTICE, 소통 = COMMUNITY)에 맞는 게시판 목록을 반환합니다.")
+		+ "파라미터로 boardGroup 전달 시 해당 그룹(소식 = NOTICE, 소통 = COMMUNITY)에 맞는 게시판 목록을 반환합니다. 미지정 시 전체 게시판을 반환합니다. 기존 isTab=true 요청도 지원합니다.")
 	public ApiResponse<BoardReadableListResponse> getAvailableBoards(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
-		@RequestParam(name = "boardGroup") BoardGroup boardGroup) {
+		@RequestParam(name = "boardGroup", required = false) BoardGroup boardGroup,
+		@RequestParam(name = "isTab", defaultValue = "false") boolean isTab) {
+		BoardGroup resolvedBoardGroup = boardGroup != null ? boardGroup : (isTab ? BoardGroup.NOTICE : null);
 		return ApiResponse.success(
 			boardReadableMapper
-				.toReadableListResponse(boardService.getReadableBoards(userDetails.getUser().getId(), boardGroup)));
+				.toReadableListResponse(boardService.getReadableBoards(userDetails.getUser().getId(), resolvedBoardGroup)));
 	}
 
 	@GetMapping("/writable")
 	@ResponseStatus(HttpStatus.OK)
 	@Operation(summary = "쓰기 가능한 게시판 목록", description = "현재 사용자가 쓰기 가능한 게시판의 id, name 목록을 표시 순서대로 반환합니다.\n"
-		+ "파라미터로 boardGroup 전달 시 해당 그룹(소식 = NOTICE, 소통 = COMMUNITY)에 맞는 게시판 목록을 반환합니다.")
+		+ "파라미터로 boardGroup 전달 시 해당 그룹(소식 = NOTICE, 소통 = COMMUNITY)에 맞는 게시판 목록을 반환합니다. 미지정 시 전체 게시판을 반환합니다.")
 	public ApiResponse<BoardWritableListResponse> getWritableBoards(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
-		@RequestParam(name = "boardGroup") BoardGroup boardGroup) {
+		@RequestParam(name = "boardGroup", required = false) BoardGroup boardGroup) {
 		return ApiResponse.success(
 			boardWritableMapper
 				.toWritableListResponse(boardService.getWritableBoards(userDetails.getUser().getId(), boardGroup)));

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/controller/BoardController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/controller/BoardController.java
@@ -18,6 +18,7 @@ import net.causw.app.main.domain.user.auth.userdetails.CustomUserDetails;
 import net.causw.app.main.shared.dto.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -38,7 +39,7 @@ public class BoardController {
 	public ApiResponse<BoardReadableListResponse> getAvailableBoards(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@RequestParam(name = "boardGroup", required = false) BoardGroup boardGroup,
-		@RequestParam(name = "isTab", defaultValue = "false") boolean isTab) {
+		@Parameter(description = "Deprecated. boardGroup=NOTICE 사용을 권장합니다.", deprecated = true) @Deprecated(since = "4.0", forRemoval = true) @RequestParam(name = "isTab", defaultValue = "false") boolean isTab) {
 		BoardGroup resolvedBoardGroup = boardGroup != null ? boardGroup : (isTab ? BoardGroup.NOTICE : null);
 		return ApiResponse.success(
 			boardReadableMapper

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/controller/BoardController.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/api/v2/controller/BoardController.java
@@ -42,7 +42,8 @@ public class BoardController {
 		BoardGroup resolvedBoardGroup = boardGroup != null ? boardGroup : (isTab ? BoardGroup.NOTICE : null);
 		return ApiResponse.success(
 			boardReadableMapper
-				.toReadableListResponse(boardService.getReadableBoards(userDetails.getUser().getId(), resolvedBoardGroup)));
+				.toReadableListResponse(
+					boardService.getReadableBoards(userDetails.getUser().getId(), resolvedBoardGroup)));
 	}
 
 	@GetMapping("/writable")

--- a/app-main/src/main/java/net/causw/app/main/domain/community/board/service/implementation/BoardAccessManager.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/board/service/implementation/BoardAccessManager.java
@@ -82,6 +82,9 @@ public class BoardAccessManager {
 
 	// tb_board_config의 is_notice 값과 요청받은 boardGroup을 매핑
 	private boolean isMatchingGroup(boolean isNoticeConfig, BoardGroup requestGroup) {
+		if (requestGroup == null) {
+			return true;
+		}
 		if (requestGroup == BoardGroup.NOTICE) {
 			return isNoticeConfig;
 		} else if (requestGroup == BoardGroup.COMMUNITY) {


### PR DESCRIPTION
### 🚩 관련사항
- Closes #1518

### 📢 전달사항

게시판 목록 API에 `boardGroup` 파라미터가 추가되면서 기존 클라이언트가 파라미터 없이 호출할 경우 `400 Bad Request`가 발생할 수 있는 문제를 수정했습니다.

- `boardGroup`을 optional로 변경했습니다.
- `boardGroup=NOTICE`와 `boardGroup=COMMUNITY` 필터는 유지합니다.
- `boardGroup` 미지정 시 기존처럼 전체 게시판을 반환합니다.
- 기존 `/api/v2/boards/available?isTab=true` 호출은 소식 게시판 조회로 매핑합니다.
- `/api/v2/boards/writable`의 기존 무인자 호출도 전체 게시판 조회를 유지합니다.
- `isTab` 파라미터에 Java와 Swagger deprecated 표기를 추가했습니다.
- `isTab` 사용량 측정이나 기존 요청 동작 변경은 포함하지 않습니다.

#### 변경 흐름

```mermaid
flowchart LR
    A[기존 클라이언트] --> B{boardGroup 또는 isTab}
    B -->|NOTICE 또는 isTab=true| C[소식 게시판]
    B -->|COMMUNITY| D[소통 게시판]
    B -->|미지정| E[전체 게시판]
```

### 📸 스크린샷
N/A

### 📃 진행사항
- [x] `boardGroup` optional 처리
- [x] 기존 `isTab=true` 호출 호환 처리
- [x] 그룹 미지정 시 전체 조회 처리
- [x] `isTab` deprecated 표기
- [x] diff 검사
- [ ] Java 25 환경에서 관련 테스트 실행

### ⚙️ 기타사항

개발기간: 2026-09-05 ~ 2026-09-05

테스트는 현재 환경에 Java 25 toolchain이 없어 Gradle 실행 전 중단되었습니다.
