### PR TITLE
chore: department null 레거시 유저 게시판 접근 정책 대응 및 학과 백필

### DIFF
--- a/app-main/src/main/java/net/causw/app/main/domain/community/common/service/CommunityPermissionPolicy.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/community/common/service/CommunityPermissionPolicy.java
@@ -219,8 +219,13 @@ public final class CommunityPermissionPolicy {
 			&& isAlive(comment.getPost());
 	}
 
+	/**
+	 * department가 null인 유저는 학과 미확정 레거시 유저로 간주하여 제한 없이 허용한다.
+	 * 이 정책은 UserBoardSubscribeQueryRepository.departmentCondition()과 동일하게 유지되어야 한다.
+	 * TODO: department 백필 완료 후 null 허용 조건 제거
+	 */
 	private static boolean isDepartmentAllowed(Set<Department> allowed, Department department) {
-		return allowed.isEmpty() || (department != null && allowed.contains(department));
+		return allowed.isEmpty() || department == null || allowed.contains(department);
 	}
 
 	private static boolean matchesReadScope(AcademicStatus academicStatus, BoardReadScope readScope) {

--- a/app-main/src/main/java/net/causw/app/main/domain/notification/notification/repository/UserBoardSubscribeQueryRepository.java
+++ b/app-main/src/main/java/net/causw/app/main/domain/notification/notification/repository/UserBoardSubscribeQueryRepository.java
@@ -128,11 +128,14 @@ public class UserBoardSubscribeQueryRepository {
 
 	/**
 	 * 학과 필터 조건. 빈 Set이면 모든 학과 허용.
+	 * department가 null인 유저는 학과 미확정 레거시 유저로 간주하여 제한 없이 포함한다.
+	 * 이 정책은 CommunityPermissionPolicy.isDepartmentAllowed()와 동일하게 유지되어야 한다.
+	 * TODO: department 백필 완료 후 isNull() 조건 제거
 	 */
 	private BooleanExpression departmentCondition(QUser user, Set<Department> allowedDepartments) {
 		if (allowedDepartments.isEmpty()) {
 			return null;
 		}
-		return user.department.in(allowedDepartments);
+		return user.department.isNull().or(user.department.in(allowedDepartments));
 	}
 }

--- a/app-main/src/main/resources/db/migration/V20260905202919__BackfillDepartmentForLegacyUsers.sql
+++ b/app-main/src/main/resources/db/migration/V20260905202919__BackfillDepartmentForLegacyUsers.sql
@@ -1,0 +1,12 @@
+-- AI학과 개설(2021) 이전 입학생 중 department 미설정 유저 백필
+-- DepartmentResolver.departmentPeriods 와 동일한 연도 구간을 적용한다.
+UPDATE tb_user
+SET department = CASE
+    WHEN admission_year BETWEEN 2018 AND 2020 THEN 'SCHOOL_OF_SW'
+    WHEN admission_year BETWEEN 2003 AND 2017 THEN 'SCHOOL_OF_CSE'
+    WHEN admission_year BETWEEN 1993 AND 2002 THEN 'DEPT_OF_CSE'
+    WHEN admission_year BETWEEN 1972 AND 1992 THEN 'DEPT_OF_CS'
+END
+WHERE department IS NULL
+  AND admission_year IS NOT NULL
+  AND admission_year < 2021;

--- a/app-main/src/test/java/net/causw/app/main/domain/community/common/service/CommunityPermissionPolicyTest.java
+++ b/app-main/src/test/java/net/causw/app/main/domain/community/common/service/CommunityPermissionPolicyTest.java
@@ -449,12 +449,12 @@ class CommunityPermissionPolicyTest {
 		}
 
 		@Test
-		@DisplayName("학과가 null인 사용자는 학과 제한 게시판에 접근할 수 없다")
-		void nullDepartment_deniesAccessToRestrictedBoard() {
+		@DisplayName("학과가 null인 사용자는 학과 미확정 레거시 유저로 간주하여 학과 제한 게시판에 접근할 수 있다")
+		void nullDepartment_allowsAccessToRestrictedBoard() {
 			BoardConfig config = boardConfigWithDepartments(Set.of(Department.SCHOOL_OF_SW));
 			User viewer = userWithDepartment(null);
 
-			assertThat(CommunityPermissionPolicy.canReadBoard(viewer, board, config, BOARD_ADMIN_IDS)).isFalse();
+			assertThat(CommunityPermissionPolicy.canReadBoard(viewer, board, config, BOARD_ADMIN_IDS)).isTrue();
 		}
 
 		private BoardConfig boardConfigWithDepartments(Set<Department> departments) {


### PR DESCRIPTION
### 🚩 관련사항
close #1517

### 📢 전달사항
게시판 학과 접근 정책 적용 이후 `department`가 null인 레거시 유저들이 게시판에 접근하지 못하는 문제를 임시 대응한 PR입니다.

**배경**
- v2 전환 이전에 가입한 유저 중 일부는 `department` 컬럼이 null인 상태로 ACTIVE 상태입니다.
- AI학과 개설(2021) 이전 입학생은 입학년도만으로 학과를 확정할 수 있어 백필이 가능하지만, 2021년 이후 입학생은 소프트웨어학부·AI학과 중 자동 판별이 불가능해 사용자 직접 선택이 필요합니다.
- 배포 일정상 2021년 이후 입학생 처리는 후속 PR로 미뤄, 이번 배포에서는 임시 우회 정책을 적용합니다.

**변경 내용**

1. **`CommunityPermissionPolicy.isDepartmentAllowed()`** — department가 null이면 학과 제한을 우회하도록 수정했습니다. null 유저는 학과 미확정 레거시 유저로 간주합니다.

2. **`UserBoardSubscribeQueryRepository.departmentCondition()`** — 알림 발송 대상 조회 시에도 동일한 정책을 적용했습니다.

3. **Flyway 마이그레이션** — AI학과 개설(2021) 이전 입학생 중 department가 null인 유저를 `DepartmentResolver.departmentPeriods`와 동일한 연도 구간 기준으로 일괄 백필합니다.

### 📸 스크린샷
N/A

### 📃 진행사항
- [x] `isDepartmentAllowed()` — department null 유저 학과 제한 우회 (임시)
- [x] `departmentCondition()` — 알림 발송 대상 조회 시 동일 정책 적용
- [ ] 2021년 이후 입학생(소프트웨어학부·AI학과 미확정) 자가 선택 API 추가 (후속 PR)
- [ ] 백필 완료 후 null 우회 조건 제거 (후속 PR)

### ⚙️ 기타사항

개발기간: 2026-09-05 ~ 2026-09-05

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 학과 정보가 없는 사용자도 허용된 게시판에 접근할 수 있습니다.
  - 학과 정보가 없는 사용자도 관련 게시판 알림 대상에 포함됩니다.

- **개선 사항**
  - 기존 사용자 중 입학 연도 정보가 있는 일부 계정의 학과 정보가 자동으로 보완됩니다.
  - 과거 입학 연도별 기준에 따라 학과 정보가 정확하게 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->